### PR TITLE
Numberfield default value set to empty string when default value is undefined

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/controls/numberfield/numberfield.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/numberfield/numberfield.jsx
@@ -72,7 +72,7 @@ class NumberfieldControl extends React.Component {
 
 	render() {
 		let controlValue = ""; // Default to empty string to avoid '0' appearing when value is 'null'
-		if (this.props.value !== null) {
+		if (this.props.value !== null && typeof this.props.value !== "undefined") {
 			controlValue = this.props.value;
 		}
 		const className = classNames("properties-numberfield", { "hide": this.props.state === STATES.HIDDEN }, this.props.messageInfo ? this.props.messageInfo.type : null);


### PR DESCRIPTION
Fixes https://github.com/elyra-ai/canvas/issues/251
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

