### PR TITLE
#693 ReadonlyTable with single row selection is non-interactive

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/readonlytable-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/readonlytable-test.js
@@ -179,6 +179,18 @@ describe("readonlytable control renders correctly", () => {
 			.find(".ReactVirtualized__Table");
 		expect(table.props()).to.have.property("aria-label", "ReadonlyTable - structurelisteditor");
 	});
+
+	it("`readonlytable` control with single row selection should be non-interactive", () => {
+		const tables = propertyUtils.openSummaryPanel(wrapper, "readonlyTable-summary-panel");
+		const table = tables
+			.find("div[data-id='properties-ft-readonlyStructurelistTableControl']")
+			.find(".properties-vt-autosizer")
+			.find(".ReactVirtualized__Table");
+		const rows = table.find("div[data-role='properties-data-row']");
+		rows.forEach((row) => {
+			expect(row.hasClass("properties-vt-row-non-interactive")).to.equal(true);
+		});
+	});
 });
 
 describe("readonlytable control conditions", () => {

--- a/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
@@ -329,7 +329,7 @@ class FlexibleTable extends React.Component {
 					this.setState({ checkedAllRows: false });
 				}
 				this.props.updateRowSelections(current);
-			} else if (this.props.rowSelection === ROW_SELECTION.SINGLE) { // Table row is clicked
+			} else if (this.props.rowSelection === ROW_SELECTION.SINGLE && typeof this.props.updateRowSelections !== "undefined") { // Table row is clicked
 				this.props.updateRowSelections(data.index, evt, this.props.data[data.index].rowKey);
 			}
 		}

--- a/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
@@ -293,7 +293,8 @@ class VirtualizedTable extends React.Component {
 			<div
 				className={classNames(className,
 					{ "properties-vt-row-selected": selectedRow },
-					{ "properties-vt-row-disabled": rowDisabled }
+					{ "properties-vt-row-disabled": rowDisabled },
+					{ "properties-vt-row-non-interactive": !this.props.selectable } // ReadonlyTable with single row selection is non-interactive.
 				)}
 				data-role="properties-data-row"
 				role="row"

--- a/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.scss
@@ -87,7 +87,8 @@ $properties-vt-checkbox-width: 45px;
 		line-height: 20px;
 		border-bottom: 1px solid $ui-03;
 
-		&:hover {
+		&:hover:not(.properties-vt-row-non-interactive) {
+			// ReadonlyTable with single row selection is non-interactive. Nothing should happen on hover
 			background-color: $hover-row;
 		}
 

--- a/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.jsx
@@ -631,8 +631,13 @@ export default class AbstractTable extends React.Component {
 			delete this.scrollToRow;
 		}
 
-		const rowClickCallback = this.props.control.rowSelection === ROW_SELECTION.SINGLE ? this.handleRowClick : this.updateRowSelections;
 		const tableLabel = (this.props.control.label && this.props.control.label.text) ? this.props.control.label.text : "";
+		// ReadonlyTable with single row selection is non-interactive. rowClickCallback should be undefined.
+		let rowClickCallback;
+		const singleRowSelectionReadonlyTable = this.isReadonlyTable() && this.props.control.rowSelection === ROW_SELECTION.SINGLE;
+		if (!singleRowSelectionReadonlyTable) {
+			rowClickCallback = this.props.control.rowSelection === ROW_SELECTION.SINGLE ? this.handleRowClick : this.updateRowSelections;
+		}
 
 		const table =	(
 			<FlexibleTable


### PR DESCRIPTION
Fixes https://github.com/elyra-ai/canvas/issues/693

For readonlyTable with single row selection, setting `selectable = false` in `virtualized-table.jsx`. 
Nothing should happen when the user hovers or clicks directly on the readonlyTable.
![readonlytable-non-interactive](https://user-images.githubusercontent.com/25124000/123683171-c1536600-d800-11eb-90bd-4222928e2b95.gif)

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

