### PR TITLE
#268 Translate dropdown menu tooltips

### DIFF
--- a/canvas_modules/common-canvas/locales/common-properties/locales/en.json
+++ b/canvas_modules/common-canvas/locales/common-properties/locales/en.json
@@ -67,5 +67,7 @@
   "moveable.table.button.up": "Move up.",
   "moveable.table.button.down": "Move down.",
   "moveable.table.button.bottom": "Move to bottom",
-  "list.table.label": "Values"
+  "list.table.label": "Values",
+  "dropdown.tooltip.openMenu": "Open menu",
+  "dropdown.tooltip.closeMenu": "Close menu"
 }

--- a/canvas_modules/common-canvas/locales/common-properties/locales/eo.json
+++ b/canvas_modules/common-canvas/locales/common-properties/locales/eo.json
@@ -67,5 +67,8 @@
   "moveable.table.button.top": "[Esperanto~Move to top.~~eo]",
   "moveable.table.button.up": "[Esperanto~Move up.~~eo]",
   "moveable.table.button.down": "[Esperanto~Move down.~~eo]",
-  "moveable.table.button.bottom": "[Esperanto~Move to bottom~~eo]"
+  "moveable.table.button.bottom": "[Esperanto~Move to bottom~~eo]",
+  "list.table.label": "[Esperanto~Values~~~~eo]",
+  "dropdown.tooltip.openMenu": "[Esperanto~Open menu~~~~eo]",
+  "dropdown.tooltip.closeMenu": "[Esperanto~Close menu~~~~~~eo]"
 }

--- a/canvas_modules/common-canvas/src/common-properties/constants/constants.js
+++ b/canvas_modules/common-canvas/src/common-properties/constants/constants.js
@@ -89,7 +89,9 @@ _defineConstant("MESSAGE_KEYS", {
 	MOVEABLE_TABLE_BUTTON_UP_DESCRIPTION: "moveable.table.button.up",
 	MOVEABLE_TABLE_BUTTON_DOWN_DESCRIPTION: "moveable.table.button.down",
 	MOVEABLE_TABLE_BUTTON_BOTTOM_DESCRIPTION: "moveable.table.button.bottom",
-	LIST_TABLE_LABEL: "list.table.label"
+	LIST_TABLE_LABEL: "list.table.label",
+	DROPDOWN_TOOLTIP_OPENMENU: "dropdown.tooltip.openMenu",
+	DROPDOWN_TOOLTIP_CLOSEMENU: "dropdown.tooltip.closeMenu"
 });
 
 _defineConstant("CHARACTER_LIMITS", {

--- a/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
@@ -24,7 +24,8 @@ import ValidationMessage from "./../../components/validation-message";
 import classNames from "classnames";
 import * as PropertyUtils from "./../../util/property-utils.js";
 import { ControlType } from "./../../constants/form-constants";
-import { STATES } from "./../../constants/constants.js";
+import { MESSAGE_KEYS, STATES } from "./../../constants/constants.js";
+import { formatMessage } from "./../../util/property-utils";
 
 class DropDown extends React.Component {
 	constructor(props) {
@@ -33,6 +34,7 @@ class DropDown extends React.Component {
 		if (props.control.additionalText) {
 			this.emptyLabel = props.control.additionalText;
 		}
+		this.reactIntl = props.controller.getReactIntl();
 		this.id = ControlUtils.getControlId(this.props.propertyId);
 		this.handleChange = this.handleChange.bind(this);
 		this.genSchemaSelectOptions = this.genSchemaSelectOptions.bind(this);
@@ -173,6 +175,10 @@ class DropDown extends React.Component {
 				{ options }
 			</Select>);
 		} else {
+			const listBoxMenuIconTranslationIds = {
+				"close.menu": formatMessage(this.reactIntl, MESSAGE_KEYS.DROPDOWN_TOOLTIP_CLOSEMENU),
+				"open.menu": formatMessage(this.reactIntl, MESSAGE_KEYS.DROPDOWN_TOOLTIP_OPENMENU)
+			};
 			dropdownComponent = (<Dropdown
 				id={`${ControlUtils.getDataId(this.props.propertyId)}-dropdown`}
 				disabled={this.props.state === STATES.DISABLED}
@@ -182,6 +188,7 @@ class DropDown extends React.Component {
 				selectedItem={dropDown.selectedOption}
 				label={this.emptyLabel}
 				light
+				translateWithId={(id) => listBoxMenuIconTranslationIds[id]}
 			/>);
 		}
 

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
@@ -495,6 +495,10 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 		const last = items.slice(1);
 		items = first.concat({ value: this.recentUseCat, label: this.recentUseCat }, last);
 		const label = (this.state.functionCategory === this.recentUseCat) ? this.recentUseCat : this.props.functionList[this.state.functionCategory].locLabel;
+		const listBoxMenuIconTranslationIds = {
+			"close.menu": formatMessage(this.reactIntl, MESSAGE_KEYS.DROPDOWN_TOOLTIP_CLOSEMENU),
+			"open.menu": formatMessage(this.reactIntl, MESSAGE_KEYS.DROPDOWN_TOOLTIP_OPENMENU)
+		};
 		return (
 			<div className="properties-expression-function-select">
 				<Dropdown
@@ -503,6 +507,7 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 					label={label}
 					items={items}
 					onChange={this.onFunctionCatChange}
+					translateWithId={(id) => listBoxMenuIconTranslationIds[id]}
 				/>
 			</div>);
 	}
@@ -516,6 +521,10 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 		const last = items.slice(1);
 		const newItems = first.concat({ value: this.recentUseCat, label: this.recentUseCat }, last);
 		const label = (this.state.fieldCategory === this.recentUseCat) ? this.recentUseCat : items[0].label;
+		const listBoxMenuIconTranslationIds = {
+			"close.menu": formatMessage(this.reactIntl, MESSAGE_KEYS.DROPDOWN_TOOLTIP_CLOSEMENU),
+			"open.menu": formatMessage(this.reactIntl, MESSAGE_KEYS.DROPDOWN_TOOLTIP_OPENMENU)
+		};
 		return (
 			<div className="properties-expression-field-select">
 				<Dropdown
@@ -524,6 +533,7 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 					label={label}
 					items={newItems}
 					onChange={this.onFieldCatChange}
+					translateWithId={(id) => listBoxMenuIconTranslationIds[id]}
 				/>
 			</div>);
 	}


### PR DESCRIPTION
Fixes https://github.com/elyra-ai/canvas/issues/268
I added test strings in `ja.json` and `de.json`.
**Tooltip translated in German language -** 
![Screen Shot 2020-09-16 at 4 14 29 PM](https://user-images.githubusercontent.com/25124000/93405738-b5368300-f842-11ea-9802-71d6e0103990.png)
![Screen Shot 2020-09-16 at 4 15 16 PM](https://user-images.githubusercontent.com/25124000/93405759-c2ec0880-f842-11ea-8a59-477555356dcc.png)

**Tooltip translated in Japanese language -** 
![Screen Shot 2020-09-16 at 4 16 21 PM](https://user-images.githubusercontent.com/25124000/93405806-ddbe7d00-f842-11ea-9843-579422c22375.png)
![Screen Shot 2020-09-16 at 4 17 35 PM](https://user-images.githubusercontent.com/25124000/93405808-deefaa00-f842-11ea-85e7-9854183f54cd.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

