### PR TITLE
#187 Notification Messages overflow on long words

### DIFF
--- a/canvas_modules/common-canvas/src/notification-panel/notification-panel.scss
+++ b/canvas_modules/common-canvas/src/notification-panel/notification-panel.scss
@@ -190,6 +190,7 @@ $notification-left-border-color-width: 4px;
 
 		.notification-message-details {
 			text-align: left;
+			overflow-wrap: anywhere;
 
 			.notification-message-title {
 				@include carbon--type-style("productive-heading-01");

--- a/canvas_modules/harness/cypress/support/properties/properties-cmds.js
+++ b/canvas_modules/harness/cypress/support/properties/properties-cmds.js
@@ -246,7 +246,7 @@ Cypress.Commands.add("selectFieldInFieldPickerPanel", (fieldName, dataType, pane
 					cy.wrap(row)
 						.find(".properties-vt-row-checkbox")
 						.find("label")
-						.click();
+						.click({ force: true });
 				});
 		});
 });


### PR DESCRIPTION
Fixes: https://github.com/elyra-ai/canvas/issues/187

![image](https://user-images.githubusercontent.com/10677021/89215471-94a9b680-d57d-11ea-9c3e-19074983f190.png)

Notification message title and messages will now wrap on long words instead of only on word breaks.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

