### PR TITLE
#628 Support light option in common-properties

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/common-properties-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/common-properties-test.js
@@ -478,6 +478,34 @@ describe("CommonProperties works correctly in flyout", () => {
 		expect(wrapper.find("aside.properties-small")).to.have.length(0);
 		expect(wrapper.find("aside.properties-medium")).to.have.length(1);
 	});
+
+	it("when light=true, common properties should render with light mode enabled", () => {
+		const newPropertiesInfo = JSON.parse(JSON.stringify(propertiesInfo));
+		wrapper = mount(
+			<IntlProvider key="IntlProvider2" locale={ locale }>
+				<CommonProperties
+					propertiesInfo={newPropertiesInfo}
+					callbacks={callbacks}
+					light
+				/>
+			</IntlProvider>
+		);
+		expect(wrapper.find("aside.properties-light-enabled")).to.have.length(1);
+	});
+
+	it("when light=false, common properties should render with light mode disabled", () => {
+		const newPropertiesInfo = JSON.parse(JSON.stringify(propertiesInfo));
+		wrapper = mount(
+			<IntlProvider key="IntlProvider2" locale={ locale }>
+				<CommonProperties
+					propertiesInfo={newPropertiesInfo}
+					callbacks={callbacks}
+					light={false}
+				/>
+			</IntlProvider>
+		);
+		expect(wrapper.find("aside.properties-light-enabled")).to.have.length(0);
+	});
 });
 
 describe("Common properties modals return the correct Carbon modal size", () => {

--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/datefield-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/datefield-test.js
@@ -153,6 +153,34 @@ describe("datefield-control renders correctly", () => {
 		const input = dateWrapper.find("input");
 		expect(input.getDOMNode().placeholder).to.equal(control.additionalText);
 	});
+
+	it("should render `DatefieldControl` with light mode enabled", () => {
+		controller.setLight(true);
+		const wrapper = mount(
+			<DatefieldControl
+				store={controller.getStore()}
+				control={control}
+				controller={controller}
+				propertyId={propertyId}
+			/>
+		);
+		const dateWrapper = wrapper.find("div[data-id='properties-test-datefield']");
+		expect(dateWrapper.find(".bx--text-input--light")).to.have.length(1);
+	});
+
+	it("should render `DatefieldControl` with light mode disabled", () => {
+		controller.setLight(false);
+		const wrapper = mount(
+			<DatefieldControl
+				store={controller.getStore()}
+				control={control}
+				controller={controller}
+				propertyId={propertyId}
+			/>
+		);
+		const dateWrapper = wrapper.find("div[data-id='properties-test-datefield']");
+		expect(dateWrapper.find(".bx--text-input--light")).to.have.length(0);
+	});
 });
 
 describe("error messages renders correctly for datefield controls", () => {

--- a/canvas_modules/common-canvas/src/common-properties/common-properties.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/common-properties.jsx
@@ -273,6 +273,7 @@ CommonProperties.defaultProps = {
 	},
 	callbacks: {
 	},
+	light: true // Enable light option by default
 };
 
 export default injectIntl(CommonProperties, { forwardRef: true });

--- a/canvas_modules/common-canvas/src/common-properties/common-properties.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/common-properties.jsx
@@ -73,6 +73,7 @@ class CommonProperties extends React.Component {
 				callbacks= {this.props.callbacks}
 				customControls={this.props.customControls}
 				customConditionOps={this.props.customConditionOps}
+				light={this.props.light}
 			/>);
 		return propertiesMain;
 	}
@@ -256,6 +257,7 @@ CommonProperties.propTypes = {
 	customPanels: PropTypes.array,
 	customControls: PropTypes.array,
 	customConditionOps: PropTypes.array,
+	light: PropTypes.bool,
 	intl: PropTypes.object.isRequired
 };
 

--- a/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.jsx
@@ -157,7 +157,7 @@ class EditorForm extends React.Component {
 				tabContent.push(
 					<div key={this._getContainerIndex(hasAlertsTab, i) + "-" + key} className="properties-category-container">
 						<button type="button" onClick={this._showCategoryPanel.bind(this, tab.group)}
-							className="properties-category-title"
+							className={classNames("properties-category-title", { "properties-light-enabled": this.props.controller.getLight() }) }
 						>
 							{tab.text}{this._getMessageCountForCategory(tab)}
 							{panelArrow}
@@ -194,7 +194,7 @@ class EditorForm extends React.Component {
 			);
 		}
 		return (
-			<Tabs key={"tab." + key} className="properties-primaryTabs" selected={modalSelected}>
+			<Tabs key={"tab." + key} className="properties-primaryTabs" selected={modalSelected} light={this.props.controller.getLight()}>
 				{tabContent}
 			</Tabs>
 		);
@@ -556,6 +556,7 @@ class EditorForm extends React.Component {
 				showPropertiesButtons={false}
 				show
 				title={title}
+				light={this.props.controller.getLight()}
 			>
 				{this.fieldPicker(title)}
 			</WideFlyout>);

--- a/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.scss
@@ -43,6 +43,7 @@
 	width: 100%;
 
 	display: flex;
+	background-color: $ui-background;
 	justify-content: space-between;
 	align-items: center;
 	padding: 0 $spacing-06;

--- a/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.scss
@@ -43,7 +43,6 @@
 	width: 100%;
 
 	display: flex;
-	background-color: $ui-01;
 	justify-content: space-between;
 	align-items: center;
 	padding: 0 $spacing-06;
@@ -114,4 +113,8 @@
 	.properties-link-text {
 		@include carbon--type-style("body-short-01");
 	}
+}
+
+.properties-light-enabled {
+	background-color: $ui-01; // Override theme background-color when light option is true
 }

