### PR TITLE
Implemented Common Properties Actions Unit Test using Cypress framework

### DIFF
--- a/canvas_modules/harness/cypress/integration/properties/common-properties-actions.js
+++ b/canvas_modules/harness/cypress/integration/properties/common-properties-actions.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe("Test of common properties actions", function() {
+	before(() => {
+		cy.visit("/");
+		cy.openPropertyDefinition("action_paramDef.json");
+	});
+
+	it("Test of Increment, Decrement actions", function() {
+		cy.clickAction("Increment");
+		cy.clickAction("Increment");
+		cy.clickAction("Increment");
+		cy.verifyReadOnlyNumericValue(3);
+		cy.clickAction("Decrement");
+		cy.verifyReadOnlyNumericValue(2);
+	});
+});
+
+describe("Test of text styling and word wrapping", function() {
+	before(() => {
+		cy.visit("/");
+		cy.openPropertyDefinition("readonly_paramDef.json");
+	});
+
+	it("Test of readonly text value and CSS style", function() {
+		cy.verifyReadOnlyTextValue("readonly_text",
+			"The more I study, the more insatiable do I feel my genius for it to be. 'Ada Lovelace'");
+		cy.verifyReadOnlyTextCSS("readonly_text", "overflow-wrap", "break-word");
+	});
+});
+
+describe("Test of ellipsis activation for a long readonly text", function() {
+	before(() => {
+		cy.visit("/");
+		cy.openPropertyDefinition("structuretable_paramDef.json");
+	});
+
+	it("Test of ellipsis activation for a long readonly text", function() {
+		cy.openSubPanel("Configure Rename fields");
+		cy.clickSubPanelButtonInRow("structuretableReadonlyColumnDefaultIndex", 0);
+		cy.setRenameSubPanelLabel("structuretableReadonlyColumnDefaultIndex_0_3",
+			"This is a very long sentence of text to test whether or not an overflow of text occurs");
+		cy.saveWideFlyoutHavingName("Rename Subpanel");
+		cy.verifyNoTextOverflow("structuretableReadonlyColumnDefaultIndex_0_3");
+		cy.saveWideFlyoutHavingName("Configure Rename fields");
+	});
+});

