### PR TITLE
#250 Styling fix - Implement new design for Expression Builder

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-builder.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-builder.scss
@@ -38,7 +38,7 @@ $operator-margin: 50%;
 
 
 .properties-expression-selection-container {
-	padding-top: $spacing-05;
+	padding-top: $spacing-03;
 }
 
 .properties-expression-selection-operator {
@@ -97,6 +97,7 @@ $operator-margin: 50%;
 	.properties-operator-tooltip-container {
 		width: $operator-width;
 		margin-right: $spacing-03;
+		margin-top: $spacing-03;
 	}
 
 	.properties-operator-button {


### PR DESCRIPTION
Adds styling fixes for https://github.com/elyra-ai/canvas/issues/250

The original styling didn't account for situations where the operators would overflow into more rows, and there wasn't padding set for those.

Before:
![image](https://user-images.githubusercontent.com/10677021/94302122-90b46800-ff20-11ea-8e46-142a2700e0c6.png)

After: 
![image](https://user-images.githubusercontent.com/10677021/94302039-6ebae580-ff20-11ea-918a-0dc4fc10d7ab.png)


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

