### PR TITLE
#325 Expression Builder empty value validation error doesn't clear on change

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-builder.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-builder.jsx
@@ -69,7 +69,12 @@ export default class ExpressionBuilder extends React.Component {
 	onBlur(editor, evt) {
 		this.lastCursorPos = editor.getCursor();
 		const newValue = this.editor.getValue();
-		this.props.controller.updatePropertyValue(this.props.propertyId, newValue, this.expressionInfo.validateLink);
+		let skipValidate = this.expressionInfo.validateLink;
+		if (this.expressionSelectionPanel && this.expressionSelectionPanel.contains(evt.relatedTarget)) {
+			// don't validate on old content when adding new content
+			skipValidate = true;
+		}
+		this.props.controller.updatePropertyValue(this.props.propertyId, newValue, skipValidate);
 	}
 
 	editorDidMount(editor, next) {
@@ -126,13 +131,15 @@ export default class ExpressionBuilder extends React.Component {
 					height={96}
 					expressionLabel={expressionLabel}
 				/>
-				<ExpressionSelectionPanel
-					controller={this.props.controller}
-					onChange={this.onChange}
-					functionList={this.expressionInfo.functionCategories}
-					operatorList={this.expressionInfo.operators}
-					language={this.props.control.language}
-				/>
+				<div ref={ (ref) => (this.expressionSelectionPanel = ref) }>
+					<ExpressionSelectionPanel
+						controller={this.props.controller}
+						onChange={this.onChange}
+						functionList={this.expressionInfo.functionCategories}
+						operatorList={this.expressionInfo.operators}
+						language={this.props.control.language}
+					/>
+				</div>
 			</div>
 		);
 	}

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.jsx
@@ -229,7 +229,11 @@ class ExpressionControl extends React.Component {
 			this.props.onBlur(editor, evt);
 		} else {
 			const newValue = this.editor.getValue();
-			this.props.controller.updatePropertyValue(this.props.propertyId, newValue, this.expressionInfo.validateLink);
+			// don't validate when opening the expression builder
+			const skipValidate = evt.relatedTarget && evt.relatedTarget.classList.contains("properties-expression-button")
+				? true
+				: this.expressionInfo.validateLink;
+			this.props.controller.updatePropertyValue(this.props.propertyId, newValue, skipValidate);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/elyra-ai/canvas/issues/325

The original error cases can only be hit when "Show Expression Validate Link" is set to `Off` in the Common Properties settings flyout before opening a paramDef.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