--- a/canvas_modules/harness/cypress/integration/properties/custom-controls.js
+++ b/canvas_modules/harness/cypress/integration/properties/custom-controls.js
@@ -35,7 +35,7 @@ describe("Test of custom panels", function() {
 			.trigger("mousemove", { clientX: 900 })
 			.trigger("mouseup");
 		verifySliderDropDown(3);
-		cy.saveWideflyout();
+		cy.saveWideFlyoutHavingName("Configure Slider");
 		cy.saveFlyout();
 		cy.document().then((doc) => {
 			const lastEventLog = testUtils.getLastEventLogData(doc);

--- a/canvas_modules/harness/cypress/integration/properties/custom-controls.js
+++ b/canvas_modules/harness/cypress/integration/properties/custom-controls.js
@@ -35,7 +35,7 @@ describe("Test of custom panels", function() {
 			.trigger("mousemove", { clientX: 900 })
 			.trigger("mouseup");
 		verifySliderDropDown(3);
-		cy.saveWideFlyoutHavingName("Configure Slider");
+		cy.saveWideFlyout("Configure Slider");
 		cy.saveFlyout();
 		cy.document().then((doc) => {
 			const lastEventLog = testUtils.getLastEventLogData(doc);

--- a/canvas_modules/harness/cypress/integration/properties/readonly-controls.js
+++ b/canvas_modules/harness/cypress/integration/properties/readonly-controls.js
@@ -14,22 +14,6 @@
  * limitations under the License.
  */
 
-describe("Test of common properties actions", function() {
-	before(() => {
-		cy.visit("/");
-		cy.openPropertyDefinition("action_paramDef.json");
-	});
-
-	it("Test of Increment, Decrement actions", function() {
-		cy.clickAction("Increment");
-		cy.clickAction("Increment");
-		cy.clickAction("Increment");
-		cy.verifyReadOnlyNumericValue(3);
-		cy.clickAction("Decrement");
-		cy.verifyReadOnlyNumericValue(2);
-	});
-});
-
 describe("Test of text styling and word wrapping", function() {
 	before(() => {
 		cy.visit("/");
@@ -52,10 +36,10 @@ describe("Test of ellipsis activation for a long readonly text", function() {
 	it("Test of ellipsis activation for a long readonly text", function() {
 		cy.openSubPanel("Configure Rename fields");
 		cy.clickSubPanelButtonInRow("structuretableReadonlyColumnDefaultIndex", 0);
-		cy.setRenameSubPanelLabel("structuretableReadonlyColumnDefaultIndex_0_3",
+		cy.setTextFieldValue("structuretableReadonlyColumnDefaultIndex_0_3",
 			"This is a very long sentence of text to test whether or not an overflow of text occurs");
-		cy.saveWideFlyoutHavingName("Rename Subpanel");
+		cy.saveWideFlyout("Rename Subpanel");
 		cy.verifyNoTextOverflow("structuretableReadonlyColumnDefaultIndex_0_3");
-		cy.saveWideFlyoutHavingName("Configure Rename fields");
+		cy.saveWideFlyout("Configure Rename fields");
 	});
 });

--- a/canvas_modules/harness/cypress/support/index.js
+++ b/canvas_modules/harness/cypress/support/index.js
@@ -15,6 +15,7 @@
  */
 
 import "./properties/properties-cmds";
+import "./properties/properties-verification-cmds";
 import "./canvas/comments-cmds";
 import "./canvas/context-menu-cmds";
 import "./canvas/node-cmds";

--- a/canvas_modules/harness/cypress/support/properties/properties-cmds.js
+++ b/canvas_modules/harness/cypress/support/properties/properties-cmds.js
@@ -14,21 +14,6 @@
  * limitations under the License.
  */
 
-// -- This is a parent command --
-// Cypress.Commands.add("login", (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
-
 Cypress.Commands.add("openPropertyDefinition", (propertyFileName) => {
 	cy.get("#harness-action-bar-sidepanel-modal").click();
 	cy.get("#common-properties-select-item").select(propertyFileName);
@@ -40,10 +25,6 @@ Cypress.Commands.add("toggleCategory", (categoryName) => {
 		.click();
 });
 
-Cypress.Commands.add("saveWideflyout", () => {
-	cy.get(".properties-wf-content button[data-id='properties-apply-button']").click();
-});
-
 Cypress.Commands.add("saveFlyout", () => {
 	cy.get(".properties-modal-buttons button[data-id='properties-apply-button']").click();
 });
@@ -52,4 +33,44 @@ Cypress.Commands.add("saveFlyout", () => {
 Cypress.Commands.add("openSubPanel", (title) => {
 	cy.get(".properties-icon-button-label").contains(title)
 		.click();
+});
+
+Cypress.Commands.add("clickAction", (actionName) => {
+	cy.get(".properties-action-button button").contains(actionName)
+		.click();
+});
+
+Cypress.Commands.add("clickSubPanelButtonInRow", (controlId, row) => {
+	cy.get("div[data-id='properties-" + controlId + "']").find(".properties-subpanel-button")
+		.then((idx) => {
+			idx[row].click();
+		});
+});
+
+Cypress.Commands.add("setRenameSubPanelLabel", (controlId, labelText) => {
+	cy.get("div[data-id='properties-" + controlId + "']").find("input")
+		.type(labelText);
+});
+
+Cypress.Commands.add("getWideFlyoutPanel", (panelName) => {
+	cy.get(".properties-wf-content.show")
+		.then((wideFlyoutPanels) => {
+			let panel = null;
+			for (var idx = 0; idx < wideFlyoutPanels.length; idx++) {
+				const flyout = wideFlyoutPanels[idx];
+				if (flyout.textContent.includes(panelName)) {
+					panel = flyout;
+					break;
+				}
+			}
+			return panel;
+		});
+});
+
+Cypress.Commands.add("saveWideFlyoutHavingName", (panelName) => {
+	cy.getWideFlyoutPanel(panelName).then((wideFlyoutPanel) => {
+		cy.wrap(wideFlyoutPanel)
+			.find(".properties-modal-buttons button[data-id='properties-apply-button']")
+			.click();
+	});
 });

--- a/canvas_modules/harness/cypress/support/properties/properties-cmds.js
+++ b/canvas_modules/harness/cypress/support/properties/properties-cmds.js
@@ -35,11 +35,6 @@ Cypress.Commands.add("openSubPanel", (title) => {
 		.click();
 });
 
-Cypress.Commands.add("clickAction", (actionName) => {
-	cy.get(".properties-action-button button").contains(actionName)
-		.click();
-});
-
 Cypress.Commands.add("clickSubPanelButtonInRow", (controlId, row) => {
 	cy.get("div[data-id='properties-" + controlId + "']").find(".properties-subpanel-button")
 		.then((idx) => {
@@ -47,7 +42,7 @@ Cypress.Commands.add("clickSubPanelButtonInRow", (controlId, row) => {
 		});
 });
 
-Cypress.Commands.add("setRenameSubPanelLabel", (controlId, labelText) => {
+Cypress.Commands.add("setTextFieldValue", (controlId, labelText) => {
 	cy.get("div[data-id='properties-" + controlId + "']").find("input")
 		.type(labelText);
 });
@@ -67,7 +62,7 @@ Cypress.Commands.add("getWideFlyoutPanel", (panelName) => {
 		});
 });
 
-Cypress.Commands.add("saveWideFlyoutHavingName", (panelName) => {
+Cypress.Commands.add("saveWideFlyout", (panelName) => {
 	cy.getWideFlyoutPanel(panelName).then((wideFlyoutPanel) => {
 		cy.wrap(wideFlyoutPanel)
 			.find(".properties-modal-buttons button[data-id='properties-apply-button']")

--- a/canvas_modules/harness/cypress/support/properties/properties-verification-cmds.js
+++ b/canvas_modules/harness/cypress/support/properties/properties-verification-cmds.js
@@ -14,15 +14,6 @@
  * limitations under the License.
  */
 
-Cypress.Commands.add("verifyReadOnlyNumericValue", (value) => {
-	cy.get(".properties-readonly span").first()
-		.invoke("text")
-		.then((text) => {
-			const num = parseFloat(text);
-			expect(value).equal(num);
-		});
-});
-
 Cypress.Commands.add("verifyReadOnlyTextValue", (controlId, value) => {
 	cy.get("div[data-id='properties-" + controlId + "'] span")
 		.invoke("text")

--- a/canvas_modules/harness/cypress/support/properties/properties-verification-cmds.js
+++ b/canvas_modules/harness/cypress/support/properties/properties-verification-cmds.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2020 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Cypress.Commands.add("verifyReadOnlyNumericValue", (value) => {
+	cy.get(".properties-readonly span").first()
+		.invoke("text")
+		.then((text) => {
+			const num = parseFloat(text);
+			expect(value).equal(num);
+		});
+});
+
+Cypress.Commands.add("verifyReadOnlyTextValue", (controlId, value) => {
+	cy.get("div[data-id='properties-" + controlId + "'] span")
+		.invoke("text")
+		.then((text) => {
+			expect(value).equal(text);
+		});
+});
+
+Cypress.Commands.add("verifyReadOnlyTextCSS", (controlId, style, value) => {
+	cy.get("div[data-id='properties-" + controlId + "'] span")
+		.should("have.css", style, value);
+});
+
+Cypress.Commands.add("verifyNoTextOverflow", (controlId) => {
+	cy.get("div[data-id='properties-" + controlId + "'] span")
+		.invoke("height")
+		.should("be.lt", 25);
+});


### PR DESCRIPTION
- Modified **cy.saveWideflyout()** command to **cy. saveWideFlyoutHavingName(panelName)** because  **cy.saveWideflyout()** didn't work when multiple wide flyouts are open.
- Created a new file for all verification commands. This is similar to `verification-cmds.js` file in `cypress/support/canvas` folder

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

