### PR TITLE
Fix datasetmetadata conditions not being ran on startup

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/operators/dmMeasurementEquals-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/operators/dmMeasurementEquals-test.js
@@ -27,6 +27,10 @@ describe("validating dmMeasurementEquals operator works correctly", () => {
 		return { value: { link_ref: "0", field_name: desc }, control: { role: "column" } };
 	}
 
+	function wrapParamNull() {
+		return { value: null, control: { role: "column" } };
+	}
+
 	function badWrap(desc) {
 		return { value: desc, control: { role: "checkbox" } };
 	}
@@ -47,6 +51,7 @@ describe("validating dmMeasurementEquals operator works correctly", () => {
 		expect(measurementEquals(badWrap("Drug"), null, "discrete", controller)).to.equal(true);
 		expect(measurementEquals(wrap("K"), wrap("discrete"), null, controller)).to.equal(false);
 		expect(measurementEquals(wrapParam("Cholesterol"), wrap("discrete"), null, controller)).to.equal(true);
+		expect(measurementEquals(wrapParamNull(), null, "range", controller)).to.equal(false);
 	});
 
 });

--- a/canvas_modules/common-canvas/src/common-properties/properties-controller.js
+++ b/canvas_modules/common-canvas/src/common-properties/properties-controller.js
@@ -119,16 +119,15 @@ export default class PropertiesController {
 			this.parsePanelTree();
 			conditionsUtil.injectDefaultValidations(this.controls, this.validationDefinitions, intl);
 			let datasetMetadata;
+			let propertyValues = {};
 			if (this.form.data) {
 				datasetMetadata = this.form.data.datasetMetadata;
-				const propertyValues = this.form.data.uiCurrentParameters ? assign({}, this.form.data.currentParameters, this.form.data.uiCurrentParameters)
+				propertyValues = this.form.data.uiCurrentParameters ? assign({}, this.form.data.currentParameters, this.form.data.uiCurrentParameters)
 					: this.form.data.currentParameters;
-				this.setPropertyValues(propertyValues);
 			}
-			// Determine from the current control set whether or not there can be multiple input datasets
-			this.multipleSchemas = this._canHaveMultipleSchemas();
 			// Set the opening dataset(s), during which multiples are flattened and compound names generated if necessary
 			this.setDatasetMetadata(datasetMetadata);
+			this.setPropertyValues(propertyValues); // needs to be after setDatasetMetadata to run conditions
 			// for control.type of structuretable that do not use FieldPicker, we need to add to
 			// the controlValue any missing data model fields.  We need to do it here so that
 			// validate can run against the added fields

--- a/canvas_modules/common-canvas/src/common-properties/ui-conditions/conditions-utils.js
+++ b/canvas_modules/common-canvas/src/common-properties/ui-conditions/conditions-utils.js
@@ -1029,24 +1029,26 @@ function _injectInvalidFieldDefinition(control, valDefinitions, keyName, control
 
 // key should be 'type', 'measure', or 'modeling_role'. Return the matching metadata given the paramInfo
 function getMetadataFieldMatch(paramInfo, metadata, key) {
-	if (typeof paramInfo.value === "string") {
-		for (let i = 0; i < metadata.length; i++) {
-			var field = metadata[i];
-			if (field.name === paramInfo.value) {
-				if (key === "type") {
-					return field.type;
+	if (paramInfo.value) {
+		if (typeof paramInfo.value === "string") {
+			for (let i = 0; i < metadata.length; i++) {
+				var field = metadata[i];
+				if (field.name === paramInfo.value) {
+					if (key === "type") {
+						return field.type;
+					}
+					return field.metadata[key];
 				}
-				return field.metadata[key];
 			}
-		}
-	} else if (typeof paramInfo.value === "object") {
-		for (var j = 0; j < metadata.length; j++) {
-			var field2 = metadata[j];
-			if (field2.origName === paramInfo.value.field_name && field2.schema === paramInfo.value.link_ref) {
-				if (key === "type") {
-					return field2.type;
+		} else if (typeof paramInfo.value === "object") {
+			for (var j = 0; j < metadata.length; j++) {
+				var field2 = metadata[j];
+				if (field2.origName === paramInfo.value.field_name && field2.schema === paramInfo.value.link_ref) {
+					if (key === "type") {
+						return field2.type;
+					}
+					return field2.metadata[key];
 				}
-				return field2.metadata[key];
 			}
 		}
 	}


### PR DESCRIPTION

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

Fixes an issue where any condition that uses the datasetmetadata wasn't able to be ran on startup of common-properties.  Also contains a fix for when a field is null.