### PR TITLE
#608 When table is empty, show customizable text and Add button

### DIFF
--- a/canvas_modules/common-canvas/__tests__/_utils_/table-utils.js
+++ b/canvas_modules/common-canvas/__tests__/_utils_/table-utils.js
@@ -24,6 +24,14 @@ function openFieldPicker(wrapper, dataIdName) {
 	return wrapper.find("div.properties-fp-table");
 }
 
+// When table has 0 rows, click on Add columns button to open FieldPicker
+function openFieldPickerForEmptyTable(wrapper, dataIdName) {
+	const tableWrapper = wrapper.find("div[data-id=\"" + dataIdName + "\"]");
+	const emptyTableButton = tableWrapper.find("button.properties-empty-table-button");
+	emptyTableButton.simulate("click"); // open field picker
+	return wrapper.find("div.properties-fp-table");
+}
+
 // expectedFields is optional
 // fieldsToSelect is an array of field names or objects with name and schema. ex: { "name": "age", "schema": "schema1" }
 function fieldPicker(fieldpickerWrapper, fieldsToSelect, expectedFields) {
@@ -196,6 +204,7 @@ function validateSelectedRowNum(wrapper) {
 
 module.exports = {
 	openFieldPicker: openFieldPicker,
+	openFieldPickerForEmptyTable: openFieldPickerForEmptyTable,
 	fieldPicker: fieldPicker,
 	verifyFieldPickerRow: verifyFieldPickerRow,
 	getTableHeaderRows: getTableHeaderRows,

--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/list-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/list-test.js
@@ -58,6 +58,22 @@ const controlInteger = {
 	}
 };
 
+const controlEmpty = {
+	"name": "test-list-empty",
+	"label": {
+		"text": "test empty list"
+	},
+	"description": {
+		"text": "list control description"
+	},
+	"controlType": "list",
+	"valueDef": {
+		"isList": true,
+		"isMap": false,
+		"propType": "string"
+	}
+};
+
 const listStringCurrentValues = ["list item 1", ""];
 const listIntegerCurrentValues = [10, null];
 
@@ -65,6 +81,7 @@ const listLongStringCurrentValues = [propertyUtils.genLongString(TRUNCATE_LIMIT 
 
 const listStringPopertyId = { name: "test-list-string" };
 const listIntegerPopertyId = { name: "test-list-integer" };
+const listEmptyPopertyId = { name: "test-list-empty" };
 
 describe("list renders correctly for array[string]", () => {
 	const controller = new Controller();
@@ -231,6 +248,27 @@ describe("list renders correctly for array[string]", () => {
 		const rowsSelected = validateSelectedRowNum(rows);
 		expect(rowsSelected).to.have.length(1);
 	});
+
+	it("should render empty table content when list is empty", () => {
+		const renderedObject = propertyUtils.flyoutEditorForm(listParamDef);
+		const wrapper = mountWithIntl(
+			<Provider store={controller.getStore()}>
+				<List
+					store={controller.getStore()}
+					control={controlEmpty}
+					controller={renderedObject.controller}
+					propertyId={listEmptyPopertyId}
+				/>
+			</Provider>
+		);
+
+		// Verify empty table content is rendered
+		expect(wrapper.find("div.properties-empty-table")).to.have.length(1);
+		expect(wrapper.find("div.properties-empty-table span")
+			.text()).to.be.equal("To begin, click \"Add value\"");
+		expect(wrapper.find("button.properties-empty-table-button")).to.have.length(1);
+		expect(wrapper.find("button.properties-empty-table-button").text()).to.be.equal("Add value");
+	});
 });
 
 describe("list renders correctly for array[integer]", () => {
@@ -376,10 +414,16 @@ describe("list renders correctly as a nested control", () => {
 			.find("div[data-id='properties-ctrl-complexListStructurelisteditor_list']");
 		expect(onPanelList).to.have.length(1);
 
+		// select Add value button in empty nested list - this adds 1 row in the list
+		let emptyTableButton = onPanelList.find("button.properties-empty-table-button");
+		expect(emptyTableButton).to.have.length(1);
+		emptyTableButton.simulate("click");
+
+		wrapper.update();
+		onPanelList = wrapper.find("div[data-id='properties-ctrl-complexListStructurelisteditor_list']");
 		// select the add column button in nested list
 		let addColumnButton = onPanelList.find("button.properties-add-fields-button");
 		expect(addColumnButton).to.have.length(1);
-		addColumnButton.simulate("click");
 		addColumnButton.simulate("click");
 
 		// The table content should increase by 2
@@ -432,10 +476,12 @@ describe("list renders correctly as a nested control", () => {
 			.find("div[data-id='properties-ctrl-complexListStructurelisteditor_list']");
 		expect(onPanelList).to.have.length(1);
 
-		// select the add column button in nested list
-		addColumnButton = onPanelList.find("button.properties-add-fields-button");
-		expect(addColumnButton).to.have.length(1);
-		addColumnButton.simulate("click");
+		// select Add value button in empty nested list - this adds 1 row in the list
+		emptyTableButton = onPanelList.find("button.properties-empty-table-button");
+		expect(emptyTableButton).to.have.length(1);
+		emptyTableButton.simulate("click");
+
+		wrapper.update();
 
 		// edit nested list row index 0
 		summaryPanel = propertyUtils.openSummaryPanel(wrapper, "nested-list-summary-panel");
@@ -463,10 +509,16 @@ describe("list renders correctly as a nested control", () => {
 
 		// subPanel table
 		let subPanelTable = wrapper.find("div[data-id='properties-complexListStructuretables']");
-		// select the add column button in nested list
-		let addColumnButton = subPanelTable.find("button.properties-add-fields-button");
+		// select Add value button in empty nested list - this adds 1 row in the list
+		let emptyTableButton = subPanelTable.find("button.properties-empty-table-button");
+		expect(emptyTableButton).to.have.length(1);
+		emptyTableButton.simulate("click");
+
+		wrapper.update();
+		subPanelTable = wrapper.find("div[data-id='properties-complexListStructuretables']");
+		// select the add value button in nested list
+		const addColumnButton = subPanelTable.find("button.properties-add-fields-button");
 		expect(addColumnButton).to.have.length(1);
-		addColumnButton.simulate("click");
 		addColumnButton.simulate("click");
 
 		// The table content should increase by 2
@@ -499,10 +551,12 @@ describe("list renders correctly as a nested control", () => {
 
 		// subPanel table of second row
 		subPanelTable = wrapper.find("div[data-id='properties-complexListStructuretables']").at(1);
-		// select the add column button in nested list
-		addColumnButton = subPanelTable.find("button.properties-add-fields-button");
-		expect(addColumnButton).to.have.length(1);
-		addColumnButton.simulate("click");
+		// select Add value button in empty nested list - this adds 1 row in the list
+		emptyTableButton = subPanelTable.find("button.properties-empty-table-button");
+		expect(emptyTableButton).to.have.length(1);
+		emptyTableButton.simulate("click");
+
+		wrapper.update();
 
 		tableData = renderedController.getPropertyValue(propertyId);
 		expected = [["Cholesterol", 5, "Ascending", ["new value list 0", "new value list 1"]], ["Na", 6, "Ascending", [""]]];

--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/readonlytable-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/readonlytable-test.js
@@ -110,12 +110,14 @@ describe("readonlytable control renders correctly", () => {
 		expect(wrapper.dive().prop("buildUIItem")).to.equal(genUIItem);
 	});
 
-	it("should render a `readonlytable` control without edit button", () => {
+	it("should render empty table content for `readonlytable` control", () => {
+		// We need getReactIntl() in the controller which will set the empty table text
+		const renderedObject = propertyUtils.flyoutEditorForm(readonlyTableParamDef);
 		const wrapper = mountWithIntl(
 			<Provider store={controller.getStore()}>
 				<ReadonlyTableControl
 					control={control}
-					controller={controller}
+					controller={renderedObject.controller}
 					propertyId={propertyId}
 					buildUIItem={genUIItem}
 					rightFlyout
@@ -124,15 +126,12 @@ describe("readonlytable control renders correctly", () => {
 		);
 
 		expect(wrapper.find("div[data-id='properties-keys']")).to.have.length(1);
-		// should have a search bar
-		expect(wrapper.find("div.properties-ft-search-container")).to.have.length(1);
-		// should not have abstract table buttons
-		const buttons = wrapper.find(".properties-at-buttons-container");
-		expect(buttons).to.have.length(0);
-		// should have moveable table rows
-		const moveableRowsContainer = wrapper.find(".properties-mr-button-container");
-		expect(moveableRowsContainer).to.have.length(1);
-		expect(moveableRowsContainer.find("button.table-row-move-button[disabled=true]")).to.have.length(4);
+		// Verify empty table content is rendered
+		expect(wrapper.find("div.properties-empty-table")).to.have.length(1);
+		expect(wrapper.find("div.properties-empty-table span")
+			.text()).to.be.equal("To begin, click \"Edit\"");
+		expect(wrapper.find("button.properties-empty-table-button")).to.have.length(1);
+		expect(wrapper.find("button.properties-empty-table-button").text()).to.be.equal("Edit");
 	});
 
 	let wrapper;

--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/selectcolumns-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/selectcolumns-test.js
@@ -196,6 +196,19 @@ describe("selectcolumns renders correctly", () => {
 		const selectColumnsTable = wrapper.find(".properties-vt-autosizer").find(".ReactVirtualized__Table");
 		expect(selectColumnsTable.props()).to.have.property("aria-label", control.label.text);
 	});
+
+	it("should render empty table content when selectcolumns is empty", () => {
+		const renderedObject = propertyUtils.flyoutEditorForm(selectcolumnsParamDef);
+		const wrapper = renderedObject.wrapper;
+
+		const emptyFields = wrapper.find("div[data-id='properties-ctrl-fields_empty']");
+		// Verify empty table content is rendered
+		expect(emptyFields.find("div.properties-empty-table")).to.have.length(1);
+		expect(emptyFields.find("div.properties-empty-table span")
+			.text()).to.be.equal("To begin, click \"Add columns\"");
+		expect(emptyFields.find("button.properties-empty-table-button")).to.have.length(1);
+		expect(emptyFields.find("button.properties-empty-table-button").text()).to.be.equal("Add columns");
+	});
 });
 
 
@@ -211,11 +224,11 @@ describe("selectcolumns control filters values correctly", () => {
 	});
 
 	it("should filter type value from selectcolumn control", () => {
-		const fieldPicker = tableUtils.openFieldPicker(wrapper, "properties-ft-fields_filter_type");
+		const fieldPicker = tableUtils.openFieldPickerForEmptyTable(wrapper, "properties-ctrl-fields_filter_type");
 		tableUtils.fieldPicker(fieldPicker, ["age"], ["age", "age2", "age3", "age4"]);
 	});
 	it("should filter role values from selectcolumn control", () => {
-		const fieldPicker = tableUtils.openFieldPicker(wrapper, "properties-fields_filter_roles");
+		const fieldPicker = tableUtils.openFieldPickerForEmptyTable(wrapper, "properties-fields_filter_roles");
 		tableUtils.fieldPicker(fieldPicker, [], ["age", "drug", "age2", "drug2", "age3", "drug3", "age4", "drug4"]);
 	});
 
@@ -282,7 +295,7 @@ describe("selectcolumns with multi input schemas renders correctly", () => {
 
 	it("should filter by type in selectcolumns control", () => {
 		// open the "filter by type" select columns field picker
-		const fieldPicker = tableUtils.openFieldPicker(wrapper, "properties-ft-fields_filter_type");
+		const fieldPicker = tableUtils.openFieldPickerForEmptyTable(wrapper, "properties-ctrl-fields_filter_type");
 		const fieldTable = [
 			{ "name": "age", "schema": "Schema-1" },
 			{ "name": "AGE", "schema": "Schema-1" },
@@ -297,7 +310,7 @@ describe("selectcolumns with multi input schemas renders correctly", () => {
 
 	it("should filter by types in selectcolumns control", () => {
 		// open the "filter by types" select columns field picker
-		const fieldPicker = tableUtils.openFieldPicker(wrapper, "properties-ft-fields_filter_types");
+		const fieldPicker = tableUtils.openFieldPickerForEmptyTable(wrapper, "properties-ctrl-fields_filter_types");
 		const fieldTable = [
 			{ "name": "age", "schema": "Schema-1" },
 			{ "name": "AGE", "schema": "Schema-1" },
@@ -316,8 +329,8 @@ describe("selectcolumns with multi input schemas renders correctly", () => {
 
 
 	it("should filter by measurement in selectcolumns control", () => {
-		// open the "filter by types" select columns field picker
-		const fieldPicker = tableUtils.openFieldPicker(wrapper, "properties-ft-fields_filter_measurement");
+		// open the "filter by measurement" select columns field picker
+		const fieldPicker = tableUtils.openFieldPickerForEmptyTable(wrapper, "properties-ctrl-fields_filter_measurement");
 		const fieldTable = [
 			{ "name": "BP", "schema": "Schema-1" },
 			{ "name": "BP2", "schema": "Schema-1" },
@@ -329,7 +342,7 @@ describe("selectcolumns with multi input schemas renders correctly", () => {
 	});
 
 	it("should filter by measurements in selectcolumns control", () => {
-		const fieldPicker = tableUtils.openFieldPicker(wrapper, "properties-ft-fields_filter_measurements");
+		const fieldPicker = tableUtils.openFieldPickerForEmptyTable(wrapper, "properties-ctrl-fields_filter_measurements");
 		const fieldTable = [
 			{ "name": "BP", "schema": "Schema-1" },
 			{ "name": "drug", "schema": "Schema-1" },
@@ -346,7 +359,7 @@ describe("selectcolumns with multi input schemas renders correctly", () => {
 	});
 
 	it("should filter by type and measurement in selectcolumns control", () => {
-		const fieldPicker = tableUtils.openFieldPicker(wrapper, "properties-ft-fields_filter_and");
+		const fieldPicker = tableUtils.openFieldPickerForEmptyTable(wrapper, "properties-ctrl-fields_filter_and");
 		const fieldTable = [
 			{ "name": "drug", "schema": "Schema-1" },
 			{ "name": "drug2", "schema": "Schema-1" },
@@ -358,7 +371,7 @@ describe("selectcolumns with multi input schemas renders correctly", () => {
 	});
 
 	it("should filter by type or measurement in selectcolumns control", () => {
-		const fieldPicker = tableUtils.openFieldPicker(wrapper, "properties-ft-fields_filter_or");
+		const fieldPicker = tableUtils.openFieldPickerForEmptyTable(wrapper, "properties-ctrl-fields_filter_or");
 		const fieldTable = [
 			{ "name": "drug", "schema": "Schema-1" },
 			{ "name": "drug2", "schema": "Schema-1" },
@@ -401,8 +414,8 @@ describe("selectcolumns control displays the proper number of rows", () => {
 		const summaryPanelWrapper = wrapper.find("div[data-id='properties-structurelist-summary-panel2']");
 		summaryPanelWrapper.find("button").simulate("click");
 		let tableWrapper = wrapper.find("div[data-id='properties-structurelist2']");
-		const addFieldsButtons = tableWrapper.find("button.properties-add-fields-button"); // add row button
-		addFieldsButtons.at(0).simulate("click"); // add row button
+		const emptyTableButton = tableWrapper.find("button.properties-empty-table-button"); // add row button for empty table
+		emptyTableButton.simulate("click"); // add row button
 
 		// open the subpanel for the added row
 		tableWrapper = wrapper.find("div[data-id='properties-structurelist2']");
@@ -436,10 +449,10 @@ describe("selectcolumns control functions correctly in a table", () => {
 		summaryPanelWrapper.find("button").simulate("click");
 
 		// select the add column button
-		let tableWrapper = wrapper.find("div[data-id='properties-ft-structurelist_sub_panel']");
+		let tableWrapper = wrapper.find("div[data-id='properties-ctrl-structurelist_sub_panel']");
 		expect(tableWrapper.length).to.equal(1);
-		const addFieldsButtons = tableWrapper.find("button.properties-add-fields-button"); // add row button
-		addFieldsButtons.at(0).simulate("click"); // add row button
+		const emptyTableButton = tableWrapper.find("button.properties-empty-table-button"); // add row button for empty table
+		emptyTableButton.simulate("click"); // add row button
 
 		// Need to reassign tableWrapper after adding row.
 		tableWrapper = wrapper.find("div[data-id='properties-ft-structurelist_sub_panel']");

--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/structurelisteditor-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/structurelisteditor-test.js
@@ -647,6 +647,33 @@ describe("StructureListEditor render from paramdef", () => {
 		const externalExpectedValues = parameter.default;
 		expect(JSON.stringify(externalCurrentValues)).to.equal(JSON.stringify(externalExpectedValues));
 	});
+
+	it("should render empty table content when StructureListEditor is empty", () => {
+		propertyUtils.openSummaryPanel(wrapper, "structurelisteditorTableInput-summary-panel");
+		wrapper.update();
+		let tableWrapper = wrapper.find("div[data-id='properties-ctrl-structurelisteditorTableInput']");
+		expect(tableWrapper).to.have.length(1);
+
+		// Select all rows in configureTableInput
+		tableWrapper.find(".properties-vt-header-checkbox input").simulate("change", { target: { checked: true } });
+		wrapper.update();
+		tableWrapper = wrapper.find("div[data-id='properties-ctrl-structurelisteditorTableInput']");
+		const rows = tableUtils.getTableRows(tableWrapper);
+		const selectedRows = tableUtils.validateSelectedRowNum(rows);
+		expect(selectedRows.length).to.equal(rows.length);
+
+		// Remove all rows
+		tableWrapper.find("button.properties-remove-fields-button").simulate("click");
+		wrapper.update();
+		tableWrapper = wrapper.find("div[data-id='properties-ctrl-structurelisteditorTableInput']");
+
+		// Verify empty table content is rendered
+		expect(tableWrapper.find("div.properties-empty-table")).to.have.length(1);
+		expect(tableWrapper.find("div.properties-empty-table span")
+			.text()).to.be.equal("To begin, click \"Add value\"");
+		expect(tableWrapper.find("button.properties-empty-table-button")).to.have.length(1);
+		expect(tableWrapper.find("button.properties-empty-table-button").text()).to.be.equal("Add value");
+	});
 });
 
 describe("StructureListEditor renders correctly with nested controls", () => {
@@ -766,12 +793,18 @@ describe("StructureListEditor renders correctly with nested controls", () => {
 		expect(editButtons).to.have.length(2);
 		editButtons.at(1).simulate("click"); // edit the second row
 
-		// subPanel table
-		const subPanelTable = wrapper.find("div[data-id='properties-ft-nestedStructuretableArrayArrays']");
+		// subPanel table - this is an empty table
+		let subPanelTable = wrapper.find("div[data-id='properties-ctrl-nestedStructuretableArrayArrays']");
 		expect(subPanelTable).to.have.length(1);
+		// select Add value button in empty subPanel table - this adds 1 row in the list
+		const emptyTableButton = subPanelTable.find("button.properties-empty-table-button");
+		expect(emptyTableButton).to.have.length(1);
+		emptyTableButton.simulate("click");
+
+		wrapper.update();
+		subPanelTable = wrapper.find("div[data-id='properties-ctrl-nestedStructuretableArrayArrays']");
 		addValueBtn = subPanelTable.find("button.properties-add-fields-button");
 		addValueBtn.simulate("click");
-		addValueBtn.simulate("click"); // add two rows
 
 		// Verify new rows added
 		tableData = renderedController.getPropertyValue(propertyIdNestedStructurelisteditorArrayArray);

--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/structuretable-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/structuretable-test.js
@@ -23,7 +23,6 @@ import sinon from "sinon";
 import propertyUtils from "../../_utils_/property-utils";
 import tableUtils from "./../../_utils_/table-utils";
 import Controller from "../../../src/common-properties/properties-controller";
-import isEqual from "lodash/isEqual";
 
 import structuretableParamDef from "../../test_resources/paramDefs/structuretable_paramDef.json";
 import structuretableMultiInputParamDef from "../../test_resources/paramDefs/structuretable_multiInput_paramDef.json";
@@ -451,27 +450,21 @@ describe("condition renders correctly with structure table control", () => {
 	afterEach(() => {
 		wrapper.unmount();
 	});
-	it("should render a table error message", () => {
+	it("should render empty table content", () => {
 		const conditionsPropertyId = { name: "structuretableReadonlyColumnStartValue" };
 		expect(renderedController.getPropertyValue(conditionsPropertyId)).to.have.length(1);
 		renderedController.updatePropertyValue(conditionsPropertyId, []);
-
-		const structuretableSortOrderErrorMessages = {
-			"validation_id": "structuretableReadonlyColumnStartValue",
-			"type": "error",
-			"text": "table cannot be empty"
-		};
-		const actual = renderedController.getErrorMessage(conditionsPropertyId);
-		expect(isEqual(JSON.parse(JSON.stringify(structuretableSortOrderErrorMessages)),
-			JSON.parse(JSON.stringify(actual)))).to.be.true;
 
 		wrapper.update();
 		propertyUtils.openSummaryPanel(wrapper, "structuretableReadonlyColumnStartValue-summary-panel");
 
 		const tableWrapper = wrapper.find("div[data-id='properties-structuretableReadonlyColumnStartValue']");
-		expect(tableWrapper.find("div.properties-validation-message")).to.have.length(1);
-		expect(tableWrapper.find("div.properties-validation-message span")
-			.text()).to.be.equal(structuretableSortOrderErrorMessages.text);
+		// Verify empty table content is rendered
+		expect(tableWrapper.find("div.properties-empty-table")).to.have.length(1);
+		expect(tableWrapper.find("div.properties-empty-table span")
+			.text()).to.be.equal("To begin, click \"Add columns\"");
+		expect(tableWrapper.find("button.properties-empty-table-button")).to.have.length(1);
+		expect(tableWrapper.find("button.properties-empty-table-button").text()).to.be.equal("Add columns");
 	});
 	it("should render an table cell error", () => {
 		// set error condition on cell

--- a/canvas_modules/common-canvas/__tests__/common-properties/defaults-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/defaults-test.js
@@ -131,7 +131,7 @@ describe("add rows in tables with correct default values", () => {
 		expect(tableRows).to.have.length(0);
 
 		// add a row
-		let fieldPickerWrapper = tableUtils.openFieldPicker(wrapper, "properties-structureTableDefault-default");
+		let fieldPickerWrapper = tableUtils.openFieldPickerForEmptyTable(wrapper, "properties-structureTableDefault-default");
 		tableUtils.fieldPicker(fieldPickerWrapper, ["Age"]);
 		wideflyout = wrapper.find("div[data-id='properties-structureTableDefault-summary-panel']");
 		tableRows = tableUtils.getTableRows(wideflyout);

--- a/canvas_modules/common-canvas/__tests__/common-properties/panels/columnselection-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/panels/columnselection-test.js
@@ -78,7 +78,7 @@ describe("selectcolumn and selectcolumns controls work in columnSelection panel"
 		// select age
 		dropdownList.at(1).simulate("click");
 		panel1 = wrapper.find("div[data-id='properties-selectcolumn']");
-		const fieldPicker = tableUtils.openFieldPicker(wrapper, "properties-ft-selectcolumns");
+		const fieldPicker = tableUtils.openFieldPickerForEmptyTable(wrapper, "properties-ctrl-selectcolumns");
 		tableUtils.fieldPicker(fieldPicker, ["BP"], ["BP", "Na", "drug"]);
 		const panel2 = wrapper.find("div[data-id='properties-selectcolumns']");
 		const rows = tableUtils.getTableRows(panel2);
@@ -210,7 +210,7 @@ describe("selectcolumn and selectcolumns controls work in columnSelection panel 
 		let actualOptions = panel1.find("Dropdown").prop("items");
 		expect(actualOptions.length).to.equal(fieldTable.length + 1); // +1 for "..."
 
-		const fieldPicker = tableUtils.openFieldPicker(wrapper, "properties-ft-selectcolumns");
+		const fieldPicker = tableUtils.openFieldPickerForEmptyTable(wrapper, "properties-ctrl-selectcolumns");
 		tableUtils.fieldPicker(fieldPicker, ["0.drug2", "2.drug2"], fieldTable);
 
 		// open the dropdown
@@ -245,7 +245,8 @@ describe("selectcolumn and selectcolumns controls work in columnSelection panel 
 	it("should show correct values from selectcolumns controls with multi schema input", () => {
 		const selectColumnsTable2 = wrapper.find("div[data-id='properties-ft-selectcolumns2']");
 		expect(selectColumnsTable2).to.have.length(1);
-		const selectColumnsTable3 = wrapper.find("div[data-id='properties-ft-selectcolumns3']");
+		// selectColumnsTable3 is an empty table. It shows empty table text and Add columns button
+		const selectColumnsTable3 = wrapper.find("div[data-id='properties-ctrl-selectcolumns3']");
 		expect(selectColumnsTable3).to.have.length(1);
 
 		const table2Rows = tableUtils.getTableRows(selectColumnsTable2);
@@ -293,7 +294,7 @@ describe("selectcolumn and selectcolumns controls work in columnSelection panel 
 			{ "link_ref": "2", "field_name": "drug2" },
 			{ "link_ref": "2", "field_name": "drug3" }
 		];
-		const fieldPicker = tableUtils.openFieldPicker(wrapper, "properties-ft-selectcolumns3");
+		const fieldPicker = tableUtils.openFieldPickerForEmptyTable(wrapper, "properties-ctrl-selectcolumns3");
 		tableUtils.fieldPicker(fieldPicker, selectcolumns3, fieldTable);
 		expect(controller.getPropertyValue({ name: "selectcolumns3" })).to.have.deep.members(selectcolumns3A);
 

--- a/canvas_modules/common-canvas/__tests__/common-properties/panels/summary-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/panels/summary-test.js
@@ -140,8 +140,7 @@ describe("summary panel renders error/warning status correctly", () => {
 		// add row back in tables
 		tableCategory.find("button.properties-summary-link-button").simulate("click");
 		wideflyout = wrapper.find("div.properties-wf-content.show");
-		wideflyout.find("button.properties-add-fields-button").at(0)
-			.simulate("click");
+		wideflyout.find("button.properties-empty-table-button").simulate("click");
 		// close fly-out
 		wideflyout.find("button.properties-apply-button").simulate("click");
 
@@ -174,9 +173,9 @@ describe("summary panel renders error/warning status correctly", () => {
 		summarypanelParamDef.current_parameters.structurelisteditorTableInput.forEach((value) => {
 			tableUtils.selectCheckboxes(tableInputBodyData, [0]);
 			const tableInputRemoveButton = wideflyout.find("button.properties-remove-fields-button");
-			expect(tableInputRemoveButton).to.have.length(2);
+			expect(tableInputRemoveButton).to.have.length(1);
 
-			tableInputRemoveButton.at(1).simulate("click");
+			tableInputRemoveButton.simulate("click");
 		});
 		// check that all rows were removed
 		wideflyout = wrapper.find("div.properties-wf-content.show");
@@ -206,7 +205,7 @@ describe("summary panel renders error/warning status correctly", () => {
 		tableCategory.find("button.properties-summary-link-button").simulate("click");
 		wideflyout = wrapper.find("div.properties-wf-content.show");
 
-		wideflyout.find("button.properties-add-fields-button").at(1)
+		wideflyout.find("button.properties-empty-table-button").at(1)
 			.simulate("click");
 		// close fly-out
 		wideflyout.find("button.properties-apply-button").simulate("click");

--- a/canvas_modules/common-canvas/locales/common-properties/locales/en.json
+++ b/canvas_modules/common-canvas/locales/common-properties/locales/en.json
@@ -1,8 +1,8 @@
 {
   "subPanel.button.tooltip": "Edit",
-  "structureListEditor.addButton.label": "Add Value",
+  "structureListEditor.addButton.label": "Add value",
   "structureListEditor.removeButton.label": "Remove",
-  "structureTable.addButton.label": "Add Columns",
+  "structureTable.addButton.label": "Add columns",
   "structureTable.removeButton.label": "Remove",
   "fieldPicker.saveButton.label": "Select Fields for",
   "fieldPicker.saveButton.tooltip": "Save and return",
@@ -87,5 +87,6 @@
   "multiselect.dropdown.empty.label": "None selected",
   "multiselect.dropdown.options.selected.label": "options selected",
   "virtualizedTable.header.checkbox.label": "Select all {header_checkbox_label}",
-  "virtualizedTable.row.checkbox.label": "Select row {row_index}, {row_checkbox_label}"
+  "virtualizedTable.row.checkbox.label": "Select row {row_index}, {row_checkbox_label}",
+  "properties.empty.table.text": "To begin, click \"{button_label}\""
 }

--- a/canvas_modules/common-canvas/locales/common-properties/locales/eo.json
+++ b/canvas_modules/common-canvas/locales/common-properties/locales/eo.json
@@ -1,9 +1,9 @@
 {
   "subPanel.button.tooltip": "[Esperanto~Edit~eo]",
-  "structureListEditor.addButton.label": "[Esperanto~Add Value~~~~eo]",
+  "structureListEditor.addButton.label": "[Esperanto~Add value~~~~eo]",
   "structureListEditor.removeButton.label": "[Esperanto~Remove~~~eo]",
   "structureListEditor.addButton.tooltip": "[Esperanto~Add new row~eo]",
-  "structureTable.addButton.label": "[Esperanto~Add Columns~eo]",
+  "structureTable.addButton.label": "[Esperanto~Add columns~eo]",
   "structureTable.removeButton.label": "[Esperanto~Remove~eo]",
   "fieldPicker.saveButton.label": "[Esperanto~Select Fields for~~~eo]",
   "fieldPicker.saveButton.tooltip": "[Esperanto~Save and return~eo]",
@@ -88,5 +88,6 @@
   "multiselect.dropdown.empty.label": "[Esperanto~None selected~~~~~~eo]",
   "multiselect.dropdown.options.selected.label": "[Esperanto~options selected~~~~~~eo]",
   "virtualizedTable.header.checkbox.label": "[Esperanto~Select all {header_checkbox_label}~~~~~~eo]",
-  "virtualizedTable.row.checkbox.label": "[Esperanto~Select row {row_index}, {row_checkbox_label}~~~~~~~~~~~~eo]"
+  "virtualizedTable.row.checkbox.label": "[Esperanto~Select row {row_index}, {row_checkbox_label}~~~~~~~~~~~~eo]",
+  "properties.empty.table.text": "[Esperanto~To begin, click \"{button_label}\"~~~~~~~eo]"
 }

--- a/canvas_modules/common-canvas/src/common-properties/components/empty-table/empty-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/empty-table/empty-table.jsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2021 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { formatMessage } from "./../../util/property-utils";
+import { MESSAGE_KEYS } from "./../../constants/constants";
+import { ControlType } from "./../../constants/form-constants";
+import { Add16, Edit16 } from "@carbon/icons-react";
+import { Button } from "carbon-components-react";
+
+export default class EmptyTable extends React.Component {
+	constructor(props) {
+		super(props);
+
+		this.getEmptyTableText = this.getEmptyTableText.bind(this);
+		this.isReadonlyTable = this.isReadonlyTable.bind(this);
+	}
+
+	getEmptyTableText() {
+		// Empty table text can be customized
+		const overrideEmptyTableTextKey = `${this.props.control.name}.empty.table.text`;
+		const defaultEmptyTableText = formatMessage(
+			this.props.controller.getReactIntl(),
+			MESSAGE_KEYS.PROPERTIES_EMPTY_TABLE_TEXT,
+			{ button_label: this.props.emptyTableButtonLabel }
+		);
+		return this.props.controller.getResource(overrideEmptyTableTextKey, defaultEmptyTableText);
+	}
+
+	isReadonlyTable() {
+		return this.props.control.controlType === ControlType.READONLYTABLE;
+	}
+
+	render() {
+		const emptyTableText = this.getEmptyTableText();
+		const emptyTableContent = (
+			<div className="properties-empty-table" disabled={this.props.disabled}>
+				<span >{emptyTableText}</span>
+				<br />
+				<Button
+					className="properties-empty-table-button"
+					kind="tertiary"
+					size="small"
+					renderIcon={this.isReadonlyTable() ? Edit16 : Add16}
+					onClick={this.props.emptyTableButtonClickHandler}
+					disabled={this.props.disabled}
+				>
+					{this.props.emptyTableButtonLabel}
+				</Button>
+			</div>
+		);
+		return emptyTableContent;
+	}
+}
+
+EmptyTable.propTypes = {
+	control: PropTypes.object.isRequired,
+	controller: PropTypes.object.isRequired,
+	emptyTableButtonLabel: PropTypes.string,
+	emptyTableButtonClickHandler: PropTypes.func,
+	disabled: PropTypes.bool,
+};

--- a/canvas_modules/common-canvas/src/common-properties/components/empty-table/empty-table.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/empty-table/empty-table.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Elyra Authors
+ * Copyright 2017-2021 Elyra Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-@import "./control-item/control-item";
-@import "./title-editor/title-editor";
-@import "./moveable-table-rows/moveable-table-rows";
-@import "./field-picker/field-picker";
-@import "./properties-modal/properties-modal";
-@import "./wide-flyout/wide-flyout";
-@import "./validation-message/validation-message";
-@import "./properties-buttons/properties-buttons";
-@import "./editor-form/editor-form";
-@import "./flexible-table/flexible-table";
-@import "./virtualized-table/virtualized-table";
-@import "./empty-table/empty-table";
+.properties-empty-table {
+	@include carbon--type-style("body-short-01");
+	&[disabled] {
+		opacity: 0.5;
+		pointer-events: none;
+	}
+	.properties-empty-table-button {
+		margin: $spacing-05 0;
+	}
+}

--- a/canvas_modules/common-canvas/src/common-properties/components/empty-table/index.js
+++ b/canvas_modules/common-canvas/src/common-properties/components/empty-table/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 Elyra Authors
+ * Copyright 2017-2021 Elyra Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,15 +14,5 @@
  * limitations under the License.
  */
 
-@import "./control-item/control-item";
-@import "./title-editor/title-editor";
-@import "./moveable-table-rows/moveable-table-rows";
-@import "./field-picker/field-picker";
-@import "./properties-modal/properties-modal";
-@import "./wide-flyout/wide-flyout";
-@import "./validation-message/validation-message";
-@import "./properties-buttons/properties-buttons";
-@import "./editor-form/editor-form";
-@import "./flexible-table/flexible-table";
-@import "./virtualized-table/virtualized-table";
-@import "./empty-table/empty-table";
+import EmptyTable from "./empty-table.jsx";
+export default EmptyTable;

--- a/canvas_modules/common-canvas/src/common-properties/components/moveable-table-rows/moveable-table-rows.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/moveable-table-rows/moveable-table-rows.jsx
@@ -21,8 +21,9 @@ import { Button } from "carbon-components-react";
 import { formatMessage } from "./../../util/property-utils";
 import { ArrowUp24, ArrowDown24, UpToTop24, DownToBottom24 } from "@carbon/icons-react";
 import classNames from "classnames";
-
+import EmptyTable from "./../empty-table";
 import { MESSAGE_KEYS } from "./../../constants/constants";
+import { has } from "lodash";
 
 class MoveableTableRows extends React.Component {
 	constructor(props) {
@@ -33,6 +34,42 @@ class MoveableTableRows extends React.Component {
 		this.upMoveRow = this.upMoveRow.bind(this);
 		this.downMoveRow = this.downMoveRow.bind(this);
 		this.bottomMoveRow = this.bottomMoveRow.bind(this);
+		this.getMoveableTableRows = this.getMoveableTableRows.bind(this);
+	}
+
+	getMoveableTableRows() {
+		var moveCol = null;
+		if (typeof this.props.control.moveableRows !== "undefined" && this.props.control.moveableRows) {
+			const moveImages = this.getTableRowMoveImages();
+			moveCol = (
+				<div
+					className="properties-mr-button-container"
+				>
+					{moveImages}
+				</div>
+			);
+		}
+
+		// Added role presentation to fix a11y violation - no headers in the table
+		var content = (<table role="presentation" className="properties-mr-table-container">
+			<tbody>
+				<tr className={classNames("properties-mr-table-content", { "disabled": this.props.disabled })}>
+					<td>
+						{this.props.tableContainer}
+					</td>
+					<td>
+						{moveCol}
+					</td>
+				</tr>
+			</tbody>
+		</table>
+		);
+
+		return (
+			<div>
+				{content}
+			</div>
+		);
 	}
 
 	// enabled the move up and down arrows based on which row is selected
@@ -196,38 +233,17 @@ class MoveableTableRows extends React.Component {
 	}
 
 	render() {
-
-		var moveCol = null;
-		if (typeof this.props.control.moveableRows !== "undefined" && this.props.control.moveableRows) {
-			const moveImages = this.getTableRowMoveImages();
-			moveCol = (
-				<div
-					className="properties-mr-button-container"
-				>
-					{moveImages}
-				</div>
-			);
-		}
-
-		// Added role presentation to fix a11y violation - no headers in the table
-		var content = (<table role="presentation" className="properties-mr-table-container">
-			<tbody>
-				<tr className={classNames("properties-mr-table-content", { "disabled": this.props.disabled })}>
-					<td>
-						{this.props.tableContainer}
-					</td>
-					<td>
-						{moveCol}
-					</td>
-				</tr>
-			</tbody>
-		</table>
-		);
-
+		const addRemoveRowsEnabled = has(this.props.control, "addRemoveRows") ? this.props.control.addRemoveRows : true;
 		return (
-			<div>
-				{content}
-			</div>
+			this.props.isEmptyTable && addRemoveRowsEnabled
+				? <EmptyTable
+					control={this.props.control}
+					controller={this.props.controller}
+					emptyTableButtonLabel={this.props.emptyTableButtonLabel}
+					emptyTableButtonClickHandler={this.props.emptyTableButtonClickHandler}
+					disabled={this.props.disabled}
+				/>
+				: this.getMoveableTableRows()
 		);
 	}
 }
@@ -240,6 +256,9 @@ MoveableTableRows.propTypes = {
 	setScrollToRow: PropTypes.func.isRequired,
 	tableContainer: PropTypes.object.isRequired,
 	disabled: PropTypes.bool,
+	isEmptyTable: PropTypes.bool.isRequired,
+	emptyTableButtonLabel: PropTypes.string,
+	emptyTableButtonClickHandler: PropTypes.func,
 	disableRowMoveButtons: PropTypes.bool // set by redux
 };
 

--- a/canvas_modules/common-canvas/src/common-properties/constants/constants.js
+++ b/canvas_modules/common-canvas/src/common-properties/constants/constants.js
@@ -109,7 +109,8 @@ _defineConstant("MESSAGE_KEYS", {
 	MULTISELECT_DROPDOWN_EMPTY_LABEL: "multiselect.dropdown.empty.label",
 	MULTISELECT_DROPDOWN_OPTIONS_SELECTED_LABEL: "multiselect.dropdown.options.selected.label",
 	VIRTUALIZEDTABLE_HEADER_CHECKBOX_LABEL: "virtualizedTable.header.checkbox.label",
-	VIRTUALIZEDTABLE_ROW_CHECKBOX_LABEL: "virtualizedTable.row.checkbox.label"
+	VIRTUALIZEDTABLE_ROW_CHECKBOX_LABEL: "virtualizedTable.row.checkbox.label",
+	PROPERTIES_EMPTY_TABLE_TEXT: "properties.empty.table.text"
 });
 
 _defineConstant("CHARACTER_LIMITS", {

--- a/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.jsx
@@ -73,6 +73,7 @@ export default class AbstractTable extends React.Component {
 		this.buildChildItem = this.buildChildItem.bind(this);
 		this.makeCells = this.makeCells.bind(this);
 		this.checkedAll = this.checkedAll.bind(this);
+		this.makeEmptyTablePanel = this.makeEmptyTablePanel.bind(this);
 
 
 		if (props.selectedRows && props.selectedRows.length > 0) {
@@ -769,6 +770,35 @@ export default class AbstractTable extends React.Component {
 			width: TABLE_SUBPANEL_BUTTON_WIDTH,
 			content: subCell
 		};
+	}
+
+	makeEmptyTablePanel(emptyTableButtonLabel, buttonClickHandler, disabled) {
+		// Empty table text can be customized
+		const overrideEmptyTableTextKey = `${this.props.control.name}.empty.table.text`;
+		const defaultEmptyTableText = PropertyUtils.formatMessage(
+			this.props.controller.getReactIntl(),
+			MESSAGE_KEYS.PROPERTIES_EMPTY_TABLE_TEXT,
+			{ button_label: emptyTableButtonLabel }
+		);
+		const emptyTableText = this.props.controller.getResource(overrideEmptyTableTextKey, defaultEmptyTableText);
+
+		const emptyTableContent = (
+			<div className="properties-empty-table" disabled={disabled}>
+				<span >{emptyTableText}</span>
+				<br />
+				<Button
+					className="properties-empty-table-button"
+					kind="tertiary"
+					size="small"
+					renderIcon={this.isReadonlyTable() ? Edit16 : Add16}
+					onClick={buttonClickHandler}
+					disabled={disabled}
+				>
+					{emptyTableButtonLabel}
+				</Button>
+			</div>
+		);
+		return emptyTableContent;
 	}
 }
 

--- a/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.jsx
@@ -73,7 +73,6 @@ export default class AbstractTable extends React.Component {
 		this.buildChildItem = this.buildChildItem.bind(this);
 		this.makeCells = this.makeCells.bind(this);
 		this.checkedAll = this.checkedAll.bind(this);
-		this.makeEmptyTablePanel = this.makeEmptyTablePanel.bind(this);
 
 
 		if (props.selectedRows && props.selectedRows.length > 0) {
@@ -770,35 +769,6 @@ export default class AbstractTable extends React.Component {
 			width: TABLE_SUBPANEL_BUTTON_WIDTH,
 			content: subCell
 		};
-	}
-
-	makeEmptyTablePanel(emptyTableButtonLabel, buttonClickHandler, disabled) {
-		// Empty table text can be customized
-		const overrideEmptyTableTextKey = `${this.props.control.name}.empty.table.text`;
-		const defaultEmptyTableText = PropertyUtils.formatMessage(
-			this.props.controller.getReactIntl(),
-			MESSAGE_KEYS.PROPERTIES_EMPTY_TABLE_TEXT,
-			{ button_label: emptyTableButtonLabel }
-		);
-		const emptyTableText = this.props.controller.getResource(overrideEmptyTableTextKey, defaultEmptyTableText);
-
-		const emptyTableContent = (
-			<div className="properties-empty-table" disabled={disabled}>
-				<span >{emptyTableText}</span>
-				<br />
-				<Button
-					className="properties-empty-table-button"
-					kind="tertiary"
-					size="small"
-					renderIcon={this.isReadonlyTable() ? Edit16 : Add16}
-					onClick={buttonClickHandler}
-					disabled={disabled}
-				>
-					{emptyTableButtonLabel}
-				</Button>
-			</div>
-		);
-		return emptyTableContent;
 	}
 }
 

--- a/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.scss
@@ -56,3 +56,14 @@
 		}
 	}
 }
+
+.properties-empty-table {
+	@include carbon--type-style("body-short-01");
+	&[disabled] {
+		opacity: 0.5;
+		pointer-events: none;
+	}
+	.properties-empty-table-button {
+		margin: $spacing-05 0;
+	}
+}

--- a/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.scss
@@ -56,14 +56,3 @@
 		}
 	}
 }
-
-.properties-empty-table {
-	@include carbon--type-style("body-short-01");
-	&[disabled] {
-		opacity: 0.5;
-		pointer-events: none;
-	}
-	.properties-empty-table-button {
-		margin: $spacing-05 0;
-	}
-}

--- a/canvas_modules/common-canvas/src/common-properties/controls/list/list.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/list/list.jsx
@@ -27,6 +27,7 @@ import { formatMessage } from "./../../util/property-utils";
 import { getDataId } from "./../../util/control-utils";
 import { MESSAGE_KEYS, STATES } from "./../../constants/constants.js";
 import { Type } from "./../../constants/form-constants.js";
+import { isEmpty, has } from "lodash";
 
 const NUMBER_TYPES = [Type.INTEGER, Type.DOUBLE, Type.LONG];
 class ListControl extends AbstractTable {
@@ -158,19 +159,23 @@ class ListControl extends AbstractTable {
 			</div>
 			<ValidationMessage state={this.props.state} messageInfo={this.props.messageInfo} />
 		</div>);
+		const disabled = this.props.state === STATES.DISABLED;
+		const addRemoveRows = has(this.props.control, "addRemoveRows") ? this.props.control.addRemoveRows : true;
 
 		return (
 			<div data-id={getDataId(this.props.propertyId)} className="properties-list-control" >
 				{this.props.controlItem}
-				<MoveableTableRows
-					tableContainer={tableContainer}
-					control={this.props.control}
-					controller={this.props.controller}
-					propertyId={this.props.propertyId}
-					setScrollToRow={this.setScrollToRow}
-					setCurrentControlValueSelected={this.setCurrentControlValueSelected}
-					disabled={this.props.state === STATES.DISABLED}
-				/>
+				{isEmpty(this.props.value) && addRemoveRows ? this.makeEmptyTablePanel(tableButtonConfig.addButtonLabel, this.addRow, disabled)
+					: <MoveableTableRows
+						tableContainer={tableContainer}
+						control={this.props.control}
+						controller={this.props.controller}
+						propertyId={this.props.propertyId}
+						setScrollToRow={this.setScrollToRow}
+						setCurrentControlValueSelected={this.setCurrentControlValueSelected}
+						disabled={disabled}
+					/>
+				}
 			</div>
 		);
 	}

--- a/canvas_modules/common-canvas/src/common-properties/controls/list/list.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/list/list.jsx
@@ -27,7 +27,7 @@ import { formatMessage } from "./../../util/property-utils";
 import { getDataId } from "./../../util/control-utils";
 import { MESSAGE_KEYS, STATES } from "./../../constants/constants.js";
 import { Type } from "./../../constants/form-constants.js";
-import { isEmpty, has } from "lodash";
+import { isEmpty } from "lodash";
 
 const NUMBER_TYPES = [Type.INTEGER, Type.DOUBLE, Type.LONG];
 class ListControl extends AbstractTable {
@@ -159,23 +159,22 @@ class ListControl extends AbstractTable {
 			</div>
 			<ValidationMessage state={this.props.state} messageInfo={this.props.messageInfo} />
 		</div>);
-		const disabled = this.props.state === STATES.DISABLED;
-		const addRemoveRows = has(this.props.control, "addRemoveRows") ? this.props.control.addRemoveRows : true;
 
 		return (
 			<div data-id={getDataId(this.props.propertyId)} className="properties-list-control" >
 				{this.props.controlItem}
-				{isEmpty(this.props.value) && addRemoveRows ? this.makeEmptyTablePanel(tableButtonConfig.addButtonLabel, this.addRow, disabled)
-					: <MoveableTableRows
-						tableContainer={tableContainer}
-						control={this.props.control}
-						controller={this.props.controller}
-						propertyId={this.props.propertyId}
-						setScrollToRow={this.setScrollToRow}
-						setCurrentControlValueSelected={this.setCurrentControlValueSelected}
-						disabled={disabled}
-					/>
-				}
+				<MoveableTableRows
+					tableContainer={tableContainer}
+					control={this.props.control}
+					controller={this.props.controller}
+					propertyId={this.props.propertyId}
+					setScrollToRow={this.setScrollToRow}
+					setCurrentControlValueSelected={this.setCurrentControlValueSelected}
+					disabled={this.props.state === STATES.DISABLED}
+					isEmptyTable={isEmpty(this.props.value)}
+					emptyTableButtonLabel={tableButtonConfig.addButtonLabel}
+					emptyTableButtonClickHandler={this.addRow}
+				/>
 			</div>
 		);
 	}

--- a/canvas_modules/common-canvas/src/common-properties/controls/readonlytable/readonlytable.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/readonlytable/readonlytable.jsx
@@ -25,6 +25,7 @@ import { STATES, MESSAGE_KEYS } from "./../../constants/constants";
 
 import ValidationMessage from "./../../components/validation-message";
 import * as ControlUtils from "./../../util/control-utils";
+import { isEmpty, has } from "lodash";
 
 class ReadonlyTableControl extends AbstractTable {
 	constructor(props) {
@@ -61,23 +62,27 @@ class ReadonlyTableControl extends AbstractTable {
 				</div>
 				<ValidationMessage state={this.props.state} messageInfo={this.props.messageInfo} />
 			</div>);
+		const disabled = this.props.state === STATES.DISABLED;
+		const addRemoveRows = has(this.props.control, "addRemoveRows") ? this.props.control.addRemoveRows : true;
 
 		return (
 			<div data-id={ControlUtils.getDataId(this.props.control, this.props.propertyId)}
 				className="properties-readonly-table-wrapper"
 			>
 				{this.props.controlItem}
-				<div className="properties-readonly-table">
-					<MoveableTableRows
-						tableContainer={content}
-						control={this.props.control}
-						controller={this.props.controller}
-						propertyId={this.props.propertyId}
-						setScrollToRow={this.setScrollToRow}
-						setCurrentControlValueSelected={this.setCurrentControlValueSelected}
-						disabled={this.props.state === STATES.DISABLED}
-					/>
-				</div>
+				{isEmpty(this.props.value) && addRemoveRows ? this.makeEmptyTablePanel(buttonLabel, this.editCallback, disabled)
+					: <div className="properties-readonly-table">
+						<MoveableTableRows
+							tableContainer={content}
+							control={this.props.control}
+							controller={this.props.controller}
+							propertyId={this.props.propertyId}
+							setScrollToRow={this.setScrollToRow}
+							setCurrentControlValueSelected={this.setCurrentControlValueSelected}
+							disabled={disabled}
+						/>
+					</div>
+				}
 			</div>
 		);
 	}

--- a/canvas_modules/common-canvas/src/common-properties/controls/readonlytable/readonlytable.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/readonlytable/readonlytable.jsx
@@ -25,7 +25,7 @@ import { STATES, MESSAGE_KEYS } from "./../../constants/constants";
 
 import ValidationMessage from "./../../components/validation-message";
 import * as ControlUtils from "./../../util/control-utils";
-import { isEmpty, has } from "lodash";
+import { isEmpty } from "lodash";
 
 class ReadonlyTableControl extends AbstractTable {
 	constructor(props) {
@@ -62,27 +62,26 @@ class ReadonlyTableControl extends AbstractTable {
 				</div>
 				<ValidationMessage state={this.props.state} messageInfo={this.props.messageInfo} />
 			</div>);
-		const disabled = this.props.state === STATES.DISABLED;
-		const addRemoveRows = has(this.props.control, "addRemoveRows") ? this.props.control.addRemoveRows : true;
 
 		return (
 			<div data-id={ControlUtils.getDataId(this.props.control, this.props.propertyId)}
 				className="properties-readonly-table-wrapper"
 			>
 				{this.props.controlItem}
-				{isEmpty(this.props.value) && addRemoveRows ? this.makeEmptyTablePanel(buttonLabel, this.editCallback, disabled)
-					: <div className="properties-readonly-table">
-						<MoveableTableRows
-							tableContainer={content}
-							control={this.props.control}
-							controller={this.props.controller}
-							propertyId={this.props.propertyId}
-							setScrollToRow={this.setScrollToRow}
-							setCurrentControlValueSelected={this.setCurrentControlValueSelected}
-							disabled={disabled}
-						/>
-					</div>
-				}
+				<div className="properties-readonly-table">
+					<MoveableTableRows
+						tableContainer={content}
+						control={this.props.control}
+						controller={this.props.controller}
+						propertyId={this.props.propertyId}
+						setScrollToRow={this.setScrollToRow}
+						setCurrentControlValueSelected={this.setCurrentControlValueSelected}
+						disabled={this.props.state === STATES.DISABLED}
+						isEmptyTable={isEmpty(this.props.value)}
+						emptyTableButtonLabel={buttonLabel}
+						emptyTableButtonClickHandler={this.editCallback}
+					/>
+				</div>
 			</div>
 		);
 	}

--- a/canvas_modules/common-canvas/src/common-properties/controls/selectcolumns/selectcolumns.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/selectcolumns/selectcolumns.jsx
@@ -36,6 +36,8 @@ class SelectColumns extends AbstractTable {
 	constructor(props) {
 		super(props);
 		this.reactIntl = props.controller.getReactIntl();
+		this.emptyTableButtonClickHandler = this.addOnClick.bind(this, this.props.propertyId);
+		this.emptyTableButtonLabel = PropertyUtils.formatMessage(this.reactIntl, MESSAGE_KEYS.STRUCTURETABLE_ADDBUTTON_LABEL);
 	}
 
 	makeRows(controlValue, tableState) {
@@ -146,8 +148,6 @@ class SelectColumns extends AbstractTable {
 				<ValidationMessage state={this.props.state} messageInfo={this.props.messageInfo} />
 			</div>
 		);
-		const emptyTableButtonClickHandler = this.addOnClick.bind(this, this.props.propertyId);
-		const emptyTableButtonLabel = PropertyUtils.formatMessage(this.reactIntl, MESSAGE_KEYS.STRUCTURETABLE_ADDBUTTON_LABEL);
 
 		return (
 			<div data-id={ControlUtils.getDataId(this.props.propertyId)} className="properties-column-select" >
@@ -161,8 +161,8 @@ class SelectColumns extends AbstractTable {
 					setCurrentControlValueSelected={this.setCurrentControlValueSelected}
 					disabled={this.props.state === STATES.DISABLED}
 					isEmptyTable={isEmpty(this.props.value)}
-					emptyTableButtonLabel={emptyTableButtonLabel}
-					emptyTableButtonClickHandler={emptyTableButtonClickHandler}
+					emptyTableButtonLabel={this.emptyTableButtonLabel}
+					emptyTableButtonClickHandler={this.emptyTableButtonClickHandler}
 				/>
 			</div>
 		);

--- a/canvas_modules/common-canvas/src/common-properties/controls/selectcolumns/selectcolumns.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/selectcolumns/selectcolumns.jsx
@@ -23,7 +23,7 @@ import AbstractTable from "./../abstract-table.jsx";
 import ValidationMessage from "./../../components/validation-message";
 import * as ControlUtils from "./../../util/control-utils";
 import * as PropertyUtils from "./../../util/property-utils";
-import { isEmpty, has } from "lodash";
+import { isEmpty } from "lodash";
 
 import { STATES, MESSAGE_KEYS } from "./../../constants/constants";
 
@@ -146,26 +146,24 @@ class SelectColumns extends AbstractTable {
 				<ValidationMessage state={this.props.state} messageInfo={this.props.messageInfo} />
 			</div>
 		);
-		const disabled = this.props.state === STATES.DISABLED;
-		const addRemoveRows = has(this.props.control, "addRemoveRows") ? this.props.control.addRemoveRows : true;
 		const emptyTableButtonClickHandler = this.addOnClick.bind(this, this.props.propertyId);
 		const emptyTableButtonLabel = PropertyUtils.formatMessage(this.reactIntl, MESSAGE_KEYS.STRUCTURETABLE_ADDBUTTON_LABEL);
 
 		return (
 			<div data-id={ControlUtils.getDataId(this.props.propertyId)} className="properties-column-select" >
 				{this.props.controlItem}
-				{isEmpty(this.props.value) && addRemoveRows ? this.makeEmptyTablePanel(emptyTableButtonLabel, emptyTableButtonClickHandler, disabled)
-					: <MoveableTableRows
-						tableContainer={content}
-						control={this.props.control}
-						controller={this.props.controller}
-						propertyId={this.props.propertyId}
-						setScrollToRow={this.setScrollToRow}
-						setCurrentControlValueSelected={this.setCurrentControlValueSelected}
-						disabled={disabled}
-
-					/>
-				}
+				<MoveableTableRows
+					tableContainer={content}
+					control={this.props.control}
+					controller={this.props.controller}
+					propertyId={this.props.propertyId}
+					setScrollToRow={this.setScrollToRow}
+					setCurrentControlValueSelected={this.setCurrentControlValueSelected}
+					disabled={this.props.state === STATES.DISABLED}
+					isEmptyTable={isEmpty(this.props.value)}
+					emptyTableButtonLabel={emptyTableButtonLabel}
+					emptyTableButtonClickHandler={emptyTableButtonClickHandler}
+				/>
 			</div>
 		);
 	}

--- a/canvas_modules/common-canvas/src/common-properties/controls/selectcolumns/selectcolumns.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/selectcolumns/selectcolumns.jsx
@@ -23,6 +23,7 @@ import AbstractTable from "./../abstract-table.jsx";
 import ValidationMessage from "./../../components/validation-message";
 import * as ControlUtils from "./../../util/control-utils";
 import * as PropertyUtils from "./../../util/property-utils";
+import { isEmpty, has } from "lodash";
 
 import { STATES, MESSAGE_KEYS } from "./../../constants/constants";
 
@@ -145,20 +146,26 @@ class SelectColumns extends AbstractTable {
 				<ValidationMessage state={this.props.state} messageInfo={this.props.messageInfo} />
 			</div>
 		);
+		const disabled = this.props.state === STATES.DISABLED;
+		const addRemoveRows = has(this.props.control, "addRemoveRows") ? this.props.control.addRemoveRows : true;
+		const emptyTableButtonClickHandler = this.addOnClick.bind(this, this.props.propertyId);
+		const emptyTableButtonLabel = PropertyUtils.formatMessage(this.reactIntl, MESSAGE_KEYS.STRUCTURETABLE_ADDBUTTON_LABEL);
 
 		return (
 			<div data-id={ControlUtils.getDataId(this.props.propertyId)} className="properties-column-select" >
 				{this.props.controlItem}
-				<MoveableTableRows
-					tableContainer={content}
-					control={this.props.control}
-					controller={this.props.controller}
-					propertyId={this.props.propertyId}
-					setScrollToRow={this.setScrollToRow}
-					setCurrentControlValueSelected={this.setCurrentControlValueSelected}
-					disabled={this.props.state === STATES.DISABLED}
+				{isEmpty(this.props.value) && addRemoveRows ? this.makeEmptyTablePanel(emptyTableButtonLabel, emptyTableButtonClickHandler, disabled)
+					: <MoveableTableRows
+						tableContainer={content}
+						control={this.props.control}
+						controller={this.props.controller}
+						propertyId={this.props.propertyId}
+						setScrollToRow={this.setScrollToRow}
+						setCurrentControlValueSelected={this.setCurrentControlValueSelected}
+						disabled={disabled}
 
-				/>
+					/>
+				}
 			</div>
 		);
 	}

--- a/canvas_modules/common-canvas/src/common-properties/controls/structurelisteditor/structurelisteditor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/structurelisteditor/structurelisteditor.jsx
@@ -23,7 +23,7 @@ import { formatMessage } from "./../../util/property-utils";
 import ValidationMessage from "./../../components/validation-message";
 import { MESSAGE_KEYS, STATES } from "./../../constants/constants";
 import * as ControlUtils from "./../../util/control-utils";
-import { isEmpty, has } from "lodash";
+import { isEmpty } from "lodash";
 
 class StructurelisteditorControl extends AbstractTable {
 
@@ -58,8 +58,6 @@ class StructurelisteditorControl extends AbstractTable {
 		</div>);
 
 		const onPanelContainer = this.getOnPanelContainer(this.props.selectedRows);
-		const disabled = this.props.state === STATES.DISABLED;
-		const addRemoveRows = has(this.props.control, "addRemoveRows") ? this.props.control.addRemoveRows : true;
 		return (
 			<div data-id={ControlUtils.getDataId(this.props.control, this.props.propertyId)}
 				className="properties-sle-wrapper"
@@ -67,17 +65,18 @@ class StructurelisteditorControl extends AbstractTable {
 				<div data-id={ControlUtils.getDataId(this.props.control, this.props.propertyId)}
 					className="properties-sle-container"
 				>
-					{isEmpty(this.props.value) && addRemoveRows ? this.makeEmptyTablePanel(tableButtonConfig.addButtonLabel, this.addRow, disabled)
-						: <MoveableTableRows
-							tableContainer={tableContainer}
-							control={this.props.control}
-							controller={this.props.controller}
-							propertyId={this.props.propertyId}
-							setScrollToRow={this.setScrollToRow}
-							setCurrentControlValueSelected={this.setCurrentControlValueSelected}
-							disabled={disabled}
-						/>
-					}
+					<MoveableTableRows
+						tableContainer={tableContainer}
+						control={this.props.control}
+						controller={this.props.controller}
+						propertyId={this.props.propertyId}
+						setScrollToRow={this.setScrollToRow}
+						setCurrentControlValueSelected={this.setCurrentControlValueSelected}
+						disabled={this.props.state === STATES.DISABLED}
+						isEmptyTable={isEmpty(this.props.value)}
+						emptyTableButtonLabel={tableButtonConfig.addButtonLabel}
+						emptyTableButtonClickHandler={this.addRow}
+					/>
 				</div>
 				<div>
 					{onPanelContainer}

--- a/canvas_modules/common-canvas/src/common-properties/controls/structurelisteditor/structurelisteditor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/structurelisteditor/structurelisteditor.jsx
@@ -23,6 +23,7 @@ import { formatMessage } from "./../../util/property-utils";
 import ValidationMessage from "./../../components/validation-message";
 import { MESSAGE_KEYS, STATES } from "./../../constants/constants";
 import * as ControlUtils from "./../../util/control-utils";
+import { isEmpty, has } from "lodash";
 
 class StructurelisteditorControl extends AbstractTable {
 
@@ -57,6 +58,8 @@ class StructurelisteditorControl extends AbstractTable {
 		</div>);
 
 		const onPanelContainer = this.getOnPanelContainer(this.props.selectedRows);
+		const disabled = this.props.state === STATES.DISABLED;
+		const addRemoveRows = has(this.props.control, "addRemoveRows") ? this.props.control.addRemoveRows : true;
 		return (
 			<div data-id={ControlUtils.getDataId(this.props.control, this.props.propertyId)}
 				className="properties-sle-wrapper"
@@ -64,15 +67,17 @@ class StructurelisteditorControl extends AbstractTable {
 				<div data-id={ControlUtils.getDataId(this.props.control, this.props.propertyId)}
 					className="properties-sle-container"
 				>
-					<MoveableTableRows
-						tableContainer={tableContainer}
-						control={this.props.control}
-						controller={this.props.controller}
-						propertyId={this.props.propertyId}
-						setScrollToRow={this.setScrollToRow}
-						setCurrentControlValueSelected={this.setCurrentControlValueSelected}
-						disabled={this.props.state === STATES.DISABLED}
-					/>
+					{isEmpty(this.props.value) && addRemoveRows ? this.makeEmptyTablePanel(tableButtonConfig.addButtonLabel, this.addRow, disabled)
+						: <MoveableTableRows
+							tableContainer={tableContainer}
+							control={this.props.control}
+							controller={this.props.controller}
+							propertyId={this.props.propertyId}
+							setScrollToRow={this.setScrollToRow}
+							setCurrentControlValueSelected={this.setCurrentControlValueSelected}
+							disabled={disabled}
+						/>
+					}
 				</div>
 				<div>
 					{onPanelContainer}

--- a/canvas_modules/common-canvas/src/common-properties/controls/structuretable/structuretable.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/structuretable/structuretable.jsx
@@ -22,15 +22,16 @@ import AbstractTable from "./../abstract-table.jsx";
 import MoveableTableRows from "./../../components/moveable-table-rows";
 import * as PropertyUtils from "./../../util/property-utils";
 import { Type, ParamRole } from "./../../constants/form-constants";
-import { STATES } from "./../../constants/constants";
+import { STATES, MESSAGE_KEYS } from "./../../constants/constants";
 
 import ValidationMessage from "./../../components/validation-message";
-import { reject, findIndex, cloneDeep } from "lodash";
+import { reject, findIndex, cloneDeep, isEmpty, has } from "lodash";
 import * as ControlUtils from "./../../util/control-utils";
 
 class StructureTableControl extends AbstractTable {
 	constructor(props) {
 		super(props);
+		this.reactIntl = props.controller.getReactIntl();
 		this.addColumns = this.addColumns.bind(this);
 		this.removeColumns = this.removeColumns.bind(this);
 		this.getDefaultRow = this.getDefaultRow.bind(this);
@@ -168,21 +169,28 @@ class StructureTableControl extends AbstractTable {
 			</div>);
 
 		const onPanelContainer = this.getOnPanelContainer(this.props.selectedRows);
+		const disabled = this.props.state === STATES.DISABLED;
+		const addRemoveRows = has(this.props.control, "addRemoveRows") ? this.props.control.addRemoveRows : true;
+		const emptyTableButtonClickHandler = this.addOnClick.bind(this, this.props.propertyId);
+		const emptyTableButtonLabel = PropertyUtils.formatMessage(this.reactIntl, MESSAGE_KEYS.STRUCTURETABLE_ADDBUTTON_LABEL);
+
 		return (
 			<div data-id={ControlUtils.getDataId(this.props.control, this.props.propertyId)}
 				className="properties-column-structure-wrapper"
 			>
-				<div className="properties-column-structure">
-					<MoveableTableRows
-						tableContainer={content}
-						control={this.props.control}
-						controller={this.props.controller}
-						propertyId={this.props.propertyId}
-						setScrollToRow={this.setScrollToRow}
-						setCurrentControlValueSelected={this.setCurrentControlValueSelected}
-						disabled={this.props.state === STATES.DISABLED}
-					/>
-				</div>
+				{isEmpty(this.props.value) && addRemoveRows ? this.makeEmptyTablePanel(emptyTableButtonLabel, emptyTableButtonClickHandler, disabled)
+					: <div className="properties-column-structure">
+						<MoveableTableRows
+							tableContainer={content}
+							control={this.props.control}
+							controller={this.props.controller}
+							propertyId={this.props.propertyId}
+							setScrollToRow={this.setScrollToRow}
+							setCurrentControlValueSelected={this.setCurrentControlValueSelected}
+							disabled={disabled}
+						/>
+					</div>
+				}
 				<div>
 					{onPanelContainer}
 				</div>

--- a/canvas_modules/common-canvas/src/common-properties/controls/structuretable/structuretable.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/structuretable/structuretable.jsx
@@ -36,6 +36,8 @@ class StructureTableControl extends AbstractTable {
 		this.removeColumns = this.removeColumns.bind(this);
 		this.getDefaultRow = this.getDefaultRow.bind(this);
 		this.indexOfRow = this.indexOfRow.bind(this);
+		this.emptyTableButtonClickHandler = this.addOnClick.bind(this, this.props.propertyId);
+		this.emptyTableButtonLabel = PropertyUtils.formatMessage(this.reactIntl, MESSAGE_KEYS.STRUCTURETABLE_ADDBUTTON_LABEL);
 	}
 
 	indexOfRow(columnName) {
@@ -169,8 +171,6 @@ class StructureTableControl extends AbstractTable {
 			</div>);
 
 		const onPanelContainer = this.getOnPanelContainer(this.props.selectedRows);
-		const emptyTableButtonClickHandler = this.addOnClick.bind(this, this.props.propertyId);
-		const emptyTableButtonLabel = PropertyUtils.formatMessage(this.reactIntl, MESSAGE_KEYS.STRUCTURETABLE_ADDBUTTON_LABEL);
 
 		return (
 			<div data-id={ControlUtils.getDataId(this.props.control, this.props.propertyId)}
@@ -186,8 +186,8 @@ class StructureTableControl extends AbstractTable {
 						setCurrentControlValueSelected={this.setCurrentControlValueSelected}
 						disabled={this.props.state === STATES.DISABLED}
 						isEmptyTable={isEmpty(this.props.value)}
-						emptyTableButtonLabel={emptyTableButtonLabel}
-						emptyTableButtonClickHandler={emptyTableButtonClickHandler}
+						emptyTableButtonLabel={this.emptyTableButtonLabel}
+						emptyTableButtonClickHandler={this.emptyTableButtonClickHandler}
 					/>
 				</div>
 				<div>

--- a/canvas_modules/common-canvas/src/common-properties/controls/structuretable/structuretable.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/structuretable/structuretable.jsx
@@ -25,7 +25,7 @@ import { Type, ParamRole } from "./../../constants/form-constants";
 import { STATES, MESSAGE_KEYS } from "./../../constants/constants";
 
 import ValidationMessage from "./../../components/validation-message";
-import { reject, findIndex, cloneDeep, isEmpty, has } from "lodash";
+import { reject, findIndex, cloneDeep, isEmpty } from "lodash";
 import * as ControlUtils from "./../../util/control-utils";
 
 class StructureTableControl extends AbstractTable {
@@ -169,8 +169,6 @@ class StructureTableControl extends AbstractTable {
 			</div>);
 
 		const onPanelContainer = this.getOnPanelContainer(this.props.selectedRows);
-		const disabled = this.props.state === STATES.DISABLED;
-		const addRemoveRows = has(this.props.control, "addRemoveRows") ? this.props.control.addRemoveRows : true;
 		const emptyTableButtonClickHandler = this.addOnClick.bind(this, this.props.propertyId);
 		const emptyTableButtonLabel = PropertyUtils.formatMessage(this.reactIntl, MESSAGE_KEYS.STRUCTURETABLE_ADDBUTTON_LABEL);
 
@@ -178,19 +176,20 @@ class StructureTableControl extends AbstractTable {
 			<div data-id={ControlUtils.getDataId(this.props.control, this.props.propertyId)}
 				className="properties-column-structure-wrapper"
 			>
-				{isEmpty(this.props.value) && addRemoveRows ? this.makeEmptyTablePanel(emptyTableButtonLabel, emptyTableButtonClickHandler, disabled)
-					: <div className="properties-column-structure">
-						<MoveableTableRows
-							tableContainer={content}
-							control={this.props.control}
-							controller={this.props.controller}
-							propertyId={this.props.propertyId}
-							setScrollToRow={this.setScrollToRow}
-							setCurrentControlValueSelected={this.setCurrentControlValueSelected}
-							disabled={disabled}
-						/>
-					</div>
-				}
+				<div className="properties-column-structure">
+					<MoveableTableRows
+						tableContainer={content}
+						control={this.props.control}
+						controller={this.props.controller}
+						propertyId={this.props.propertyId}
+						setScrollToRow={this.setScrollToRow}
+						setCurrentControlValueSelected={this.setCurrentControlValueSelected}
+						disabled={this.props.state === STATES.DISABLED}
+						isEmptyTable={isEmpty(this.props.value)}
+						emptyTableButtonLabel={emptyTableButtonLabel}
+						emptyTableButtonClickHandler={emptyTableButtonClickHandler}
+					/>
+				</div>
 				<div>
 					{onPanelContainer}
 				</div>

--- a/canvas_modules/harness/cypress/integration/properties/structure-list-editor-table-control.js
+++ b/canvas_modules/harness/cypress/integration/properties/structure-list-editor-table-control.js
@@ -26,7 +26,7 @@ describe("Test of subpanel editing of selectcolumns in a structurelisteditor", f
 	it("Test of subpanel editing of selectcolumns in a structurelisteditor", function() {
 		cy.toggleCategory("Table");
 		cy.openSubPanel("Configure Fields in Sub-panel");
-		cy.clickButtonInTable("Add", "structurelist_sub_panel");
+		cy.clickButtonInTable("Add in empty table", "structurelist_sub_panel");
 		cy.clickSubPanelButtonInRow("structurelist_sub_panel", 0);
 		cy.clickButtonInTable("Add", "fields2");
 		cy.selectFieldInFieldPickerPanel("Na", "double", "Select Fields for Select Columns");
@@ -60,6 +60,7 @@ describe("Test the feature to have tables use the available vertical space", fun
 	it("Test the feature to have tables use the available vertical space", function() {
 		cy.toggleCategory("Table");
 		cy.openSubPanel("Configure Fields in Sub-panel");
+		cy.clickButtonInTable("Add in empty table", "structurelist_sub_panel");
 		cy.verifyHeightOfTable("structurelist_sub_panel", "524px");
 	});
 });

--- a/canvas_modules/harness/cypress/support/properties/properties-cmds.js
+++ b/canvas_modules/harness/cypress/support/properties/properties-cmds.js
@@ -202,13 +202,17 @@ Cypress.Commands.add("selectAllRowsInTable", (propertyId) => {
 });
 
 Cypress.Commands.add("clickButtonInTable", (buttonName, propertyId) => {
-	cy.get(`div[data-id='properties-ft-${propertyId}']`)
+	cy.get(`div[data-id='properties-ctrl-${propertyId}']`)
 		.then((tableDiv) => {
 			cy.wrap(tableDiv).should("exist");
 
 			if (buttonName === "Add") {
 				cy.wrap(tableDiv)
 					.find(".properties-add-fields-button")
+					.click();
+			} else if (buttonName === "Add in empty table") {
+				cy.wrap(tableDiv)
+					.find(".properties-empty-table-button")
 					.click();
 			} else {
 				cy.wrap(tableDiv)

--- a/canvas_modules/harness/test_resources/parameterDefs/list_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/list_paramDef.json
@@ -582,5 +582,8 @@
         }
       ]
     }
-  ]
+  ],
+  "resources": {
+    "list_long_disabled.empty.table.text": "This is a custom empty text for list."
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/elyra-ai/canvas/issues/608

Added empty table content for controls - 
- List
- Readonlytable
- Selectcolumns
- Structurelisteditor
- Structuretable
- Fieldpicker

Empty table content general format -
```
text: To begin, click "{button_label}"
button: tertiary button - label same as the Add button label in the table
```
- Text can be customized by the host applications for **all** controls by passing `"{parameter-id}.empty.table.text"` in resources in parameter definition.
For example - 
```
"resources": {
    "list_string.empty.table.text": "This is a custom empty text for list."
  }
```
- Button label will be different for different controls -
**Add value** - List, structurelisteditor
**Add columns** - Selectcolumns, Structuretable, Fieldpicker
**Edit** or any custom label (if defined) - Readonlytable

 List, structurelisteditor controls -
![Screen Shot 2021-03-30 at 4 23 03 PM](https://user-images.githubusercontent.com/25124000/113345938-06422c00-92e8-11eb-83cd-cbea3ea22a28.png)

Selectcolumns, Structuretable, Fieldpicker controls -
![Screen Shot 2021-03-30 at 4 24 40 PM](https://user-images.githubusercontent.com/25124000/113345981-1528de80-92e8-11eb-9903-1cbe900d76b3.png)

Readonlytable control -
![Screen Shot 2021-03-30 at 4 59 56 PM](https://user-images.githubusercontent.com/25124000/113346015-1f4add00-92e8-11eb-99a3-61e6fe95fdfa.png)


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

