### PR TITLE
#323 Right flyout drop shadow should not extend above top of flyout

### DIFF
--- a/canvas_modules/common-canvas/src/common-canvas/common-canvas.scss
+++ b/canvas_modules/common-canvas/src/common-canvas/common-canvas.scss
@@ -68,7 +68,7 @@ $toolbar-button-height: 41px; // Allow one extra pixel for the toolbar border
 .right-flyout-panel {
 	height: 100%;
 	position: relative;
-	box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.4);
+	box-shadow: -2px 0 4px 0 rgba(22, 22, 22, 0.25);
 }
 
 /* Alternative layout for common-canvas components where canvas and right-side


### PR DESCRIPTION
Fixes: #323 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

