### PR TITLE
#599 Table rows and headers are 32px tall and table title in Text panel style

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/selectcolumns-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/selectcolumns-test.js
@@ -393,7 +393,7 @@ describe("selectcolumns control displays the proper number of rows", () => {
 		const heightDiv = columnSelect.find("div.properties-ft-container-wrapper");
 		const heightStyle = heightDiv.at(0).prop("style");
 		// console.log("STYLE: " + JSON.stringify(heightStyle));
-		expect(heightStyle).to.eql({ "height": "12em" }); // includes header
+		expect(heightStyle).to.eql({ "height": "9.25em" }); // includes header
 	});
 
 	it("should display 5 rows in select columns in subpanel", () => {
@@ -413,7 +413,7 @@ describe("selectcolumns control displays the proper number of rows", () => {
 		const heightDiv = selectColumnsWrapper.find("div.properties-ft-container-wrapper");
 		const heightStyle = heightDiv.prop("style");
 		// console.log("STYLE: " + JSON.stringify(heightStyle));
-		expect(heightStyle).to.eql({ "height": "18em" }); // includes header
+		expect(heightStyle).to.eql({ "height": "13.75em" }); // includes header
 	});
 });
 

--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/structuretable-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/structuretable-test.js
@@ -815,10 +815,10 @@ describe("structuretable multiselect edit works", () => {
 		selectedEditRow = wrapper.find("div.properties-at-selectedEditRows").find(".properties-vt-row-checkbox");
 		expect(selectedEditRow).to.have.length(1);
 
-		// verify the select header row is 3em in height
+		// verify the select header row is 2.5em in height
 		const selectHeaderTable = wrapper.find("div.properties-at-selectedEditRows").find("div.properties-ft-container-wrapper");
 		const heightStyle = selectHeaderTable.prop("style");
-		expect(heightStyle).to.eql({ "height": "3em" });
+		expect(heightStyle).to.eql({ "height": "2.5em" });
 	});
 });
 

--- a/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.jsx
@@ -86,7 +86,7 @@ class ControlItem extends React.Component {
 				</Button>);
 			}
 			label = (
-				<div className="properties-label-container">
+				<div className={classNames("properties-label-container", { "table-control": this.props.tableControl === true })}>
 					<label className="properties-control-label">{this.props.control.label.text}</label>
 					{requiredIndicator}
 					{numberGenerator}
@@ -133,6 +133,7 @@ ControlItem.propTypes = {
 	controller: PropTypes.object.isRequired,
 	controlObj: PropTypes.object,
 	accessibleControls: PropTypes.array, // TODO: Remove this after all controls are accessible
+	tableControl: PropTypes.bool,
 	state: PropTypes.string // passed by redux
 };
 

--- a/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.scss
@@ -42,6 +42,12 @@
 			text-decoration: underline;
 		}
 	}
+	&.table-control {
+		label, .properties-required-indicator {
+			@include carbon--type-style("productive-heading-01");
+			color: $text-01;
+		}
+	}
 }
 
 .properties-label-container, .properties-summary-link-container {

--- a/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
@@ -241,8 +241,8 @@ export default class FlexibleTable extends React.Component {
 			return;
 		}
 		let newHeight = this.state.tableHeight;
-		const rowHeight = 3; // in em
-		const headerHeight = 3; // in em
+		const rowHeight = 2.25; // in em
+		const headerHeight = 2.5; // in em
 		const rows = typeof this.props.rows !== "undefined" ? this.props.rows : 4;
 		if (rows > 0) {
 			newHeight = (rowHeight * rows + headerHeight);

--- a/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
@@ -353,12 +353,12 @@ class VirtualizedTable extends React.Component {
 
 								disableHeader={this.props.disableHeader}
 								headerClassName="properties-autosized-vt-header"
-								headerHeight={40}
+								headerHeight={32}
 								headerRowRenderer={this.headerRowRenderer.bind(this, this.props.scrollKey)}
 								onHeaderClick={this.props.onHeaderClick}
 
 								rowClassName="properties-vt-row-class"
-								rowHeight={this.props.rowHeight ? this.props.rowHeight : 40}
+								rowHeight={this.props.rowHeight ? this.props.rowHeight : 32}
 
 								rowCount={this.state.rowCount}
 								rowGetter={this.props.rowGetter}

--- a/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.scss
@@ -38,7 +38,7 @@ $properties-vt-checkbox-width: 45px;
 	}
 
 	.properties-vt-header-checkbox {
-		height: 40px;
+		height: $spacing-07;
 		display: flex;
 		align-items: center;
 		flex: 0 1 $properties-vt-checkbox-width;
@@ -69,7 +69,7 @@ $properties-vt-checkbox-width: 45px;
 	}
 
 	.properties-vt-row-checkbox {
-		height: 32px;
+		height: $spacing-07;
 		margin-left: $spacing-05;
 		flex: 0 1 $properties-vt-checkbox-width;
 	}

--- a/canvas_modules/common-canvas/src/common-properties/constants/constants.js
+++ b/canvas_modules/common-canvas/src/common-properties/constants/constants.js
@@ -189,7 +189,7 @@ _defineConstant("ACTIONS", {
 
 _defineConstant("DEFAULT_LABEL_EDITABLE", true);
 
-_defineConstant("ROW_HEIGHT", 42);
+_defineConstant("ROW_HEIGHT", 32);
 
 _defineConstant("EXPRESSION_TABLE_ROWS", 7);
 

--- a/canvas_modules/common-canvas/src/common-properties/controls/control-factory.js
+++ b/canvas_modules/common-canvas/src/common-properties/controls/control-factory.js
@@ -77,6 +77,15 @@ const accessibleControls = [
 	ControlType.SELECTCOLUMN
 ];
 
+const tableControls = [
+	ControlType.LIST,
+	ControlType.READONLYTABLE,
+	ControlType.SOMEOFSELECT,
+	ControlType.SELECTCOLUMNS,
+	ControlType.STRUCTURETABLE,
+	ControlType.STRUCTURELISTEDITOR
+];
+
 export default class ControlFactory {
 
 	constructor(controller) {
@@ -123,6 +132,7 @@ export default class ControlFactory {
 					control={control}
 					controlObj={controlObj}
 					accessibleControls={accessibleControls}
+					tableControl = {tableControls.includes(control.controlType)}
 				/>
 			</div>);
 	}
@@ -147,6 +157,7 @@ export default class ControlFactory {
 				propertyId={propertyId}
 				control={control}
 				accessibleControls={accessibleControls}
+				tableControl = {tableControls.includes(control.controlType)}
 			/>
 		);
 		if (tableInfo) {


### PR DESCRIPTION
Fixes: https://github.com/elyra-ai/canvas/issues/599

Showing Text panel style label for following controls -
- List
- Readonlytable
- Structurelisteditor
- Structuretable
- Selectcolumns
- Someofselect

No change in label for other controls.

![Screen Shot 2021-03-26 at 4 13 38 PM](https://user-images.githubusercontent.com/25124000/112701728-a8789480-8e4e-11eb-8c95-4d9992fdbb8b.png)

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

