### PR TITLE
#528 Wide labels with closely positiond nodes doesn't display edit icon

### DIFF
--- a/canvas_modules/common-canvas/src/common-canvas/svg-canvas-d3.scss
+++ b/canvas_modules/common-canvas/src/common-canvas/svg-canvas-d3.scss
@@ -247,7 +247,7 @@ $new-halo-link-color: $ui-05;
 	padding: 0; // Makes padding consistent for div and text area (overrides default 2px padding for text areas)
 	width: 100%;
 	height: 100%;
-	pointer-events: auto; /* Override the pointer-events: none on the foreignObject container */
+	pointer-events: none;
 	overflow: hidden;
 	line-height: 105%;  /* Set so that entry text is displayed the same as display text */
 	letter-spacing: 0.16px; /* Keeps letter spacing the same as before changing labels to use foreignObject */
@@ -257,6 +257,10 @@ $new-halo-link-color: $ui-05;
 .d3-node-label {
 	@include d3-node-label-mixin;
 	border-width: $node-label-display-border;
+
+	& span {
+		pointer-events: auto; /* Override the pointer-events: none on the foreignObject and div */
+	}
 }
 
 /* Style for node label text entry when shown in an HTML textarea control. */

--- a/canvas_modules/harness/cypress/support/canvas/node-cmds.js
+++ b/canvas_modules/harness/cypress/support/canvas/node-cmds.js
@@ -37,7 +37,7 @@ Cypress.Commands.add("getNodeIdForLabel", (nodeLabel) =>
 
 Cypress.Commands.add("doubleClickLabelOnNode", (nodeLabel) => {
 	cy.getNodeWithLabel(nodeLabel)
-		.find("foreignObject > div")
+		.find("foreignObject > div > span")
 		.dblclick();
 });
 
@@ -191,7 +191,7 @@ Cypress.Commands.add("hoverOverNode", (nodeName) => {
 
 Cypress.Commands.add("hoverOverNodeLabel", (nodeName) => {
 	cy.getNodeWithLabel(nodeName)
-		.find(".d3-node-label")
+		.find(".d3-node-label > span")
 		.trigger("mouseenter");
 });
 


### PR DESCRIPTION
Fixes: #528 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

