### PR TITLE
#104 notification center styling compatibility

### DIFF
--- a/canvas_modules/common-canvas/src/notification-panel/notification-panel.scss
+++ b/canvas_modules/common-canvas/src/notification-panel/notification-panel.scss
@@ -16,7 +16,6 @@
 
 $notification-panel-arrow-height: 8px;
 $notification-panel-header-height: 35px;
-$notification-panel-clear-all-height: 49px;
 $notification-message-height: 64px;
 
 $notification-left-border-color-width: 4px;
@@ -82,7 +81,7 @@ $notification-left-border-color-width: 4px;
 
 .notification-panel-clear-all-container {
 	width: 100%;
-	height: $notification-panel-clear-all-height;
+	height: 49px;
 	background-color: $ui-01;
 	display: flex;
 	flex-direction: column;
@@ -92,7 +91,7 @@ $notification-left-border-color-width: 4px;
 	border-bottom: 1px solid $ui-03;
 	font-weight: 400;
 	padding: $spacing-03 $spacing-05;
-	.notification-panel-clear-all {
+	.bx--btn--ghost.bx--btn--sm {
 		width: fit-content;
 		padding: 0;
 	}
@@ -104,7 +103,7 @@ $notification-left-border-color-width: 4px;
 	height: fit-content;
 }
 .notification-panel-messages {
-	max-height: calc(50% - #{$notification-panel-clear-all-height});
+	max-height: 500px;
 	height: fit-content;
 	overflow-y: auto;
 	line-height: normal;


### PR DESCRIPTION
Fixes Carbon compatibility for https://github.com/elyra-ai/canvas/issues/104

Styling on Carbon components needs to use identical scss selectors if a Carbon theme is used. Though it's not specified in the test harness, if @elyra-ai/canvas were to be used with theming on Carbon components, the scss selectors need to be properly set.

Also fixes notification message scrolling issue introduced by the fix for no-click-through when the notification panel is open.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