--- a/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
@@ -440,6 +440,7 @@ export default class FieldPicker extends React.Component {
 				selectedRows={this.selectedRowsIndex}
 				updateRowSelections={this.updateFieldSelections}
 				rowSelection={ROW_SELECTION.MULTIPLE}
+				light={this.props.controller.getLight()}
 			/>
 		);
 	}

--- a/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
@@ -438,6 +438,7 @@ class FlexibleTable extends React.Component {
 						disabled={disabled}
 						size="sm"
 						labelText={searchBarLabel}
+						light={has(this.props, "light") ? this.props.light : false}
 					/>
 				</div>
 			);
@@ -483,6 +484,7 @@ class FlexibleTable extends React.Component {
 									sortColumns={this.state.columnSortDir}
 									sortDirection={this.state.columnSortDir[this.state.currentSortColumn]}
 									tableState={this.props.tableState}
+									light={has(this.props, "light") ? this.props.light : true}
 									{...(scrollIndex !== -1 && { scrollToIndex: scrollIndex, scrollToAlignment: "center" })}
 								/>
 							</div>
@@ -523,6 +525,7 @@ FlexibleTable.propTypes = {
 	selectedRows: PropTypes.array,
 	rowSelection: PropTypes.string,
 	summaryTable: PropTypes.bool,
+	light: PropTypes.bool,
 	intl: PropTypes.object.isRequired
 };
 

--- a/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
@@ -438,7 +438,7 @@ class FlexibleTable extends React.Component {
 						disabled={disabled}
 						size="sm"
 						labelText={searchBarLabel}
-						light={has(this.props, "light") ? this.props.light : false}
+						light={this.props.light}
 					/>
 				</div>
 			);
@@ -484,7 +484,7 @@ class FlexibleTable extends React.Component {
 									sortColumns={this.state.columnSortDir}
 									sortDirection={this.state.columnSortDir[this.state.currentSortColumn]}
 									tableState={this.props.tableState}
-									light={has(this.props, "light") ? this.props.light : true}
+									light={this.props.light}
 									{...(scrollIndex !== -1 && { scrollToIndex: scrollIndex, scrollToAlignment: "center" })}
 								/>
 							</div>
@@ -497,7 +497,8 @@ class FlexibleTable extends React.Component {
 }
 
 FlexibleTable.defaultProps = {
-	showHeader: true
+	showHeader: true,
+	light: true
 };
 
 FlexibleTable.propTypes = {

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -120,6 +120,7 @@ class TitleEditor extends Component {
 						hideLabel
 						onFocus={this.textInputOnFocus}
 						onBlur={this.textInputOnBlur}
+						light={this.props.controller.getLight()}
 						{... this.state.focused && { className: "properties-title-editor-focused" }}
 					/>
 					{propertiesTitleEdit}

--- a/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
@@ -321,7 +321,8 @@ class VirtualizedTable extends React.Component {
 		return (
 			<div className="properties-vt">
 				<div className={classNames("properties-vt-autosizer",
-					{ "properties-vt-single-selection": this.props.rowSelection && this.props.rowSelection === ROW_SELECTION.SINGLE })}
+					{ "properties-vt-single-selection": this.props.rowSelection && this.props.rowSelection === ROW_SELECTION.SINGLE,
+						"properties-light-disabled": !this.props.light })}
 				>
 					<AutoSizer>
 						{({ height, width }) => ( // Table height: subtract 50 for margin below the table.
@@ -407,6 +408,7 @@ VirtualizedTable.propTypes = {
 	onHeaderClick: PropTypes.func,
 	scrollKey: PropTypes.string,
 	tableState: PropTypes.string,
+	light: PropTypes.bool,
 	intl: PropTypes.object.isRequired
 };
 

--- a/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.scss
@@ -150,4 +150,11 @@ $properties-vt-checkbox-width: 45px;
 		height: 100%;
 		width: 100%;
 	}
+
+	.properties-light-disabled {
+		background-color: $ui-01;
+		.bx--select--inline .bx--select-input[disabled] {
+			background-color: $ui-background;
+		}
+	}
 }

--- a/canvas_modules/common-canvas/src/common-properties/components/wide-flyout/wide-flyout.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/wide-flyout/wide-flyout.jsx
@@ -89,7 +89,7 @@ export default class WideFlyout extends Component {
 			<div className="properties-wf-modal" ref={ (ref) => (this.wideFlyout = ref) }>
 				<Portal node={this.commonPropertiesParent}>
 					{ overlay }
-					<div className={classNames("properties-wf-content", { "show": this.props.show })} style={this.state.style}>
+					<div className={classNames("properties-wf-content", { "show": this.props.show, "properties-light-disabled": !this.props.light })} style={this.state.style}>
 						{title}
 						{children}
 						{buttons}
@@ -108,7 +108,8 @@ WideFlyout.propTypes = {
 	showPropertiesButtons: PropTypes.bool,
 	applyLabel: PropTypes.string,
 	rejectLabel: PropTypes.string,
-	title: PropTypes.string
+	title: PropTypes.string,
+	light: PropTypes.bool
 };
 
 WideFlyout.defaultProps = {

--- a/canvas_modules/common-canvas/src/common-properties/components/wide-flyout/wide-flyout.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/wide-flyout/wide-flyout.scss
@@ -55,8 +55,12 @@ $properties-modal-buttons-height: 64px;
 		border-bottom: 1px solid $ui-03;
 	}
 	.properties-wf-children {
-		padding: $spacing-04 $spacing-06 $spacing-06 $spacing-06;
+		padding: $spacing-04 $spacing-06 $spacing-06;
 		overflow-y: auto;
 		height: calc(100% - #{$properties-wf-title-height} - #{$properties-modal-buttons-height});
 	}
+}
+
+.properties-light-disabled {
+	background-color: $ui-background;
 }

--- a/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.jsx
@@ -459,6 +459,7 @@ export default class AbstractTable extends React.Component {
 					tableLabel={tableLabel}
 					summaryTable
 					rowSelection={ROW_SELECTION.MULTIPLE}
+					light={this.props.controller.getLight()}
 				/>
 			</div>);
 		}
@@ -653,6 +654,7 @@ export default class AbstractTable extends React.Component {
 				updateRowSelections={rowClickCallback}
 				selectedRows= {this.props.selectedRows}
 				rowSelection={this.props.control.rowSelection}
+				light={this.props.controller.getLight()}
 			/>);
 		return (
 			<div>

--- a/canvas_modules/common-canvas/src/common-properties/controls/datefield/datefield.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/datefield/datefield.jsx
@@ -81,7 +81,7 @@ class DatefieldControl extends React.Component {
 					value={displayValue}
 					labelText={this.props.controlItem}
 					hideLabel={this.props.tableControl}
-					light
+					light={this.props.controller.getLight()}
 				/>
 				<ValidationMessage inTable={this.props.tableControl} state={this.props.state} messageInfo={this.props.messageInfo} />
 			</div>

--- a/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
@@ -205,6 +205,7 @@ class DropDown extends React.Component {
 				disabled={this.props.state === STATES.DISABLED}
 				onChange={this.handleChange}
 				value={selection}
+				light={this.props.controller.getLight()}
 			>
 				{ options }
 			</Select>);
@@ -217,7 +218,7 @@ class DropDown extends React.Component {
 				items={dropDown.options}
 				onChange={this.handleComboOnChange}
 				onInputChange={this.handleOnInputChange}
-				light
+				light={this.props.controller.getLight()}
 				translateWithId={(id) => listBoxMenuIconTranslationIds[id]}
 				titleText={this.props.controlItem}
 			/>);
@@ -230,7 +231,7 @@ class DropDown extends React.Component {
 				onChange={this.handleChange}
 				selectedItem={dropDown.selectedOption}
 				label={this.emptyLabel}
-				light
+				light={this.props.controller.getLight()}
 				translateWithId={(id) => listBoxMenuIconTranslationIds[id]}
 				titleText={this.props.controlItem}
 			/>);

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
@@ -415,6 +415,7 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 						selectedRows={[selectedField]}
 						onRowDoubleClick={this.onFieldTableDblClick}
 						onSort={this.setSortColumn.bind(this, "fieldTable")}
+						light={this.props.controller.getLight()}
 					/>
 				</div>
 				<div className="properties-value-table-container" >
@@ -431,6 +432,7 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 						selectedRows={[selectedValue]}
 						onRowDoubleClick={this.onValueTableDblClick}
 						onSort={this.setSortColumn.bind(this, "valuesTable")}
+						light={this.props.controller.getLight()}
 					/>
 				</div>
 			</div>
@@ -507,7 +509,7 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 			<div className="properties-expression-function-select">
 				<Dropdown
 					id={"properties-expression-function-select-dropdown-" + uuid4()}
-					light
+					light={this.props.controller.getLight()}
 					label={label}
 					items={items}
 					onChange={this.onFunctionCatChange}
@@ -536,7 +538,7 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 			<div className="properties-expression-field-select">
 				<Dropdown
 					id={"properties-expression-field-select-dropdown-" + uuid4()}
-					light
+					light={this.props.controller.getLight()}
 					label={label}
 					items={newItems}
 					onChange={this.onFieldCatChange}
@@ -583,6 +585,7 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 						selectedRows={[selectedFunction]}
 						onRowDoubleClick={this.onFunctionTableDblClick}
 						onSort={this.setSortColumn.bind(this, "functionTable")}
+						light={this.props.controller.getLight()}
 					/>
 				</div>
 				<div className="properties-help-table-container" >

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.jsx
@@ -22,6 +22,7 @@ import { connect } from "react-redux";
 import { UnControlled as CodeMirror } from "react-codemirror2";
 import Icon from "./../../../icons/icon.jsx";
 import { Button } from "carbon-components-react";
+import classNames from "classnames";
 
 import ValidationMessage from "./../../components/validation-message";
 import WideFlyout from "./../../components/wide-flyout";
@@ -315,6 +316,7 @@ class ExpressionControl extends React.Component {
 			applyLabel={applyLabel}
 			rejectLabel={rejectLabel}
 			title={expressonTitle}
+			light={this.props.controller.getLight()}
 		>
 			<div>
 				<ExpressionBuilder
@@ -325,7 +327,7 @@ class ExpressionControl extends React.Component {
 			</div>
 		</WideFlyout>) : null;
 
-		const className = "properties-expression-editor " + messageType;
+		const className = classNames(`properties-expression-editor ${messageType}`, { "properties-light-disabled": !this.props.controller.getLight() });
 
 		const expressionLink = (<div className="properties-expression-link-container" >
 			{button}

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.scss
@@ -73,6 +73,12 @@
 	}
 }
 
+.properties-light-disabled {
+	.CodeMirror {
+		background: $ui-01;
+	}
+}
+
 
 .properties-expression-link-container {
 	display: flex;

--- a/canvas_modules/common-canvas/src/common-properties/controls/list/list.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/list/list.jsx
@@ -150,6 +150,7 @@ class ListControl extends AbstractTable {
 				selectedRows={this.props.selectedRows}
 				rowSelection={this.props.control.rowSelection}
 				updateRowSelections={this.updateRowSelections}
+				light={this.props.controller.getLight()}
 			/>);
 
 		const tableContainer = (<div>

--- a/canvas_modules/common-canvas/src/common-properties/controls/multiselect/multiselect.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/multiselect/multiselect.jsx
@@ -100,7 +100,7 @@ class MultiSelectControl extends React.Component {
 				onChange={this.handleOnChange}
 				placeholder={label}
 				titleText={this.props.tableControl ? null : this.props.controlItem}
-				light
+				light={this.props.controller.getLight()}
 			/>);
 		} else {
 			dropdownComponent = (<MultiSelect
@@ -112,7 +112,7 @@ class MultiSelectControl extends React.Component {
 				onChange={this.handleOnChange}
 				label={label}
 				titleText={this.props.tableControl ? null : this.props.controlItem}
-				light
+				light={this.props.controller.getLight()}
 			/>);
 		}
 

--- a/canvas_modules/common-canvas/src/common-properties/controls/numberfield/numberfield.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/numberfield/numberfield.jsx
@@ -90,7 +90,7 @@ class NumberfieldControl extends React.Component {
 					label={this.props.controlItem}
 					hideLabel={this.props.tableControl}
 					allowEmpty
-					light
+					light={this.props.controller.getLight()}
 				/>
 				<ValidationMessage inTable={this.props.tableControl} state={this.props.state} messageInfo={this.props.messageInfo} />
 			</div>

--- a/canvas_modules/common-canvas/src/common-properties/controls/passwordfield/passwordfield.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/passwordfield/passwordfield.jsx
@@ -48,7 +48,7 @@ class PasswordControl extends React.Component {
 					value={value}
 					labelText={this.props.controlItem}
 					hideLabel={this.props.tableControl}
-					light
+					light={this.props.controller.getLight()}
 				/>
 				<ValidationMessage inTable={this.props.tableControl} state={this.props.state} messageInfo={this.props.messageInfo} />
 			</div>);

--- a/canvas_modules/common-canvas/src/common-properties/controls/selectcolumns/selectcolumns.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/selectcolumns/selectcolumns.jsx
@@ -137,6 +137,7 @@ class SelectColumns extends AbstractTable {
 				selectedRows={this.props.selectedRows}
 				rowSelection={this.props.control.rowSelection}
 				updateRowSelections={this.updateRowSelections}
+				light={this.props.controller.getLight()}
 			/>);
 
 		var content = (

--- a/canvas_modules/common-canvas/src/common-properties/controls/someofselect/someofselect.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/someofselect/someofselect.jsx
@@ -109,6 +109,7 @@ class SomeofselectControl extends React.Component {
 					updateRowSelections={this.updateSelections}
 					selectable
 					showHeader={false}
+					light={this.props.controller.getLight()}
 				/>
 				<ValidationMessage state={this.props.state} messageInfo={this.props.messageInfo} inTable={this.props.tableControl} />
 			</div>

--- a/canvas_modules/common-canvas/src/common-properties/controls/textarea/textarea.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/textarea/textarea.jsx
@@ -69,7 +69,7 @@ class TextareaControl extends React.Component {
 					value={value}
 					labelText={this.props.controlItem}
 					hideLabel={this.props.tableControl}
-					light
+					light={this.props.controller.getLight()}
 				/>
 				<ValidationMessage inTable={this.props.tableControl} state={""} messageInfo={errorMessage} />
 			</div>);
@@ -82,7 +82,7 @@ class TextareaControl extends React.Component {
 				value={value}
 				labelText={this.props.controlItem}
 				hideLabel={this.props.tableControl}
-				light
+				light={this.props.controller.getLight()}
 			/>);
 		}
 

--- a/canvas_modules/common-canvas/src/common-properties/controls/textfield/textfield.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/textfield/textfield.jsx
@@ -100,7 +100,7 @@ class TextfieldControl extends React.Component {
 				value={value}
 				labelText={this.props.controlItem}
 				hideLabel={this.props.tableControl}
-				light
+				light={this.props.controller.getLight()}
 			/>);
 		}
 

--- a/canvas_modules/common-canvas/src/common-properties/controls/timefield/timefield.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/timefield/timefield.jsx
@@ -80,7 +80,7 @@ class TimefieldControl extends React.Component {
 					value={displayValue}
 					labelText={this.props.controlItem}
 					hideLabel={this.props.tableControl}
-					light
+					light={this.props.controller.getLight()}
 				/>
 				<ValidationMessage inTable={this.props.tableControl} state={this.props.state} messageInfo={this.props.messageInfo} />
 			</div>

--- a/canvas_modules/common-canvas/src/common-properties/panels/sub-panel/invoker.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/sub-panel/invoker.jsx
@@ -74,6 +74,7 @@ export default class SubPanelInvoker extends React.Component {
 				applyLabel={this.props.applyLabel}
 				rejectLabel={this.props.rejectLabel}
 				title={this.state.title}
+				light={this.props.controller.getLight()}
 			>
 				<div>
 					{this.state.panel}

--- a/canvas_modules/common-canvas/src/common-properties/panels/subtabs/subtabs.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/subtabs/subtabs.jsx
@@ -66,7 +66,7 @@ class Subtabs extends React.Component {
 		}
 		return (
 			<div className={classNames("properties-sub-tab-container", { vertical: !this.props.rightFlyout }, className)}>
-				<Tabs className="properties-subtabs" selected={activeTab}>
+				<Tabs className="properties-subtabs" selected={activeTab} light={this.props.controller.getLight()}>
 					{subTabs}
 				</Tabs>
 			</div>

--- a/canvas_modules/common-canvas/src/common-properties/panels/summary/summary.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/summary/summary.jsx
@@ -298,6 +298,7 @@ class SummaryPanel extends React.Component {
 			applyLabel={applyLabel}
 			rejectLabel={rejectLabel}
 			title={this.props.panel.label}
+			light={this.props.controller.getLight()}
 		>
 			<div>
 				{this.props.children}

--- a/canvas_modules/common-canvas/src/common-properties/properties-controller.js
+++ b/canvas_modules/common-canvas/src/common-properties/properties-controller.js
@@ -66,6 +66,7 @@ export default class PropertiesController {
 		this.expressionRecentlyUsed = [];
 		this.expressionFieldsRecentlyUsed = [];
 		this.selectionListeners = {};
+		this.light = true; // Enable light option by default
 	}
 
 	getStore() {
@@ -103,6 +104,14 @@ export default class PropertiesController {
 
 	getEditorSize() {
 		return this.editorSize;
+	}
+
+	setLight(light) {
+		this.light = light;
+	}
+
+	getLight() {
+		return this.light;
 	}
 
 	setPropertiesConfig(config) {

--- a/canvas_modules/common-canvas/src/common-properties/properties-controller.js
+++ b/canvas_modules/common-canvas/src/common-properties/properties-controller.js
@@ -66,7 +66,6 @@ export default class PropertiesController {
 		this.expressionRecentlyUsed = [];
 		this.expressionFieldsRecentlyUsed = [];
 		this.selectionListeners = {};
-		this.light = true; // Enable light option by default
 	}
 
 	getStore() {

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -482,7 +482,11 @@ class PropertiesMain extends React.Component {
 				</PropertiesModal>);
 			}
 			const className = classNames("properties-wrapper",
-				{ "properties-right-flyout": this.props.propertiesConfig.rightFlyout, "properties-light-enabled": this.props.light },
+				{
+					"properties-right-flyout": this.props.propertiesConfig.rightFlyout,
+					"properties-light-enabled": this.props.light,
+					"properties-light-disabled": !this.props.light
+				},
 				`properties-${this.state.editorSize}`);
 			const overrideSize = this._getOverrideSize();
 			let overrideStyle = null;

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -54,6 +54,7 @@ class PropertiesMain extends React.Component {
 		}
 		this.propertiesController.setCustomControls(props.customControls);
 		this.propertiesController.setConditionOps(props.customConditionOps);
+		this.propertiesController.setLight(props.light);
 		this.propertiesController.setAppData(props.propertiesInfo.appData);
 		this.propertiesController.setExpressionInfo(props.propertiesInfo.expressionInfo);
 		this.propertiesController.setHandlers({
@@ -480,7 +481,9 @@ class PropertiesMain extends React.Component {
 					{editorForm}
 				</PropertiesModal>);
 			}
-			const className = classNames("properties-wrapper", { "properties-right-flyout": this.props.propertiesConfig.rightFlyout }, `properties-${this.state.editorSize}`);
+			const className = classNames("properties-wrapper",
+				{ "properties-right-flyout": this.props.propertiesConfig.rightFlyout, "properties-light-enabled": this.props.light },
+				`properties-${this.state.editorSize}`);
 			const overrideSize = this._getOverrideSize();
 			let overrideStyle = null;
 			if (overrideSize !== null) {
@@ -541,6 +544,7 @@ PropertiesMain.propTypes = {
 	customPanels: PropTypes.array, // array of custom panels
 	customControls: PropTypes.array, // array of custom controls
 	customConditionOps: PropTypes.array, // array of custom condition ops
+	light: PropTypes.bool,
 	intl: PropTypes.object.isRequired
 };
 

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.scss
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.scss
@@ -78,3 +78,7 @@
 .properties-light-enabled {
 	background-color: $ui-01; // Override theme background-color when light option is true
 }
+
+.properties-light-disabled {
+	background-color: $ui-background;
+}

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.scss
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.scss
@@ -21,7 +21,6 @@
 	font-size: 14px;
 	width: 0;
 	height: 100%;
-	background-color: $ui-01;
 	overflow: hidden;
 	border-left: 1px solid $ui-03;
 	outline: none;
@@ -74,4 +73,8 @@
 	&.properties-custom-container-with-heading {
 		height: calc(100% - 160px);
 	}
+}
+
+.properties-light-enabled {
+	background-color: $ui-01; // Override theme background-color when light option is true
 }

--- a/canvas_modules/harness/src/client/App.js
+++ b/canvas_modules/harness/src/client/App.js
@@ -1952,7 +1952,6 @@ class App extends React.Component {
 			rightFlyout: this.state.propertiesContainerType === PROPERTIES_FLYOUT,
 			applyOnBlur: this.state.applyOnBlur,
 			heading: this.state.heading,
-			light: this.state.light,
 			schemaValidation: this.state.propertiesSchemaValidation,
 			applyPropertiesWithoutEdit: this.state.applyPropertiesWithoutEdit,
 			conditionHiddenPropertyHandling: this.state.conditionHiddenPropertyHandling,

--- a/canvas_modules/harness/src/client/App.js
+++ b/canvas_modules/harness/src/client/App.js
@@ -212,6 +212,7 @@ class App extends React.Component {
 			applyOnBlur: true,
 			expressionBuilder: true,
 			heading: false,
+			light: true,
 			propertiesSchemaValidation: true,
 			applyPropertiesWithoutEdit: false,
 			propertiesValidationHandler: true,
@@ -285,6 +286,7 @@ class App extends React.Component {
 		this.useExpressionBuilder = this.useExpressionBuilder.bind(this);
 		this.useDisplayAdditionalComponents = this.useDisplayAdditionalComponents.bind(this);
 		this.useHeading = this.useHeading.bind(this);
+		this.useLightOption = this.useLightOption.bind(this);
 		this.useEditorSize = this.useEditorSize.bind(this);
 		this.disableRowMoveButtons = this.disableRowMoveButtons.bind(this);
 
@@ -1073,6 +1075,11 @@ class App extends React.Component {
 	useHeading(enabled) {
 		this.setState({ heading: enabled });
 		this.log("show heading", enabled);
+	}
+
+	useLightOption(enabled) {
+		this.setState({ light: enabled });
+		this.log("light option", enabled);
 	}
 
 	useEditorSize(editorSize) {
@@ -1945,6 +1952,7 @@ class App extends React.Component {
 			rightFlyout: this.state.propertiesContainerType === PROPERTIES_FLYOUT,
 			applyOnBlur: this.state.applyOnBlur,
 			heading: this.state.heading,
+			light: this.state.light,
 			schemaValidation: this.state.propertiesSchemaValidation,
 			applyPropertiesWithoutEdit: this.state.applyPropertiesWithoutEdit,
 			conditionHiddenPropertyHandling: this.state.conditionHiddenPropertyHandling,
@@ -1983,6 +1991,7 @@ class App extends React.Component {
 				callbacks={callbacks}
 				customControls={[CustomToggleControl, CustomTableControl, CustomEmmeansDroplist]}
 				customConditionOps={[CustomOpMax, CustomNonEmptyListLessThan, CustomOpSyntaxCheck]}
+				light={this.state.light}
 			/>);
 
 		const commonProperties2 = (
@@ -1997,6 +2006,7 @@ class App extends React.Component {
 				callbacks={callbacks2}
 				customControls={[CustomToggleControl, CustomTableControl, CustomEmmeansDroplist]}
 				customConditionOps={[CustomOpMax, CustomOpSyntaxCheck]}
+				light={this.state.light}
 			/>);
 
 		let commonPropertiesContainer = null;
@@ -2168,6 +2178,8 @@ class App extends React.Component {
 			useDisplayAdditionalComponents: this.useDisplayAdditionalComponents,
 			heading: this.state.heading,
 			useHeading: this.useHeading,
+			light: this.state.light,
+			useLightOption: this.useLightOption,
 			useEditorSize: this.useEditorSize,
 			disableRowMoveButtons: this.disableRowMoveButtons,
 			selectedPropertiesDropdownFile: this.state.selectedPropertiesDropdownFile,

--- a/canvas_modules/harness/src/client/components/common-properties-components.jsx
+++ b/canvas_modules/harness/src/client/components/common-properties-components.jsx
@@ -93,7 +93,8 @@ class CommonPropertiesComponents extends React.Component {
 		super(props);
 		this.state = {
 			showRightFlyout: false,
-			rightFlyoutContent: null
+			rightFlyoutContent: null,
+			light: false
 		};
 
 		this.propertiesConfig = { containerType: "Custom" };
@@ -514,6 +515,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={CONTROLS_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(CONTROLS_PROPS_INFO)}
 						</div>
@@ -534,6 +536,7 @@ class CommonPropertiesComponents extends React.Component {
 								<CommonProperties
 									propertiesInfo={PANELS_PROPS_INFO}
 									propertiesConfig={this.propertiesConfig}
+									light={this.state.light}
 								/>
 								{this.renderRightFlyoutButton(PANELS_PROPS_INFO)}
 							</div>
@@ -557,6 +560,7 @@ class CommonPropertiesComponents extends React.Component {
 								<CommonProperties
 									propertiesInfo={TABS_PROPS_INFO}
 									propertiesConfig={this.propertiesConfig}
+									light={this.state.light}
 								/>
 								{this.renderRightFlyoutButton(TABS_PROPS_INFO)}
 							</div>
@@ -583,6 +587,7 @@ class CommonPropertiesComponents extends React.Component {
 								<CommonProperties
 									propertiesInfo={SUBTABS_PROPS_INFO}
 									propertiesConfig={this.propertiesConfig}
+									light={this.state.light}
 								/>
 								{this.renderRightFlyoutButton(SUBTABS_PROPS_INFO)}
 							</div>
@@ -611,6 +616,7 @@ class CommonPropertiesComponents extends React.Component {
 								<CommonProperties
 									propertiesInfo={PANEL_SELECTOR_PROPS_INFO}
 									propertiesConfig={this.propertiesConfig}
+									light={this.state.light}
 								/>
 								{this.renderRightFlyoutButton(PANEL_SELECTOR_PROPS_INFO)}
 							</div>
@@ -636,6 +642,7 @@ class CommonPropertiesComponents extends React.Component {
 								<CommonProperties
 									propertiesInfo={PANEL_SELECTOR_INSERT_PROPS_INFO}
 									propertiesConfig={this.propertiesConfig}
+									light={this.state.light}
 								/>
 								{this.renderRightFlyoutButton(PANEL_SELECTOR_INSERT_PROPS_INFO)}
 							</div>
@@ -663,6 +670,7 @@ class CommonPropertiesComponents extends React.Component {
 								<CommonProperties
 									propertiesInfo={SUMMARY_PANEL_PROPS_INFO}
 									propertiesConfig={this.propertiesConfig}
+									light={this.state.light}
 								/>
 								{this.renderRightFlyoutButton(SUMMARY_PANEL_PROPS_INFO)}
 							</div>
@@ -687,6 +695,7 @@ class CommonPropertiesComponents extends React.Component {
 									propertiesInfo={TWISTY_PANEL_PROPS_INFO}
 									callbacks={{ actionHandler: this.twistyActionHandler, controllerHandler: this.twistyControllerHandler }}
 									propertiesConfig={this.propertiesConfig}
+									light={this.state.light}
 								/>
 								{this.renderRightFlyoutButton(TWISTY_PANEL_PROPS_INFO)}
 							</div>
@@ -707,6 +716,7 @@ class CommonPropertiesComponents extends React.Component {
 								<CommonProperties
 									propertiesInfo={COLUMN_PANEL_PROPS_INFO}
 									propertiesConfig={this.propertiesConfig}
+									light={this.state.light}
 								/>
 								{this.renderRightFlyoutButton(COLUMN_PANEL_PROPS_INFO)}
 							</div>
@@ -733,6 +743,7 @@ class CommonPropertiesComponents extends React.Component {
 								<CommonProperties
 									propertiesInfo={COLUMNSELECTION_PROPS_INFO}
 									propertiesConfig={this.propertiesConfig}
+									light={this.state.light}
 								/>
 								{this.renderRightFlyoutButton(COLUMNSELECTION_PROPS_INFO)}
 							</div>
@@ -754,6 +765,7 @@ class CommonPropertiesComponents extends React.Component {
 								<CommonProperties
 									propertiesInfo={TEXT_PANEL_PROPS_INFO}
 									propertiesConfig={this.propertiesConfig}
+									light={this.state.light}
 								/>
 								{this.renderRightFlyoutButton(TEXT_PANEL_PROPS_INFO)}
 							</div>
@@ -782,6 +794,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={TEXTFIELD_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(TEXTFIELD_PROPS_INFO)}
 						</div>
@@ -800,6 +813,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={TEXTAREA_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(TEXTAREA_PROPS_INFO)}
 						</div>
@@ -825,6 +839,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={LIST_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(LIST_PROPS_INFO)}
 						</div>
@@ -843,6 +858,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={PASSWORD_FIELD_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(PASSWORD_FIELD_PROPS_INFO)}
 						</div>
@@ -876,6 +892,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={expressionInfoProps}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(expressionInfoProps)}
 						</div>
@@ -894,6 +911,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={CODE_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(CODE_PROPS_INFO)}
 						</div>
@@ -913,6 +931,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={HIDDEN_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(HIDDEN_PROPS_INFO)}
 						</div>
@@ -932,6 +951,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={READONLY_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(READONLY_PROPS_INFO)}
 						</div>
@@ -950,6 +970,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={NUMBERFIELD_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(NUMBERFIELD_PROPS_INFO)}
 						</div>
@@ -967,6 +988,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={NUMBERFIELD_GENERATOR_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(NUMBERFIELD_GENERATOR_PROPS_INFO)}
 						</div>
@@ -991,6 +1013,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={SPINNER_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(SPINNER_PROPS_INFO)}
 						</div>
@@ -1017,6 +1040,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={DATEFIELD_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(DATEFIELD_PROPS_INFO)}
 						</div>
@@ -1045,6 +1069,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={TIMEFIELD_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(TIMEFIELD_PROPS_INFO)}
 						</div>
@@ -1065,6 +1090,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={CHECKBOX_SINGLE_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(CHECKBOX_SINGLE_PROPS_INFO)}
 						</div>
@@ -1086,6 +1112,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={CHECKBOX_SET_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(CHECKBOX_SET_PROPS_INFO)}
 						</div>
@@ -1109,6 +1136,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={RADIOSET_HORIZONTAL_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(RADIOSET_HORIZONTAL_PROPS_INFO)}
 						</div>
@@ -1125,6 +1153,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={RADIOSET_VERTICAL_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(RADIOSET_VERTICAL_PROPS_INFO)}
 						</div>
@@ -1146,6 +1175,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={ONEOFSELECT_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(ONEOFSELECT_PROPS_INFO)}
 						</div>
@@ -1164,6 +1194,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={ONEOFSELECT_CUSTOM_VALUE_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(ONEOFSELECT_CUSTOM_VALUE_PROPS_INFO)}
 						</div>
@@ -1186,6 +1217,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={FORCED_RADIOSET_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(FORCED_RADIOSET_PROPS_INFO)}
 						</div>
@@ -1209,6 +1241,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={MULTISELECT_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(MULTISELECT_PROPS_INFO)}
 						</div>
@@ -1225,6 +1258,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={MULTISELECT_FILTERABLE_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(MULTISELECT_FILTERABLE_PROPS_INFO)}
 						</div>
@@ -1252,6 +1286,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={SOMEOFSELECT_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(SOMEOFSELECT_PROPS_INFO)}
 						</div>
@@ -1273,6 +1308,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={FORCED_CHECKBOX_SET_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(FORCED_CHECKBOX_SET_PROPS_INFO)}
 						</div>
@@ -1297,6 +1333,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={SELECTSCHEMA_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(SELECTSCHEMA_PROPS_INFO)}
 						</div>
@@ -1322,6 +1359,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={SELECTCOLUMN_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(SELECTCOLUMN_PROPS_INFO)}
 						</div>
@@ -1346,6 +1384,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={SELECTCOLUMN_MULTI_INPUT_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(SELECTCOLUMN_MULTI_INPUT_PROPS_INFO)}
 						</div>
@@ -1370,6 +1409,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={SELECTCOLUMNS_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(SELECTCOLUMNS_PROPS_INFO)}
 						</div>
@@ -1392,6 +1432,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={SELECTCOLUMNS_MULTI_INPUT_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(SELECTCOLUMNS_MULTI_INPUT_PROPS_INFO)}
 						</div>
@@ -1412,6 +1453,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={TOGGLETEXT_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(TOGGLETEXT_PROPS_INFO)}
 						</div>
@@ -1429,6 +1471,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={TOGGLETEXTICONS_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(TOGGLETEXTICONS_PROPS_INFO)}
 						</div>
@@ -1485,6 +1528,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={STRUCTURETABLE_INLINE_TOGGLE_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(STRUCTURETABLE_INLINE_TOGGLE_PROPS_INFO)}
 						</div>
@@ -1509,6 +1553,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={STRUCTURELISTEDITOR_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(STRUCTURELISTEDITOR_PROPS_INFO)}
 						</div>
@@ -1538,6 +1583,7 @@ class CommonPropertiesComponents extends React.Component {
 								propertiesInfo={READONLYTABLE_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
 								callbacks={this.callbacks}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(READONLYTABLE_PROPS_INFO)}
 						</div>
@@ -1569,6 +1615,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={STRUCTURETABLE_INLINE_DROPDOWN_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(STRUCTURETABLE_INLINE_DROPDOWN_PROPS_INFO)}
 						</div>
@@ -1586,6 +1633,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={STRUCTURETABLE_INLINE_TEXTFIELD_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(STRUCTURETABLE_INLINE_TEXTFIELD_PROPS_INFO)}
 						</div>
@@ -1604,6 +1652,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={STRUCTURETABLE_SUBPANEL_TEXTFIELD_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(STRUCTURETABLE_SUBPANEL_TEXTFIELD_PROPS_INFO)}
 						</div>
@@ -1634,6 +1683,7 @@ class CommonPropertiesComponents extends React.Component {
 								<CommonProperties
 									propertiesInfo={STRUCTURETABLE_ONPANEL_EXPRESSION_PROPS_INFO}
 									propertiesConfig={this.propertiesConfig}
+									light={this.state.light}
 								/>
 								{this.renderRightFlyoutButton(STRUCTURETABLE_ONPANEL_EXPRESSION_PROPS_INFO)}
 							</div>
@@ -1656,6 +1706,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={STRUCTURETABLE_MOVEABLE_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(STRUCTURETABLE_MOVEABLE_PROPS_INFO)}
 						</div>
@@ -1679,6 +1730,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={STRUCTURETABLE_ROW_SELECTION_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(STRUCTURETABLE_ROW_SELECTION_PROPS_INFO)}
 						</div>
@@ -1702,6 +1754,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={STRUCTURELISTEDITOR_ADDREMOVEROWS_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(STRUCTURELISTEDITOR_ADDREMOVEROWS_PROPS_INFO)}
 						</div>
@@ -1730,6 +1783,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={STRUCTURETABLE_SORTABLE_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(STRUCTURETABLE_SORTABLE_PROPS_INFO)}
 						</div>
@@ -1757,6 +1811,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={STRUCTURETABLE_FILTERABLE_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(STRUCTURETABLE_FILTERABLE_PROPS_INFO)}
 						</div>
@@ -1798,6 +1853,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={SUMMARY_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(SUMMARY_PROPS_INFO)}
 						</div>
@@ -1817,6 +1873,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={STRUCTURETABLE_GENERATED_VALUES_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(STRUCTURETABLE_GENERATED_VALUES_PROPS_INFO)}
 						</div>
@@ -1835,6 +1892,7 @@ class CommonPropertiesComponents extends React.Component {
 							<CommonProperties
 								propertiesInfo={STRUCTURETABLE_GENERATED_VALUES_DEFAULT_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(STRUCTURETABLE_GENERATED_VALUES_DEFAULT_PROPS_INFO)}
 						</div>
@@ -1867,6 +1925,7 @@ class CommonPropertiesComponents extends React.Component {
 								propertiesInfo={ACTION_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
 								callbacks={{ actionHandler: this.actionHandler, controllerHandler: this.controllerHandler }}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(ACTION_PROPS_INFO)}
 						</div>
@@ -1887,6 +1946,7 @@ class CommonPropertiesComponents extends React.Component {
 								propertiesInfo={ACTION_IMAGE_PROPS_INFO}
 								propertiesConfig={this.propertiesConfig}
 								callbacks={{ actionHandler: this.actionHandler, controllerHandler: this.controllerHandler }}
+								light={this.state.light}
 							/>
 							{this.renderRightFlyoutButton(ACTION_IMAGE_PROPS_INFO)}
 						</div>

--- a/canvas_modules/harness/src/client/components/sidepanel-properties.jsx
+++ b/canvas_modules/harness/src/client/components/sidepanel-properties.jsx
@@ -53,6 +53,7 @@ export default class SidePanelModal extends React.Component {
 		this.useExpressionBuilder = this.useExpressionBuilder.bind(this);
 		this.useDisplayAdditionalComponents = this.useDisplayAdditionalComponents.bind(this);
 		this.useHeading = this.useHeading.bind(this);
+		this.useLightOption = this.useLightOption.bind(this);
 		this.useEditorSize = this.useEditorSize.bind(this);
 		this.getSelectedFile = this.getSelectedFile.bind(this);
 		this.disableRowMoveButtons = this.disableRowMoveButtons.bind(this);
@@ -159,6 +160,10 @@ export default class SidePanelModal extends React.Component {
 
 	useHeading(checked) {
 		this.props.propertiesConfig.useHeading(checked);
+	}
+
+	useLightOption(checked) {
+		this.props.propertiesConfig.useLightOption(checked);
 	}
 
 	useEditorSize(evt) {
@@ -356,6 +361,17 @@ export default class SidePanelModal extends React.Component {
 			</div>
 		);
 
+		const useLightOption = (
+			<div className="harness-sidepanel-children" id="sidepanel-properties-light">
+				<Toggle
+					id="harness-sidepanel-light-toggle"
+					labelText="Enable light option"
+					toggled={ this.props.propertiesConfig.light }
+					onToggle={ this.useLightOption }
+				/>
+			</div>
+		);
+
 		const editorSizes = [
 			{
 				id: EDITOR_SIZE.UNSET,
@@ -450,6 +466,8 @@ export default class SidePanelModal extends React.Component {
 				{divider}
 				{useHeading}
 				{divider}
+				{useLightOption}
+				{divider}
 				{persistEditorSize}
 				{divider}
 				{conditionHiddenPropertyHandling}
@@ -485,6 +503,8 @@ SidePanelModal.propTypes = {
 		setPropertiesDropdownSelect: PropTypes.func,
 		heading: PropTypes.bool,
 		useHeading: PropTypes.func,
+		light: PropTypes.bool,
+		useLightOption: PropTypes.func,
 		useEditorSize: PropTypes.func,
 		disableRowMoveButtons: PropTypes.func,
 		enablePropertiesSchemaValidation: PropTypes.func,


### PR DESCRIPTION
Fixes https://github.com/elyra-ai/canvas/issues/628

Enable light option toggle in test harness -
<img width="262" alt="Screen Shot 2021-04-15 at 2 11 45 PM" src="https://user-images.githubusercontent.com/25124000/114939445-4bd91b80-9df5-11eb-9027-77400c839304.png">

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

