### PR TITLE
Update license in node packages

### DIFF
--- a/canvas_modules/eslint-config-canvas/package.json
+++ b/canvas_modules/eslint-config-canvas/package.json
@@ -7,6 +7,7 @@
     "type": "git",
     "url": "https://github.ibm.com/NGP-TWC/wdp-abstract-canvas"
   },
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.ibm.com/NGP-TWC/wdp-abstract-canvas/issue"
   },

--- a/canvas_modules/harness/package.json
+++ b/canvas_modules/harness/package.json
@@ -2,6 +2,7 @@
   "name": "canvas-demo",
   "version": "0.0.1",
   "private": true,
+  "license": "Apache-2.0",
   "scripts": {
     "start": "node index.js",
     "test": "chimp config/chimp.js",


### PR DESCRIPTION
Update license in package.json for both canvas modules prior to release
Will wait for @matthoward366 build fix changes before updating the rest of the links in each respective package.json
