### PR TITLE
#419 Improve Common Properties TitleEditor

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/components/title-editor-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/components/title-editor-test.js
@@ -48,7 +48,7 @@ describe("title-editor renders correctly", () => {
 				help={help}
 				icon={"images/nodes/derive.svg"}
 				heading={"heading"}
-				subtitle
+				showHeading
 			/>
 		);
 		expect(wrapper.prop("controller")).to.equal(controller);
@@ -57,7 +57,7 @@ describe("title-editor renders correctly", () => {
 		expect(wrapper.prop("help")).to.eql(help);
 		expect(wrapper.prop("icon")).to.eql("images/nodes/derive.svg");
 		expect(wrapper.prop("heading")).to.eql("heading");
-		expect(wrapper.prop("subtitle")).to.eql(true);
+		expect(wrapper.prop("showHeading")).to.eql(true);
 
 	});
 	it("test help button callback", (done) => {
@@ -144,7 +144,7 @@ describe("title-editor renders correctly", () => {
 		const input = wrapper.find("input");
 		expect(input.prop("readOnly")).to.equal(true);
 	});
-	it("subtitle should render if enabled and passed in", () => {
+	it("heading should render if enabled and passed in", () => {
 		const wrapper = mountWithIntl(
 			<TitleEditor
 				store={controller.getStore()}
@@ -153,15 +153,15 @@ describe("title-editor renders correctly", () => {
 				labelEditable
 				icon={"images/nodes/derive.svg"}
 				heading={"heading"}
-				subtitle
+				showHeading
 			/>
 		);
-		expect(wrapper.find(".properties-title-subtitle")).to.have.length(1);
-		expect(wrapper.find(".properties-title-editor.properties-title-with-subtitle")).to.have.length(1);
-		expect(wrapper.find(".properties-title-subtitle-label")).to.have.length(1);
-		expect(wrapper.find("InlineSVG.properties-title-subtitle-icon")).to.have.length(1);
+		expect(wrapper.find(".properties-title-heading")).to.have.length(1);
+		expect(wrapper.find(".properties-title-editor.properties-title-with-heading")).to.have.length(1);
+		expect(wrapper.find(".properties-title-heading-label")).to.have.length(1);
+		expect(wrapper.find("InlineSVG.properties-title-heading-icon")).to.have.length(1);
 	});
-	it("subtitle should not render if disabled", () => {
+	it("heading should not render if disabled", () => {
 		const wrapper = mountWithIntl(
 			<TitleEditor
 				store={controller.getStore()}
@@ -172,24 +172,24 @@ describe("title-editor renders correctly", () => {
 				heading={"heading"}
 			/>
 		);
-		expect(wrapper.find(".properties-title-subtitle")).to.have.length(0);
-		expect(wrapper.find(".properties-title-editor.properties-title-with-subtitle")).to.have.length(0);
-		expect(wrapper.find(".properties-title-subtitle-label")).to.have.length(0);
-		expect(wrapper.find("InlineSVG.properties-title-subtitle-icon")).to.have.length(0);
+		expect(wrapper.find(".properties-title-heading")).to.have.length(0);
+		expect(wrapper.find(".properties-title-editor.properties-title-with-heading")).to.have.length(0);
+		expect(wrapper.find(".properties-title-heading-label")).to.have.length(0);
+		expect(wrapper.find("InlineSVG.properties-title-heading-icon")).to.have.length(0);
 	});
-	it("subtitle should not render if enabled but no uiHints are passed in", () => {
+	it("heading should not render if enabled but no uiHints are passed in", () => {
 		const wrapper = mountWithIntl(
 			<TitleEditor
 				store={controller.getStore()}
 				controller={controller}
 				helpClickHandler={helpClickHandler}
 				labelEditable
-				subtitle
+				showHeading
 			/>
 		);
-		expect(wrapper.find(".properties-title-subtitle")).to.have.length(0);
-		expect(wrapper.find(".properties-title-editor.properties-title-with-subtitle")).to.have.length(0);
-		expect(wrapper.find(".properties-title-subtitle-label")).to.have.length(0);
-		expect(wrapper.find("InlineSVG.properties-title-subtitle-icon")).to.have.length(0);
+		expect(wrapper.find(".properties-title-heading")).to.have.length(0);
+		expect(wrapper.find(".properties-title-editor.properties-title-with-heading")).to.have.length(0);
+		expect(wrapper.find(".properties-title-heading-label")).to.have.length(0);
+		expect(wrapper.find("InlineSVG.properties-title-heading-icon")).to.have.length(0);
 	});
 });

--- a/canvas_modules/common-canvas/__tests__/common-properties/components/title-editor-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/components/title-editor-test.js
@@ -34,6 +34,13 @@ controller.setAppData(appData);
 
 const helpClickHandler = sinon.spy();
 const help = { data: "test-data" };
+const uiHints = {
+	icon: "images/nodes/derive.svg",
+	id: "default",
+	label: {
+		default: "test label"
+	}
+};
 
 describe("title-editor renders correctly", () => {
 
@@ -45,12 +52,17 @@ describe("title-editor renders correctly", () => {
 				helpClickHandler={helpClickHandler}
 				labelEditable
 				help={help}
+				uiHints={uiHints}
+				subtitle
 			/>
 		);
 		expect(wrapper.prop("controller")).to.equal(controller);
 		expect(wrapper.prop("helpClickHandler")).to.equal(helpClickHandler);
 		expect(wrapper.prop("labelEditable")).to.equal(true);
 		expect(wrapper.prop("help")).to.eql(help);
+		expect(wrapper.prop("uiHints")).to.eql(uiHints);
+		expect(wrapper.prop("subtitle")).to.eql(true);
+
 	});
 	it("test help button callback", (done) => {
 		function callback(componentId, inData, inAppData) {
@@ -135,5 +147,51 @@ describe("title-editor renders correctly", () => {
 		);
 		const input = wrapper.find("input");
 		expect(input.prop("readOnly")).to.equal(true);
+	});
+	it("subtitle should render if enabled and passed in", () => {
+		const wrapper = mountWithIntl(
+			<TitleEditor
+				store={controller.getStore()}
+				controller={controller}
+				helpClickHandler={helpClickHandler}
+				labelEditable
+				uiHints={uiHints}
+				subtitle
+			/>
+		);
+		expect(wrapper.find(".properties-title-subtitle")).to.have.length(1);
+		expect(wrapper.find(".properties-title-editor.properties-title-with-subtitle")).to.have.length(1);
+		expect(wrapper.find(".properties-title-subtitle-label")).to.have.length(1);
+		expect(wrapper.find(".properties-title-subtitle-icon")).to.have.length(1);
+	});
+	it("subtitle should not render if disabled", () => {
+		const wrapper = mountWithIntl(
+			<TitleEditor
+				store={controller.getStore()}
+				controller={controller}
+				helpClickHandler={helpClickHandler}
+				labelEditable
+				uiHints={uiHints}
+			/>
+		);
+		expect(wrapper.find(".properties-title-subtitle")).to.have.length(0);
+		expect(wrapper.find(".properties-title-editor.properties-title-with-subtitle")).to.have.length(0);
+		expect(wrapper.find(".properties-title-subtitle-label")).to.have.length(0);
+		expect(wrapper.find(".properties-title-subtitle-icon")).to.have.length(0);
+	});
+	it("subtitle should not render if enabled but no uiHints are passed in", () => {
+		const wrapper = mountWithIntl(
+			<TitleEditor
+				store={controller.getStore()}
+				controller={controller}
+				helpClickHandler={helpClickHandler}
+				labelEditable
+				subtitle
+			/>
+		);
+		expect(wrapper.find(".properties-title-subtitle")).to.have.length(0);
+		expect(wrapper.find(".properties-title-editor.properties-title-with-subtitle")).to.have.length(0);
+		expect(wrapper.find(".properties-title-subtitle-label")).to.have.length(0);
+		expect(wrapper.find(".properties-title-subtitle-icon")).to.have.length(0);
 	});
 });

--- a/canvas_modules/common-canvas/__tests__/common-properties/components/title-editor-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/components/title-editor-test.js
@@ -34,13 +34,7 @@ controller.setAppData(appData);
 
 const helpClickHandler = sinon.spy();
 const help = { data: "test-data" };
-const uiHints = {
-	icon: "images/nodes/derive.svg",
-	id: "default",
-	label: {
-		default: "test label"
-	}
-};
+
 
 describe("title-editor renders correctly", () => {
 
@@ -52,7 +46,8 @@ describe("title-editor renders correctly", () => {
 				helpClickHandler={helpClickHandler}
 				labelEditable
 				help={help}
-				uiHints={uiHints}
+				icon={"images/nodes/derive.svg"}
+				heading={"heading"}
 				subtitle
 			/>
 		);
@@ -60,7 +55,8 @@ describe("title-editor renders correctly", () => {
 		expect(wrapper.prop("helpClickHandler")).to.equal(helpClickHandler);
 		expect(wrapper.prop("labelEditable")).to.equal(true);
 		expect(wrapper.prop("help")).to.eql(help);
-		expect(wrapper.prop("uiHints")).to.eql(uiHints);
+		expect(wrapper.prop("icon")).to.eql("images/nodes/derive.svg");
+		expect(wrapper.prop("heading")).to.eql("heading");
 		expect(wrapper.prop("subtitle")).to.eql(true);
 
 	});
@@ -155,14 +151,15 @@ describe("title-editor renders correctly", () => {
 				controller={controller}
 				helpClickHandler={helpClickHandler}
 				labelEditable
-				uiHints={uiHints}
+				icon={"images/nodes/derive.svg"}
+				heading={"heading"}
 				subtitle
 			/>
 		);
 		expect(wrapper.find(".properties-title-subtitle")).to.have.length(1);
 		expect(wrapper.find(".properties-title-editor.properties-title-with-subtitle")).to.have.length(1);
 		expect(wrapper.find(".properties-title-subtitle-label")).to.have.length(1);
-		expect(wrapper.find(".properties-title-subtitle-icon")).to.have.length(1);
+		expect(wrapper.find("InlineSVG.properties-title-subtitle-icon")).to.have.length(1);
 	});
 	it("subtitle should not render if disabled", () => {
 		const wrapper = mountWithIntl(
@@ -171,13 +168,14 @@ describe("title-editor renders correctly", () => {
 				controller={controller}
 				helpClickHandler={helpClickHandler}
 				labelEditable
-				uiHints={uiHints}
+				icon={"images/nodes/derive.svg"}
+				heading={"heading"}
 			/>
 		);
 		expect(wrapper.find(".properties-title-subtitle")).to.have.length(0);
 		expect(wrapper.find(".properties-title-editor.properties-title-with-subtitle")).to.have.length(0);
 		expect(wrapper.find(".properties-title-subtitle-label")).to.have.length(0);
-		expect(wrapper.find(".properties-title-subtitle-icon")).to.have.length(0);
+		expect(wrapper.find("InlineSVG.properties-title-subtitle-icon")).to.have.length(0);
 	});
 	it("subtitle should not render if enabled but no uiHints are passed in", () => {
 		const wrapper = mountWithIntl(
@@ -192,6 +190,6 @@ describe("title-editor renders correctly", () => {
 		expect(wrapper.find(".properties-title-subtitle")).to.have.length(0);
 		expect(wrapper.find(".properties-title-editor.properties-title-with-subtitle")).to.have.length(0);
 		expect(wrapper.find(".properties-title-subtitle-label")).to.have.length(0);
-		expect(wrapper.find(".properties-title-subtitle-icon")).to.have.length(0);
+		expect(wrapper.find("InlineSVG.properties-title-subtitle-icon")).to.have.length(0);
 	});
 });

--- a/canvas_modules/common-canvas/__tests__/common-properties/form/form-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/form/form-test.js
@@ -148,7 +148,7 @@ describe("Correct form should be created", () => {
 		expect(isEqual(JSON.parse(JSON.stringify(conditionResource.expectedResult)), JSON.parse(JSON.stringify(generatedForm)))).to.be.true;
 	});
 
-	it.only("should create a form with editStyle set to subpanel and checkbox panel", () => {
+	it("should create a form with editStyle set to subpanel and checkbox panel", () => {
 		const generatedForm = Form.makeForm(editStyleResource.paramDef);
 		// console.info("Expected: " + JSON.stringify(editStyleResource.expectedResult));
 		// console.info("Actual  : " + JSON.stringify(generatedForm) + "\n\n");

--- a/canvas_modules/common-canvas/__tests__/common-properties/form/form-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/form/form-test.js
@@ -34,7 +34,6 @@ describe("Correct form should be created", () => {
 		// console.info("Expected: " + JSON.stringify(formResource.expectedResult));
 		// console.info("Actual  : " + JSON.stringify(generatedForm));
 		// console.info("\n\n");
-
 		// Work around since comparing the objects directly doesn't work.
 		expect(isEqual(JSON.parse(JSON.stringify(formResource.expectedResult)), JSON.parse(JSON.stringify(generatedForm)))).to.be.true;
 	});
@@ -89,7 +88,9 @@ describe("Correct form should be created", () => {
 		};
 		let help;
 		let pixelWidth; // Pass in an undefined pixelWidth to simulate it missing from ParamDefs.
-		const expectedForm = new Form("TestOp", "TestOp", true, help, "small", pixelWidth, [primaryTabs], buttons, data);
+		let conditions;
+		let resources;
+		const expectedForm = new Form("TestOp", "TestOp", true, help, "small", pixelWidth, [primaryTabs], buttons, data, conditions, resources, "./test.svg");
 
 		const paramSpec = {
 			"current_parameters": {
@@ -147,7 +148,7 @@ describe("Correct form should be created", () => {
 		expect(isEqual(JSON.parse(JSON.stringify(conditionResource.expectedResult)), JSON.parse(JSON.stringify(generatedForm)))).to.be.true;
 	});
 
-	it("should create a form with editStyle set to subpanel and checkbox panel", () => {
+	it.only("should create a form with editStyle set to subpanel and checkbox panel", () => {
 		const generatedForm = Form.makeForm(editStyleResource.paramDef);
 		// console.info("Expected: " + JSON.stringify(editStyleResource.expectedResult));
 		// console.info("Actual  : " + JSON.stringify(generatedForm) + "\n\n");

--- a/canvas_modules/common-canvas/__tests__/test_resources/json/form-actions-test.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/json/form-actions-test.json
@@ -451,6 +451,8 @@
       "increment": "Increment",
       "decrement": "Decrement",
       "dm-update": "Update Datamodel"
-    }
+    },
+    "icon": "images/actions.svg",
+    "heading": "Action Test"
   }
 }

--- a/canvas_modules/common-canvas/__tests__/test_resources/json/form-editstyle-test.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/json/form-editstyle-test.json
@@ -470,6 +470,7 @@
       "RenameFieldEntry.new_name": "Output name",
       "RenameFieldEntry.new_label": "New Label",
       "output_name_not_empty": "The 'Output Name' field cannot be empty"
-    }
+    },
+    "icon": "./rename.svg"
   }
 }

--- a/canvas_modules/common-canvas/__tests__/test_resources/json/form-placement-test.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/json/form-placement-test.json
@@ -309,6 +309,8 @@
       "selected_fields.label": "Columns",
       "selected_fields.desc": "Select columns to include or exclude",
       "cols_not_empty": "The 'Column Name' field cannot be empty"
-    }
+    },
+    "icon": "images/transformationspark.svg",
+    "heading": "Distinct"
   }
 }

--- a/canvas_modules/common-canvas/__tests__/test_resources/json/form-structure-test.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/json/form-structure-test.json
@@ -398,6 +398,7 @@
       "field.label": "Input name",
       "new_name.label": "Output name",
       "output_name_not_empty": "The 'Output Name' field cannot be empty"
-    }
+    },
+    "icon": "./rename.svg"
   }
 }

--- a/canvas_modules/common-canvas/__tests__/test_resources/json/form-structure2-test.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/json/form-structure2-test.json
@@ -398,6 +398,8 @@
       "SortEntry.sort_order.label": "Order",
       "SortEntry.sort_order.Ascending.label": "Ascending",
       "SortEntry.sort_order.Descending.label": "Descending"
-    }
+    },
+    "icon": "images/sort.svg",
+    "heading": "Sort"
   }
 }

--- a/canvas_modules/common-canvas/__tests__/test_resources/json/form-test.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/json/form-test.json
@@ -430,6 +430,8 @@
       "enum_param.key.Include.label": "Include: resource",
       "column-settings.label": "Field Settings label: resource",
       "str_param.place_holder_text": "Place holder text: resource"
-    }
+    },
+    "icon": "./test.svg",
+    "heading": "TestOp label: resource"
   }
 }

--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/Filter_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/Filter_paramDef.json
@@ -75,7 +75,10 @@
   ],
   "uihints": {
     "id": "filter",
-    "icon": "images/filter.svg",
+    "icon": "images/common_node_icons/operations/operation_filter.svg",
+    "label": {
+      "default": "Filter Test"
+    },
     "editor_size": "medium",
     "complex_type_info": [
       {

--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/empty_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/empty_paramDef.json
@@ -6,7 +6,11 @@
     "id": "default",
     "icon": "images/nodes/derive.svg",
     "label": {
-      "default": "Empty parameter definition"
+      "default": "Empty parameter definition",
+      "resource_key": "emptyDefinition.uihints.label"
     }
+  },
+  "resources": {
+    "emptyDefinition.uihints.label": "Empty Definition Label"
   }
 }

--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/empty_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/empty_paramDef.json
@@ -4,7 +4,7 @@
   },
   "uihints": {
     "id": "default",
-    "icon": "images/default.svg",
+    "icon": "images/nodes/derive.svg",
     "label": {
       "default": "Empty parameter definition"
     }

--- a/canvas_modules/common-canvas/package.json
+++ b/canvas_modules/common-canvas/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@carbon/icons-react": "10.18.0",
     "@carbon/themes": "10.19.0",
-    "@elyra/pipeline-schemas": "^3.0.27",
+    "@elyra/pipeline-schemas": "^3.0.28",
     "carbon-components": "10.20.0",
     "carbon-components-react": "7.20.0",
     "carbon-icons": "7.0.7",

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -77,7 +77,7 @@ class TitleEditor extends Component {
 			</Button>);
 
 		const helpButton = this.props.help
-			? (<Button kind="ghost" className="properties-title-editor-btn" data-id="help" onClick={this.helpClickHandler}>
+			? (<Button kind="ghost" className="properties-title-editor-btn help" data-id="help" onClick={this.helpClickHandler}>
 				<Icon type={CARBON_ICONS.INFORMATION} />
 			</Button>)
 			: null;
@@ -105,7 +105,7 @@ class TitleEditor extends Component {
 				{ "properties-title-with-heading": this.props.showHeading && (this.props.heading || this.props.icon) })}
 			>
 				{heading}
-				<div className="properties-title-editor-input">
+				<div className={classNames("properties-title-editor-input", { "properties-title-editor-with-help": this.props.help })}>
 					<TextInput
 						id={this.id}
 						ref={this.textInputRef}

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -22,16 +22,24 @@ import Icon from "./../../../icons/icon.jsx";
 import { TextInput, Button } from "carbon-components-react";
 import { MESSAGE_KEYS, CARBON_ICONS } from "./../../constants/constants";
 import * as PropertyUtils from "./../../util/property-utils";
+import classNames from "classnames";
+
 
 class TitleEditor extends Component {
 	constructor(props) {
 		super(props);
+		this.state = {
+			focused: false
+		};
 		this.editTitleClickHandler = this.editTitleClickHandler.bind(this);
 		this.helpClickHandler = this.helpClickHandler.bind(this);
 		this.id = PropertyUtils.generateId();
 		this.textInputRef = React.createRef();
 		this.labelText = PropertyUtils.formatMessage(props.controller.getReactIntl(),
 			MESSAGE_KEYS.TITLE_EDITOR_LABEL);
+		this.textInputOnFocus = this.textInputOnFocus.bind(this);
+		this.textInputOnBlur = this.textInputOnBlur.bind(this);
+
 	}
 
 	_handleKeyPress(e) {
@@ -52,9 +60,16 @@ class TitleEditor extends Component {
 				this.props.controller.getAppData());
 		}
 	}
+	textInputOnFocus() {
+		this.setState({ focused: true });
+	}
+
+	textInputOnBlur() {
+		this.setState({ focused: false });
+	}
 
 	render() {
-		const propertiesTitleEdit = this.props.labelEditable === false ? <div />
+		const propertiesTitleEdit = this.props.labelEditable === false || this.state.focused ? <div />
 			: (<Button kind="ghost" className="properties-title-editor-btn edit" data-id="edit" onClick={this.editTitleClickHandler}>
 				<Icon type={CARBON_ICONS.EDIT} />
 			</Button>);
@@ -65,8 +80,34 @@ class TitleEditor extends Component {
 			</Button>)
 			: null;
 
+		let subtitle = null;
+		if (this.props.uihints && (this.props.uihints.label || this.props.uihints.icon)) {
+			let label = null;
+			if (this.props.uihints.label) {
+				if (typeof this.props.uihints.label === "string") {
+					label = this.props.uihints.label;
+				} else if (this.props.uihints.label.default) {
+					label = this.props.uihints.label.default;
+				}
+			}
+			const icon = this.props.uihints.icon && typeof this.props.uihints.icon === "string"
+				? <img className="properties-title-subtitle-icon" src={this.props.uihints.icon} />
+				: null;
+
+			subtitle = (<div className="properties-title-subtitle">
+				{icon}
+				<div className="properties-title-subtitle-label">
+					{label}
+				</div>
+			</div>);
+		}
+
+
 		return (
-			<div className="properties-title-editor">
+			<div className={classNames("properties-title-editor",
+				{ "properties-title-with-subtitle": this.props.uihints && (this.props.uihints.label || this.props.uihints.icon) })}
+			>
+				{subtitle}
 				<div className="properties-title-editor-input">
 					<TextInput
 						id={this.id}
@@ -77,6 +118,9 @@ class TitleEditor extends Component {
 						readOnly={this.props.labelEditable === false}
 						labelText={this.labelText}
 						hideLabel
+						onFocus={this.textInputOnFocus}
+						onBlur={this.textInputOnBlur}
+						{... this.state.focused && { className: "properties-title-editor-focused" }}
 					/>
 					{propertiesTitleEdit}
 				</div>
@@ -91,6 +135,7 @@ TitleEditor.propTypes = {
 	controller: PropTypes.object.isRequired,
 	labelEditable: PropTypes.bool,
 	help: PropTypes.object,
+	uihints: PropTypes.object,
 	title: PropTypes.string, // set by redux
 	setTitle: PropTypes.func // set by redux
 };

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -83,17 +83,17 @@ class TitleEditor extends Component {
 			: null;
 
 		let subtitle = null;
-		if (this.props.subtitle && this.props.uihints && (this.props.uihints.label || this.props.uihints.icon)) {
+		if (this.props.subtitle && this.props.uiHints && (this.props.uiHints.label || this.props.uiHints.icon)) {
 			let label = null;
-			if (this.props.uihints.label) {
-				if (typeof this.props.uihints.label === "string") {
-					label = this.props.uihints.label;
-				} else if (this.props.uihints.label.default) {
-					label = this.props.uihints.label.default;
+			if (this.props.uiHints.label) {
+				if (typeof this.props.uiHints.label === "string") {
+					label = this.props.uiHints.label;
+				} else if (this.props.uiHints.label.default) {
+					label = this.props.uiHints.label.default;
 				}
 			}
-			const icon = this.props.uihints.icon && typeof this.props.uihints.icon === "string"
-				? <Isvg className="properties-title-subtitle-icon" src={this.props.uihints.icon} />
+			const icon = this.props.uiHints.icon && typeof this.props.uiHints.icon === "string"
+				? <Isvg className="properties-title-subtitle-icon" src={this.props.uiHints.icon} />
 				: null;
 
 			subtitle = (<div className="properties-title-subtitle">
@@ -104,10 +104,9 @@ class TitleEditor extends Component {
 			</div>);
 		}
 
-
 		return (
 			<div className={classNames("properties-title-editor",
-				{ "properties-title-with-subtitle": this.props.uihints && (this.props.uihints.label || this.props.uihints.icon) })}
+				{ "properties-title-with-subtitle": this.props.subtitle && this.props.uiHints && (this.props.uiHints.label || this.props.uiHints.icon) })}
 			>
 				{subtitle}
 				<div className="properties-title-editor-input">
@@ -137,7 +136,7 @@ TitleEditor.propTypes = {
 	controller: PropTypes.object.isRequired,
 	labelEditable: PropTypes.bool,
 	help: PropTypes.object,
-	uihints: PropTypes.object,
+	uiHints: PropTypes.object,
 	subtitle: PropTypes.bool,
 	title: PropTypes.string, // set by redux
 	setTitle: PropTypes.func // set by redux

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -19,6 +19,8 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { setTitle } from "./../../actions";
 import Icon from "./../../../icons/icon.jsx";
+import Isvg from "react-inlinesvg";
+
 import { TextInput, Button } from "carbon-components-react";
 import { MESSAGE_KEYS, CARBON_ICONS } from "./../../constants/constants";
 import * as PropertyUtils from "./../../util/property-utils";
@@ -91,7 +93,7 @@ class TitleEditor extends Component {
 				}
 			}
 			const icon = this.props.uihints.icon && typeof this.props.uihints.icon === "string"
-				? <img className="properties-title-subtitle-icon" src={this.props.uihints.icon} />
+				? <Isvg className="properties-title-subtitle-icon" src={this.props.uihints.icon} />
 				: null;
 
 			subtitle = (<div className="properties-title-subtitle">

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -83,14 +83,14 @@ class TitleEditor extends Component {
 			: null;
 
 		let subtitle = null;
-		if (this.props.subtitle && this.props.uiHints && (this.props.uiHints.label || this.props.uiHints.icon)) {
-			const label = this.props.uiHints.label
+		if (this.props.subtitle && (this.props.heading || this.props.icon)) {
+			const label = this.props.heading
 				? (<div className="properties-title-subtitle-label">
-					{this.props.uiHints.label}
+					{this.props.heading}
 				</div>)
 				: null;
-			const icon = this.props.uiHints.icon && typeof this.props.uiHints.icon === "string"
-				? <Isvg className="properties-title-subtitle-icon" src={this.props.uiHints.icon} />
+			const icon = this.props.icon && typeof this.props.icon === "string"
+				? <Isvg className="properties-title-subtitle-icon" src={this.props.icon} />
 				: null;
 			if (label || icon) {
 				subtitle = (<div className="properties-title-subtitle">
@@ -102,7 +102,7 @@ class TitleEditor extends Component {
 
 		return (
 			<div className={classNames("properties-title-editor",
-				{ "properties-title-with-subtitle": this.props.subtitle && this.props.uiHints && (this.props.uiHints.label || this.props.uiHints.icon) })}
+				{ "properties-title-with-subtitle": this.props.subtitle && (this.props.heading || this.props.icon) })}
 			>
 				{subtitle}
 				<div className="properties-title-editor-input">
@@ -132,7 +132,8 @@ TitleEditor.propTypes = {
 	controller: PropTypes.object.isRequired,
 	labelEditable: PropTypes.bool,
 	help: PropTypes.object,
-	uiHints: PropTypes.object,
+	icon: PropTypes.string,
+	heading: PropTypes.string,
 	subtitle: PropTypes.bool,
 	title: PropTypes.string, // set by redux
 	setTitle: PropTypes.func // set by redux

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -84,24 +84,20 @@ class TitleEditor extends Component {
 
 		let subtitle = null;
 		if (this.props.subtitle && this.props.uiHints && (this.props.uiHints.label || this.props.uiHints.icon)) {
-			let label = null;
-			if (this.props.uiHints.label) {
-				if (typeof this.props.uiHints.label === "string") {
-					label = this.props.uiHints.label;
-				} else if (this.props.uiHints.label.default) {
-					label = this.props.uiHints.label.default;
-				}
-			}
+			const label = this.props.uiHints.label
+				? (<div className="properties-title-subtitle-label">
+					{this.props.uiHints.label}
+				</div>)
+				: null;
 			const icon = this.props.uiHints.icon && typeof this.props.uiHints.icon === "string"
 				? <Isvg className="properties-title-subtitle-icon" src={this.props.uiHints.icon} />
 				: null;
-
-			subtitle = (<div className="properties-title-subtitle">
-				{icon}
-				<div className="properties-title-subtitle-label">
+			if (label || icon) {
+				subtitle = (<div className="properties-title-subtitle">
+					{icon}
 					{label}
-				</div>
-			</div>);
+				</div>);
+			}
 		}
 
 		return (

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -82,18 +82,18 @@ class TitleEditor extends Component {
 			</Button>)
 			: null;
 
-		let subtitle = null;
-		if (this.props.subtitle && (this.props.heading || this.props.icon)) {
+		let heading = null;
+		if (this.props.showHeading && (this.props.heading || this.props.icon)) {
 			const label = this.props.heading
-				? (<div className="properties-title-subtitle-label">
+				? (<div className="properties-title-heading-label">
 					{this.props.heading}
 				</div>)
 				: null;
 			const icon = this.props.icon && typeof this.props.icon === "string"
-				? <Isvg className="properties-title-subtitle-icon" src={this.props.icon} />
+				? <Isvg className="properties-title-heading-icon" src={this.props.icon} />
 				: null;
 			if (label || icon) {
-				subtitle = (<div className="properties-title-subtitle">
+				heading = (<div className="properties-title-heading">
 					{icon}
 					{label}
 				</div>);
@@ -102,9 +102,9 @@ class TitleEditor extends Component {
 
 		return (
 			<div className={classNames("properties-title-editor",
-				{ "properties-title-with-subtitle": this.props.subtitle && (this.props.heading || this.props.icon) })}
+				{ "properties-title-with-heading": this.props.showHeading && (this.props.heading || this.props.icon) })}
 			>
-				{subtitle}
+				{heading}
 				<div className="properties-title-editor-input">
 					<TextInput
 						id={this.id}
@@ -134,7 +134,7 @@ TitleEditor.propTypes = {
 	help: PropTypes.object,
 	icon: PropTypes.string,
 	heading: PropTypes.string,
-	subtitle: PropTypes.bool,
+	showHeading: PropTypes.bool,
 	title: PropTypes.string, // set by redux
 	setTitle: PropTypes.func // set by redux
 };

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -81,7 +81,7 @@ class TitleEditor extends Component {
 			: null;
 
 		let subtitle = null;
-		if (this.props.uihints && (this.props.uihints.label || this.props.uihints.icon)) {
+		if (this.props.subtitle && this.props.uihints && (this.props.uihints.label || this.props.uihints.icon)) {
 			let label = null;
 			if (this.props.uihints.label) {
 				if (typeof this.props.uihints.label === "string") {
@@ -136,6 +136,7 @@ TitleEditor.propTypes = {
 	labelEditable: PropTypes.bool,
 	help: PropTypes.object,
 	uihints: PropTypes.object,
+	subtitle: PropTypes.bool,
 	title: PropTypes.string, // set by redux
 	setTitle: PropTypes.func // set by redux
 };

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
@@ -18,17 +18,17 @@
 	display: block;
 	align-items: center;
 	padding-top: $spacing-05;
-	padding-bottom: $spacing-06;
-	height: 80px;
+	padding-bottom: $spacing-05;
+	height: 72px;
+	border-bottom: 1px $ui-03 solid;
 	&.properties-title-with-subtitle {
-		height: 112px; // include subtitle with icon height
+		height: 96px; // include subtitle with icon height
 	}
 }
 
 .properties-title-subtitle {
 	padding-left: $spacing-05;
 	padding-right: $spacing-05;
-	margin-bottom: $spacing-02;
 	height: $spacing-06;
 	display: flex;
 	align-items: center;

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
@@ -21,23 +21,23 @@
 	padding-bottom: $spacing-05;
 	height: 72px;
 	border-bottom: 1px $ui-03 solid;
-	&.properties-title-with-subtitle {
-		height: 96px; // include subtitle with icon height
+	&.properties-title-with-heading {
+		height: 96px; // include heading with icon height
 	}
 }
 
-.properties-title-subtitle {
+.properties-title-heading {
 	padding-left: $spacing-05;
 	padding-right: $spacing-05;
 	height: $spacing-06;
 	display: flex;
 	align-items: center;
-	.properties-title-subtitle-icon {
+	.properties-title-heading-icon {
 		height: $spacing-06;
 		width: $spacing-06;
 		margin-right: $spacing-03;
 	}
-	.properties-title-subtitle-label {
+	.properties-title-heading-label {
 		@include carbon--type-style("label-01");
 	}
 }

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
@@ -15,19 +15,40 @@
  */
 
 .properties-title-editor {
-	height: 41px;
-	display: flex;
+	display: block;
 	align-items: center;
-	border-bottom: 1px solid $ui-03;
+	padding-top: $spacing-06;
+	padding-bottom: $spacing-06;
+	height: 88px;
+	&.properties-title-with-subtitle {
+		height: 120px; // include subtitle with icon height
+	}
 }
 
+.properties-title-subtitle {
+	padding-left: $spacing-05;
+	padding-right: $spacing-05;
+	margin-bottom: $spacing-03;
+	height: $spacing-06;
+	display: flex;
+	align-items: center;
+	.properties-title-subtitle-icon {
+		height: $spacing-06;
+		width: $spacing-06;
+		margin-right: $spacing-03;
+	}
+	.properties-title-subtitle-label {
+		@include carbon--type-style("label-01");
+	}
+}
 .properties-title-editor-input {
-	height: 100%;
+	height: $spacing-08;
 	width: calc(100% - 2px); // subtract 2px for input active right border
 	top: 1px; // align input with bottom border
 	position: relative;
 	display: flex;
 	align-items: center;
+
 
 	.bx--form-item.bx--text-input-wrapper {
 		// allow edit icon to be at the end of text input
@@ -35,15 +56,18 @@
 		width: 100%;
 
 		input { //override styling from carbon
-			@include carbon--type-style("productive-heading-03");
+			@include carbon--type-style("productive-heading-02");
 			color: $text-01;
-
 			min-width: unset;
 			background: unset;
-			padding-right: 40px; // avoid edit icon
+			text-overflow: ellipsis;
+			border-bottom: unset;
 			&[readonly] {
 				box-shadow: unset;
 				cursor: default;
+			}
+			&:not(.properties-title-editor-focused) {
+				padding-right: $spacing-08; // avoid edit icon
 			}
 		}
 	}

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
@@ -17,18 +17,18 @@
 .properties-title-editor {
 	display: block;
 	align-items: center;
-	padding-top: $spacing-06;
+	padding-top: $spacing-05;
 	padding-bottom: $spacing-06;
-	height: 88px;
+	height: 80px;
 	&.properties-title-with-subtitle {
-		height: 120px; // include subtitle with icon height
+		height: 112px; // include subtitle with icon height
 	}
 }
 
 .properties-title-subtitle {
 	padding-left: $spacing-05;
 	padding-right: $spacing-05;
-	margin-bottom: $spacing-03;
+	margin-bottom: $spacing-02;
 	height: $spacing-06;
 	display: flex;
 	align-items: center;

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
@@ -50,7 +50,7 @@
 	align-items: center;
 
 	&.properties-title-editor-with-help {
-		width: calc(100% - 42px); // subtract another 40px for help button
+		width: calc(100% - #{$spacing-07}); // subtract the size of the help button
 	}
 	.bx--form-item.bx--text-input-wrapper {
 		// allow edit icon to be at the end of text input
@@ -77,25 +77,22 @@
 	// Edit button should be inside the title input box
 	.properties-title-editor-btn {
 		position: absolute;
-		right: 2px;
-		fill: $icon-02;
-		padding: 7px;
-		min-height: 16px;
-		&:hover {
-			background-color: $ui-03;
-		}
-		&:active {
-			background-color: $ui-03;
-		}
+		right: $spacing-01;
 	}
 }
 
-.properties-title-editor-btn.help {
-	min-height: $spacing-08;
+.properties-title-editor-btn.help, .properties-title-editor-btn.edit {
+	fill: $icon-02;
+	padding: calc(#{$spacing-03} - 1px);
+	min-height: $spacing-05;
 	&:hover {
 		background-color: $ui-03;
 	}
 	&:active {
 		background-color: $ui-03;
+	}
+	&.help {
+		margin-top: $spacing-02;
+		margin-bottom: $spacing-02;
 	}
 }

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
@@ -46,10 +46,12 @@
 	width: calc(100% - 2px); // subtract 2px for input active right border
 	top: 1px; // align input with bottom border
 	position: relative;
-	display: flex;
+	display: inline-flex;
 	align-items: center;
 
-
+	&.properties-title-editor-with-help {
+		width: calc(100% - 42px); // subtract another 40px for help button
+	}
 	.bx--form-item.bx--text-input-wrapper {
 		// allow edit icon to be at the end of text input
 		position: absolute;
@@ -79,12 +81,21 @@
 		fill: $icon-02;
 		padding: 7px;
 		min-height: 16px;
-
 		&:hover {
 			background-color: $ui-03;
 		}
 		&:active {
 			background-color: $ui-03;
 		}
+	}
+}
+
+.properties-title-editor-btn.help {
+	min-height: $spacing-08;
+	&:hover {
+		background-color: $ui-03;
+	}
+	&:active {
+		background-color: $ui-03;
 	}
 }

--- a/canvas_modules/common-canvas/src/common-properties/form/Form.js
+++ b/canvas_modules/common-canvas/src/common-properties/form/Form.js
@@ -23,7 +23,7 @@ import { translateMessages } from "./Conditions";
 import { Size } from "../constants/form-constants";
 
 export default class Form {
-	constructor(componentId, label, labelEditable, help, editorSize, pixelWidth, uiItems, buttons, data, conditions, resources) {
+	constructor(componentId, label, labelEditable, help, editorSize, pixelWidth, uiItems, buttons, data, conditions, resources, uiHints) {
 		this.componentId = componentId;
 		this.label = label;
 		this.labelEditable = labelEditable;
@@ -35,6 +35,7 @@ export default class Form {
 		this.data = data;
 		this.conditions = conditions;
 		this.resources = resources;
+		this.uiHints = uiHints;
 	}
 
 	/**
@@ -47,6 +48,7 @@ export default class Form {
 			propertyOf(paramDef)("uihints"));
 		const resources = propertyOf(paramDef)("resources");
 		const conditions = propertyOf(paramDef)("conditions");
+		const uiHints = propertyOf(paramDef)("uihints");
 		if (propDef) {
 			const l10nProvider = new L10nProvider(resources);
 			const tabs = [];
@@ -54,6 +56,10 @@ export default class Form {
 				for (const group of propDef.groupMetadata.groups) {
 					tabs.push(makePrimaryTab(propDef, group, l10nProvider, conditions));
 				}
+			}
+
+			if (uiHints && uiHints.label) {
+				uiHints.label = l10nProvider.l10nResource(uiHints.label);
 			}
 
 			const data = {
@@ -72,7 +78,8 @@ export default class Form {
 				_defaultButtons(),
 				data,
 				translateMessages(conditions, l10nProvider),
-				resources
+				resources,
+				uiHints
 			);
 		}
 		return null;

--- a/canvas_modules/common-canvas/src/common-properties/form/Form.js
+++ b/canvas_modules/common-canvas/src/common-properties/form/Form.js
@@ -23,7 +23,7 @@ import { translateMessages } from "./Conditions";
 import { Size } from "../constants/form-constants";
 
 export default class Form {
-	constructor(componentId, label, labelEditable, help, editorSize, pixelWidth, uiItems, buttons, data, conditions, resources, uiHints) {
+	constructor(componentId, label, labelEditable, help, editorSize, pixelWidth, uiItems, buttons, data, conditions, resources, icon, heading) {
 		this.componentId = componentId;
 		this.label = label;
 		this.labelEditable = labelEditable;
@@ -35,7 +35,8 @@ export default class Form {
 		this.data = data;
 		this.conditions = conditions;
 		this.resources = resources;
-		this.uiHints = uiHints;
+		this.icon = icon;
+		this.heading = heading;
 	}
 
 	/**
@@ -48,7 +49,6 @@ export default class Form {
 			propertyOf(paramDef)("uihints"));
 		const resources = propertyOf(paramDef)("resources");
 		const conditions = propertyOf(paramDef)("conditions");
-		const uiHints = propertyOf(paramDef)("uihints");
 		if (propDef) {
 			const l10nProvider = new L10nProvider(resources);
 			const tabs = [];
@@ -56,10 +56,6 @@ export default class Form {
 				for (const group of propDef.groupMetadata.groups) {
 					tabs.push(makePrimaryTab(propDef, group, l10nProvider, conditions));
 				}
-			}
-
-			if (uiHints && uiHints.label) {
-				uiHints.label = l10nProvider.l10nResource(uiHints.label);
 			}
 
 			const data = {
@@ -79,7 +75,8 @@ export default class Form {
 				data,
 				translateMessages(conditions, l10nProvider),
 				resources,
-				uiHints
+				propDef.icon,
+				l10nProvider.l10nResource(propDef.heading)
 			);
 		}
 		return null;

--- a/canvas_modules/common-canvas/src/common-properties/form/PropertyDef.js
+++ b/canvas_modules/common-canvas/src/common-properties/form/PropertyDef.js
@@ -24,7 +24,7 @@ import { ResourceDef } from "../util/L10nProvider";
 import { propertyOf } from "lodash";
 
 export class PropertyDef {
-	constructor(cname, icon, editorSize, pixelWidth, label, labelEditable, help, description, structureMetadata, parameterMetadata, groupMetadata, actionMetadata) {
+	constructor(cname, icon, editorSize, pixelWidth, label, labelEditable, help, description, structureMetadata, parameterMetadata, groupMetadata, actionMetadata, heading) {
 		this.name = cname;
 		this.icon = icon;
 		this.editorSize = editorSize;
@@ -37,6 +37,7 @@ export class PropertyDef {
 		this.parameterMetadata = parameterMetadata;
 		this.groupMetadata = groupMetadata;
 		this.actionMetadata = actionMetadata;
+		this.heading = heading;
 	}
 
 	/**
@@ -76,7 +77,8 @@ export class PropertyDef {
 			structureMetadata,
 			parameterMetadata,
 			groupMetadata,
-			actionMetadata
+			actionMetadata,
+			propertyOf(uihints)("label")
 		);
 	}
 }

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -386,7 +386,7 @@ class PropertiesMain extends React.Component {
 					help={formData.help}
 					controller={this.propertiesController}
 					helpClickHandler={this.props.callbacks.helpClickHandler}
-					uiHints={this.props.propertiesInfo.uihints}
+					uiHints={formData.uiHints}
 					subtitle={this.props.propertiesConfig.subtitle}
 				/>);
 				buttonsContainer = (<PropertiesButtons

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -386,7 +386,8 @@ class PropertiesMain extends React.Component {
 					help={formData.help}
 					controller={this.propertiesController}
 					helpClickHandler={this.props.callbacks.helpClickHandler}
-					uiHints={formData.uiHints}
+					icon={formData.icon}
+					heading={formData.heading}
 					subtitle={this.props.propertiesConfig.subtitle}
 				/>);
 				buttonsContainer = (<PropertiesButtons

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -386,7 +386,7 @@ class PropertiesMain extends React.Component {
 					help={formData.help}
 					controller={this.propertiesController}
 					helpClickHandler={this.props.callbacks.helpClickHandler}
-					uihints={this.props.propertiesInfo.uihints}
+					uiHints={this.props.propertiesInfo.uihints}
 					subtitle={this.props.propertiesConfig.subtitle}
 				/>);
 				buttonsContainer = (<PropertiesButtons

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -379,6 +379,7 @@ class PropertiesMain extends React.Component {
 			let propertiesTitle = <div />;
 			let buttonsContainer = <div />;
 			let resizeBtn = null;
+			let hasHeading = false;
 
 			if (this.props.propertiesConfig.rightFlyout) {
 				propertiesTitle = (<TitleEditor
@@ -388,8 +389,11 @@ class PropertiesMain extends React.Component {
 					helpClickHandler={this.props.callbacks.helpClickHandler}
 					icon={formData.icon}
 					heading={formData.heading}
-					subtitle={this.props.propertiesConfig.subtitle}
+					showHeading={this.props.propertiesConfig.heading}
 				/>);
+
+				hasHeading = this.props.propertiesConfig.heading && (formData.icon || formData.heading);
+
 				buttonsContainer = (<PropertiesButtons
 					okHandler={this.applyPropertiesEditing.bind(this, true)}
 					cancelHandler={cancelHandler}
@@ -429,7 +433,7 @@ class PropertiesMain extends React.Component {
 					{editorForm}
 				</PropertiesEditor>);
 			} else if (this.props.propertiesConfig.containerType === "Custom") {
-				propertiesDialog = (<div className="properties-custom-container">
+				propertiesDialog = (<div className={classNames("properties-custom-container", { "properties-custom-container-with-heading": hasHeading })}>
 					{editorForm}
 				</div>);
 			} else { // Modal
@@ -483,7 +487,7 @@ PropertiesMain.propTypes = {
 		containerType: PropTypes.string,
 		enableResize: PropTypes.bool,
 		conditionReturnValueHandling: PropTypes.string,
-		subtitle: PropTypes.bool,
+		heading: PropTypes.bool,
 		buttonLabels: PropTypes.shape({
 			primary: PropTypes.string,
 			secondary: PropTypes.string

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -387,6 +387,7 @@ class PropertiesMain extends React.Component {
 					controller={this.propertiesController}
 					helpClickHandler={this.props.callbacks.helpClickHandler}
 					uihints={this.props.propertiesInfo.uihints}
+					subtitle={this.props.propertiesConfig.subtitle}
 				/>);
 				buttonsContainer = (<PropertiesButtons
 					okHandler={this.applyPropertiesEditing.bind(this, true)}
@@ -481,6 +482,7 @@ PropertiesMain.propTypes = {
 		containerType: PropTypes.string,
 		enableResize: PropTypes.bool,
 		conditionReturnValueHandling: PropTypes.string,
+		subtitle: PropTypes.bool,
 		buttonLabels: PropTypes.shape({
 			primary: PropTypes.string,
 			secondary: PropTypes.string

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -386,6 +386,7 @@ class PropertiesMain extends React.Component {
 					help={formData.help}
 					controller={this.propertiesController}
 					helpClickHandler={this.props.callbacks.helpClickHandler}
+					uihints={this.props.propertiesInfo.uihints}
 				/>);
 				buttonsContainer = (<PropertiesButtons
 					okHandler={this.applyPropertiesEditing.bind(this, true)}

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.scss
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.scss
@@ -68,7 +68,10 @@
 
 
 .properties-right-flyout > .properties-custom-container {
-	height: calc(100% - 106px);
+	height: calc(100% - 136px);
 	overflow-y: auto;
 	transform: translateZ(0); // https://github.com/elyra-ai/canvas/issues/160
+	&.properties-custom-container-with-heading {
+		height: calc(100% - 160px);
+	}
 }

--- a/canvas_modules/harness/cypress/integration/canvas/tips.js
+++ b/canvas_modules/harness/cypress/integration/canvas/tips.js
@@ -161,10 +161,10 @@ describe("Test tip location adjusted based on boundaries of browser", function()
 	});
 
 	it("Test tip location adjusted based on boundaries of browser", function() {
-		cy.moveMouseToCoordinatesInCommonProperties(75, 80);
+		cy.moveMouseToCoordinatesInCommonProperties(75, 110);
 		cy.verifyTipForLabelIsVisibleAtLocation("Mode", "top", "Include or discard rows");
 
-		cy.moveMouseToCoordinatesInCommonProperties(255, 135);
+		cy.moveMouseToCoordinatesInCommonProperties(255, 170);
 		cy.verifyTipForLabelIsVisibleAtLocation(
 			"Modeler CLEM Condition Expression", "top", "Enter a boolean expression to use for filtering rows"
 		);

--- a/canvas_modules/harness/src/client/App.js
+++ b/canvas_modules/harness/src/client/App.js
@@ -205,7 +205,7 @@ class App extends React.Component {
 			applyOnBlur: true,
 			expressionBuilder: true,
 			expressionValidate: true,
-			subtitle: false,
+			heading: false,
 
 			apiSelectedOperation: "",
 			selectedPropertiesDropdownFile: "",
@@ -275,7 +275,7 @@ class App extends React.Component {
 		this.useExpressionBuilder = this.useExpressionBuilder.bind(this);
 		this.useExpressionValidate = this.useExpressionValidate.bind(this);
 		this.useDisplayAdditionalComponents = this.useDisplayAdditionalComponents.bind(this);
-		this.useSubtitle = this.useSubtitle.bind(this);
+		this.useHeading = this.useHeading.bind(this);
 
 		this.clearSavedZoomValues = this.clearSavedZoomValues.bind(this);
 		this.usePropertiesContainerType = this.usePropertiesContainerType.bind(this);
@@ -1033,9 +1033,9 @@ class App extends React.Component {
 		this.log("set properties container", type);
 	}
 
-	useSubtitle(enabled) {
-		this.setState({ subtitle: enabled });
-		this.log("show subtitle", enabled);
+	useHeading(enabled) {
+		this.setState({ heading: enabled });
+		this.log("show heading", enabled);
 	}
 
 	// common-canvas
@@ -1323,8 +1323,7 @@ class App extends React.Component {
 			formData: properties.formData,
 			parameterDef: properties,
 			additionalComponents: additionalComponents,
-			expressionInfo: expressionInfo,
-			uihints: properties.uihints
+			expressionInfo: expressionInfo
 		};
 
 		this.setState({ showPropertiesDialog: true, propertiesInfo: propsInfo });
@@ -1842,7 +1841,7 @@ class App extends React.Component {
 			containerType: this.state.propertiesContainerType === PROPERTIES_FLYOUT ? CUSTOM : this.state.propertiesContainerType,
 			rightFlyout: this.state.propertiesContainerType === PROPERTIES_FLYOUT,
 			applyOnBlur: this.state.applyOnBlur,
-			subtitle: this.state.subtitle
+			heading: this.state.heading
 		};
 		const callbacks = {
 			controllerHandler: this.propertiesControllerHandler,
@@ -2052,8 +2051,8 @@ class App extends React.Component {
 			useExpressionValidate: this.useExpressionValidate,
 			displayAdditionalComponents: this.state.displayAdditionalComponents,
 			useDisplayAdditionalComponents: this.useDisplayAdditionalComponents,
-			subtitle: this.state.subtitle,
-			useSubtitle: this.useSubtitle,
+			heading: this.state.heading,
+			useHeading: this.useHeading,
 			selectedPropertiesDropdownFile: this.state.selectedPropertiesDropdownFile,
 			selectedPropertiesFileCategory: this.state.selectedPropertiesFileCategory,
 			fileChooserVisible: this.state.propertiesFileChooserVisible,

--- a/canvas_modules/harness/src/client/App.js
+++ b/canvas_modules/harness/src/client/App.js
@@ -205,6 +205,7 @@ class App extends React.Component {
 			applyOnBlur: true,
 			expressionBuilder: true,
 			expressionValidate: true,
+			subtitle: false,
 
 			apiSelectedOperation: "",
 			selectedPropertiesDropdownFile: "",
@@ -274,6 +275,7 @@ class App extends React.Component {
 		this.useExpressionBuilder = this.useExpressionBuilder.bind(this);
 		this.useExpressionValidate = this.useExpressionValidate.bind(this);
 		this.useDisplayAdditionalComponents = this.useDisplayAdditionalComponents.bind(this);
+		this.useSubtitle = this.useSubtitle.bind(this);
 
 		this.clearSavedZoomValues = this.clearSavedZoomValues.bind(this);
 		this.usePropertiesContainerType = this.usePropertiesContainerType.bind(this);
@@ -1029,6 +1031,11 @@ class App extends React.Component {
 	usePropertiesContainerType(type) {
 		this.setState({ propertiesContainerType: type });
 		this.log("set properties container", type);
+	}
+
+	useSubtitle(enabled) {
+		this.setState({ subtitle: enabled });
+		this.log("show subtitle", enabled);
 	}
 
 	// common-canvas
@@ -1834,7 +1841,8 @@ class App extends React.Component {
 		const propertiesConfig = {
 			containerType: this.state.propertiesContainerType === PROPERTIES_FLYOUT ? CUSTOM : this.state.propertiesContainerType,
 			rightFlyout: this.state.propertiesContainerType === PROPERTIES_FLYOUT,
-			applyOnBlur: this.state.applyOnBlur
+			applyOnBlur: this.state.applyOnBlur,
+			subtitle: this.state.subtitle
 		};
 		const callbacks = {
 			controllerHandler: this.propertiesControllerHandler,
@@ -2044,6 +2052,8 @@ class App extends React.Component {
 			useExpressionValidate: this.useExpressionValidate,
 			displayAdditionalComponents: this.state.displayAdditionalComponents,
 			useDisplayAdditionalComponents: this.useDisplayAdditionalComponents,
+			subtitle: this.state.subtitle,
+			useSubtitle: this.useSubtitle,
 			selectedPropertiesDropdownFile: this.state.selectedPropertiesDropdownFile,
 			selectedPropertiesFileCategory: this.state.selectedPropertiesFileCategory,
 			fileChooserVisible: this.state.propertiesFileChooserVisible,

--- a/canvas_modules/harness/src/client/App.js
+++ b/canvas_modules/harness/src/client/App.js
@@ -1316,7 +1316,8 @@ class App extends React.Component {
 			formData: properties.formData,
 			parameterDef: properties,
 			additionalComponents: additionalComponents,
-			expressionInfo: expressionInfo
+			expressionInfo: expressionInfo,
+			uihints: properties.uihints
 		};
 
 		this.setState({ showPropertiesDialog: true, propertiesInfo: propsInfo });

--- a/canvas_modules/harness/src/client/components/sidepanel-properties.jsx
+++ b/canvas_modules/harness/src/client/components/sidepanel-properties.jsx
@@ -51,6 +51,7 @@ export default class SidePanelModal extends React.Component {
 		this.useExpressionBuilder = this.useExpressionBuilder.bind(this);
 		this.useExpressionValidate = this.useExpressionValidate.bind(this);
 		this.useDisplayAdditionalComponents = this.useDisplayAdditionalComponents.bind(this);
+		this.useSubtitle = this.useSubtitle.bind(this);
 		this.getSelectedFile = this.getSelectedFile.bind(this);
 	}
 	// should be changed to componentDidMount but causes FVT tests to fail
@@ -155,6 +156,9 @@ export default class SidePanelModal extends React.Component {
 
 	useExpressionValidate(checked) {
 		this.props.propertiesConfig.useExpressionValidate(checked);
+	}
+	useSubtitle(checked) {
+		this.props.propertiesConfig.useSubtitle(checked);
 	}
 
 	dropdownOptions() {
@@ -300,6 +304,17 @@ export default class SidePanelModal extends React.Component {
 			</div>
 		);
 
+		const subtitle = (
+			<div className="harness-sidepanel-children" id="sidepanel-properties-show-subtitle">
+				<Toggle
+					id="harness-sidepanel-show-subtitle-toggle"
+					labelText="Show panel subtitle (icon and label)"
+					toggled={ this.props.propertiesConfig.subtitle }
+					onToggle={ this.useSubtitle }
+				/>
+			</div>
+		);
+
 		const divider = (<div className="harness-sidepanel-children harness-sidepanel-divider" />);
 		return (
 			<div>
@@ -316,6 +331,8 @@ export default class SidePanelModal extends React.Component {
 				{expressionValidate}
 				{divider}
 				{addtlCmpts}
+				{divider}
+				{subtitle}
 			</div>
 		);
 	}
@@ -343,6 +360,8 @@ SidePanelModal.propTypes = {
 		selectedPropertiesDropdownFile: PropTypes.string,
 		selectedPropertiesFileCategory: PropTypes.string,
 		fileChooserVisible: PropTypes.bool,
-		setPropertiesDropdownSelect: PropTypes.func
+		setPropertiesDropdownSelect: PropTypes.func,
+		subtitle: PropTypes.bool,
+		useSubtitle: PropTypes.func
 	})
 };

--- a/canvas_modules/harness/src/client/components/sidepanel-properties.jsx
+++ b/canvas_modules/harness/src/client/components/sidepanel-properties.jsx
@@ -51,7 +51,7 @@ export default class SidePanelModal extends React.Component {
 		this.useExpressionBuilder = this.useExpressionBuilder.bind(this);
 		this.useExpressionValidate = this.useExpressionValidate.bind(this);
 		this.useDisplayAdditionalComponents = this.useDisplayAdditionalComponents.bind(this);
-		this.useSubtitle = this.useSubtitle.bind(this);
+		this.useHeading = this.useHeading.bind(this);
 		this.getSelectedFile = this.getSelectedFile.bind(this);
 	}
 	// should be changed to componentDidMount but causes FVT tests to fail
@@ -157,8 +157,8 @@ export default class SidePanelModal extends React.Component {
 	useExpressionValidate(checked) {
 		this.props.propertiesConfig.useExpressionValidate(checked);
 	}
-	useSubtitle(checked) {
-		this.props.propertiesConfig.useSubtitle(checked);
+	useHeading(checked) {
+		this.props.propertiesConfig.useHeading(checked);
 	}
 
 	dropdownOptions() {
@@ -304,13 +304,13 @@ export default class SidePanelModal extends React.Component {
 			</div>
 		);
 
-		const subtitle = (
-			<div className="harness-sidepanel-children" id="sidepanel-properties-show-subtitle">
+		const useHeading = (
+			<div className="harness-sidepanel-children" id="sidepanel-properties-show-heading">
 				<Toggle
-					id="harness-sidepanel-show-subtitle-toggle"
-					labelText="Show panel subtitle (icon and label)"
-					toggled={ this.props.propertiesConfig.subtitle }
-					onToggle={ this.useSubtitle }
+					id="harness-sidepanel-show-heading-toggle"
+					labelText="Show panel heading (icon and label)"
+					toggled={ this.props.propertiesConfig.heading }
+					onToggle={ this.useHeading }
 				/>
 			</div>
 		);
@@ -332,7 +332,7 @@ export default class SidePanelModal extends React.Component {
 				{divider}
 				{addtlCmpts}
 				{divider}
-				{subtitle}
+				{useHeading}
 			</div>
 		);
 	}
@@ -361,7 +361,7 @@ SidePanelModal.propTypes = {
 		selectedPropertiesFileCategory: PropTypes.string,
 		fileChooserVisible: PropTypes.bool,
 		setPropertiesDropdownSelect: PropTypes.func,
-		subtitle: PropTypes.bool,
-		useSubtitle: PropTypes.func
+		heading: PropTypes.bool,
+		useHeading: PropTypes.func
 	})
 };

--- a/canvas_modules/harness/test_resources/parameterDefs/Conditions_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/Conditions_paramDef.json
@@ -595,7 +595,7 @@
   ],
   "uihints": {
     "id": "Conditions.test",
-    "icon": "images/modelbuildspark.svg",
+    "icon": "images/nodes/model.svg",
     "label": {
       "default": "Conditions Test"
     },

--- a/canvas_modules/harness/test_resources/parameterDefs/Filter_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/Filter_paramDef.json
@@ -75,7 +75,10 @@
   ],
   "uihints": {
     "id": "filter",
-    "icon": "images/filter.svg",
+    "icon": "images/common_node_icons/operations/operation_filter.svg",
+    "label": {
+      "default": "Filter Test"
+    },
     "editor_size": "medium",
     "complex_type_info": [
       {

--- a/canvas_modules/harness/test_resources/parameterDefs/Spark_SelectColumns_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/Spark_SelectColumns_paramDef.json
@@ -25,7 +25,10 @@
   ],
   "uihints": {
     "id": "org.ibm.spark.ibm.transformers.selectcolumns",
-    "icon": "./select.svg",
+    "icon": "images/common_node_icons/operations/operation_select.svg",
+    "label": {
+      "default": "Spark Select Columns Test"
+    },
     "ui_parameters": [
       {
         "id": "uiOnlyField1",

--- a/canvas_modules/harness/test_resources/parameterDefs/empty_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/empty_paramDef.json
@@ -6,7 +6,11 @@
     "id": "default",
     "icon": "images/nodes/derive.svg",
     "label": {
-      "default": "Empty parameter definition"
+      "default": "Empty parameter definition",
+      "resource_key": "emptyDefinition.uihints.label"
     }
+  },
+  "resources": {
+    "emptyDefinition.uihints.label": "Empty Definition Label"
   }
 }

--- a/canvas_modules/harness/test_resources/parameterDefs/empty_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/empty_paramDef.json
@@ -8,7 +8,8 @@
     "label": {
       "default": "Empty parameter definition",
       "resource_key": "emptyDefinition.uihints.label"
-    }
+    },
+    "help": {}
   },
   "resources": {
     "emptyDefinition.uihints.label": "Empty Definition Label"

--- a/canvas_modules/harness/test_resources/parameterDefs/empty_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/empty_paramDef.json
@@ -4,7 +4,7 @@
   },
   "uihints": {
     "id": "default",
-    "icon": "images/default.svg",
+    "icon": "images/nodes/derive.svg",
     "label": {
       "default": "Empty parameter definition"
     }


### PR DESCRIPTION
Addresses https://github.com/elyra-ai/canvas/issues/419

An option in the common properties config panel has been added to display the subtitle, and `empty_paramDef.json` has been updated to show a working demo of an icon in the subtitle.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

