### PR TITLE
#731 Align elyra tooltip with carbon tooltip

### DIFF
--- a/canvas_modules/common-canvas/src/common-canvas/common-canvas.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/common-canvas.jsx
@@ -268,7 +268,7 @@ class CommonCanvas extends React.Component {
 			that.tipOpening = true;
 			that.setState({ tipDef: tipDef });
 			that.tipOpening = false;
-		}, tipDef.delay ? tipDef.delay : 750);
+		}, 0);
 	}
 
 	closeTip() {

--- a/canvas_modules/common-canvas/src/common-properties/actions/button/button.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/actions/button/button.jsx
@@ -70,7 +70,7 @@ class ButtonAction extends React.Component {
 			display = (<Tooltip
 				id={tooltipId}
 				tip={tooltip}
-				direction="top"
+				direction="bottom"
 				delay={TOOL_TIP_DELAY}
 				className="properties-tooltips"
 				disable={disabled}

--- a/canvas_modules/common-canvas/src/common-properties/actions/button/button.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/actions/button/button.jsx
@@ -18,7 +18,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Button } from "carbon-components-react";
-import { STATES, TOOL_TIP_DELAY } from "./../../constants/constants.js";
+import { STATES } from "./../../constants/constants.js";
 import Tooltip from "./../../../tooltip/tooltip.jsx";
 import classNames from "classnames";
 import { v4 as uuid4 } from "uuid";
@@ -71,7 +71,6 @@ class ButtonAction extends React.Component {
 				id={tooltipId}
 				tip={tooltip}
 				direction="bottom"
-				delay={TOOL_TIP_DELAY}
 				className="properties-tooltips"
 				disable={disabled}
 			>

--- a/canvas_modules/common-canvas/src/common-properties/actions/image/image.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/actions/image/image.jsx
@@ -78,7 +78,7 @@ class ImageAction extends React.Component {
 			display = (<Tooltip
 				id={tooltipId}
 				tip={tooltip}
-				direction="top"
+				direction="bottom"
 				delay={TOOL_TIP_DELAY}
 				className="properties-tooltips"
 				disable={disabled}

--- a/canvas_modules/common-canvas/src/common-properties/actions/image/image.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/actions/image/image.jsx
@@ -17,7 +17,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { STATES, TOOL_TIP_DELAY } from "./../../constants/constants.js";
+import { STATES } from "./../../constants/constants.js";
 import Tooltip from "./../../../tooltip/tooltip.jsx";
 import classNames from "classnames";
 import { v4 as uuid4 } from "uuid";
@@ -79,7 +79,6 @@ class ImageAction extends React.Component {
 				id={tooltipId}
 				tip={tooltip}
 				direction="bottom"
-				delay={TOOL_TIP_DELAY}
 				className="properties-tooltips"
 				disable={disabled}
 			>

--- a/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.jsx
@@ -18,7 +18,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import classNames from "classnames";
-import { STATES, TOOL_TIP_DELAY_ICON, CARBON_ICONS } from "./../../constants/constants.js";
+import { STATES, CARBON_ICONS } from "./../../constants/constants.js";
 import { ControlType } from "./../../constants/form-constants";
 import { Button } from "carbon-components-react";
 import Tooltip from "./../../../tooltip/tooltip.jsx";
@@ -63,7 +63,6 @@ class ControlItem extends React.Component {
 						id={`${this.uuid}-tooltip-label-${this.props.control.name}`}
 						tip={this.props.control.description.text}
 						direction="bottom"
-						delay={TOOL_TIP_DELAY_ICON}
 						disable={hidden || disabled}
 						showToolTipOnClick
 					>

--- a/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.jsx
@@ -62,9 +62,10 @@ class ControlItem extends React.Component {
 					tooltip = (<Tooltip
 						id={`${this.uuid}-tooltip-label-${this.props.control.name}`}
 						tip={this.props.control.description.text}
-						direction="top"
+						direction="bottom"
 						delay={TOOL_TIP_DELAY_ICON}
 						disable={hidden || disabled}
+						showToolTipOnClick
 					>
 						<Icon type={CARBON_ICONS.INFORMATION} className="properties-control-description-icon-info" />
 					</Tooltip>);

--- a/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.scss
@@ -66,6 +66,7 @@
 		width: 16px;
 		height: 16px;
 		margin-left: $spacing-03;
+		cursor: pointer;
 	}
 }
 

--- a/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.scss
@@ -65,7 +65,7 @@
 		display: flex;
 		width: 16px;
 		height: 16px;
-		margin-left: $spacing-02;
+		margin-left: $spacing-03;
 	}
 }
 

--- a/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
@@ -24,7 +24,7 @@ import * as PropertyUtils from "./../../util/property-utils";
 
 import { Button } from "carbon-components-react";
 
-import { MESSAGE_KEYS, DATA_TYPE, TOOL_TIP_DELAY, SORT_DIRECTION, ROW_SELECTION } from "./../../constants/constants";
+import { MESSAGE_KEYS, DATA_TYPE, SORT_DIRECTION, ROW_SELECTION } from "./../../constants/constants";
 import Icon from "./../../../icons/icon.jsx";
 import { ArrowLeft24, Reset24 } from "@carbon/icons-react";
 
@@ -315,7 +315,6 @@ export default class FieldPicker extends React.Component {
 					id={tooltipId}
 					tip={tooltip}
 					direction="left"
-					delay={TOOL_TIP_DELAY}
 					className="properties-tooltips"
 				>
 					<div>
@@ -377,7 +376,6 @@ export default class FieldPicker extends React.Component {
 							id={filterTooltipId}
 							tip={tooltip}
 							direction="bottom"
-							delay={TOOL_TIP_DELAY}
 							className="properties-tooltips"
 							disable={isEmpty(filter.type)}
 						>

--- a/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
@@ -376,7 +376,7 @@ export default class FieldPicker extends React.Component {
 						<Tooltip
 							id={filterTooltipId}
 							tip={tooltip}
-							direction="top"
+							direction="bottom"
 							delay={TOOL_TIP_DELAY}
 							className="properties-tooltips"
 							disable={isEmpty(filter.type)}

--- a/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
@@ -376,7 +376,7 @@ export default class FieldPicker extends React.Component {
 							id={filterTooltipId}
 							tip={tooltip}
 							direction="bottom"
-							className="properties-tooltips"
+							className="properties-tooltips icon-tooltip"
 							disable={isEmpty(filter.type)}
 						>
 							<Button

--- a/canvas_modules/common-canvas/src/common-properties/components/validation-message/validation-message.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/validation-message/validation-message.jsx
@@ -18,7 +18,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import Icon from "./../../../icons/icon.jsx";
 import Tooltip from "./../../../tooltip/tooltip.jsx";
-import { STATES, TOOL_TIP_DELAY } from "./../../constants/constants.js";
+import { STATES } from "./../../constants/constants.js";
 import classNames from "classnames";
 import { v4 as uuid4 } from "uuid";
 
@@ -38,7 +38,6 @@ export default class ValidationMessage extends React.Component {
 					id={uuid4() + "-table-cell-msg-icon"}
 					tip={this.props.messageInfo.text}
 					direction="bottom"
-					delay={TOOL_TIP_DELAY}
 					className="properties-tooltips"
 				>
 					{icon}

--- a/canvas_modules/common-canvas/src/common-properties/components/validation-message/validation-message.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/validation-message/validation-message.jsx
@@ -37,7 +37,7 @@ export default class ValidationMessage extends React.Component {
 				<Tooltip
 					id={uuid4() + "-table-cell-msg-icon"}
 					tip={this.props.messageInfo.text}
-					direction="top"
+					direction="bottom"
 					delay={TOOL_TIP_DELAY}
 					className="properties-tooltips"
 				>

--- a/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
@@ -20,7 +20,7 @@ import { Column, Table } from "react-virtualized/dist/commonjs/Table";
 import { Checkbox, Loading } from "carbon-components-react";
 import Icon from "./../../../icons/icon.jsx";
 import Tooltip from "./../../../tooltip/tooltip.jsx";
-import { TOOL_TIP_DELAY, SORT_DIRECTION, STATES, ROW_SELECTION, CARBON_ICONS } from "./../../constants/constants";
+import { SORT_DIRECTION, STATES, ROW_SELECTION, CARBON_ICONS } from "./../../constants/constants";
 import { injectIntl } from "react-intl";
 import defaultMessages from "../../../../locales/common-properties/locales/en.json";
 
@@ -202,7 +202,6 @@ class VirtualizedTable extends React.Component {
 					id={tooltipId}
 					tip={tooltip}
 					direction="bottom"
-					delay={TOOL_TIP_DELAY}
 					className="properties-tooltips"
 				>
 					{label}

--- a/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
@@ -201,7 +201,7 @@ class VirtualizedTable extends React.Component {
 				: <Tooltip
 					id={tooltipId}
 					tip={tooltip}
-					direction="top"
+					direction="bottom"
 					delay={TOOL_TIP_DELAY}
 					className="properties-tooltips"
 				>

--- a/canvas_modules/common-canvas/src/common-properties/constants/constants.js
+++ b/canvas_modules/common-canvas/src/common-properties/constants/constants.js
@@ -148,9 +148,6 @@ _defineConstant("ELLIPSIS_STRING", "...");
 
 _defineConstant("DISPLAY_CHARS_DEFAULT", 64);
 
-_defineConstant("TOOL_TIP_DELAY", 1000);
-_defineConstant("TOOL_TIP_DELAY_ICON", 500);
-
 _defineConstant("STATES", {
 	VISIBLE: "visible",
 	HIDDEN: "hidden",

--- a/canvas_modules/common-canvas/src/common-properties/controls/checkbox/checkbox.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/checkbox/checkbox.jsx
@@ -51,7 +51,7 @@ class CheckboxControl extends React.Component {
 			<Tooltip
 				id={tooltipId}
 				tip={tooltip}
-				direction="top"
+				direction="bottom"
 				delay={TOOL_TIP_DELAY}
 				className="properties-tooltips"
 			>

--- a/canvas_modules/common-canvas/src/common-properties/controls/checkbox/checkbox.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/checkbox/checkbox.jsx
@@ -53,6 +53,7 @@ class CheckboxControl extends React.Component {
 				tip={tooltip}
 				direction="bottom"
 				className="properties-tooltips"
+				showToolTipOnClick
 			>
 				<Icon type={CARBON_ICONS.INFORMATION} className="properties-control-description-icon-info" />
 			</Tooltip>
@@ -60,7 +61,6 @@ class CheckboxControl extends React.Component {
 		const checkboxLabel = (
 			<span className="properties-checkbox-label">
 				{label}
-				{tooltipIcon}
 			</span>
 		);
 		return (
@@ -75,6 +75,7 @@ class CheckboxControl extends React.Component {
 					checked={Boolean(this.props.value)}
 					hideLabel={this.props.tableControl}
 				/>
+				{tooltipIcon}
 				<ValidationMessage inTable={this.props.tableControl} state={this.props.state} messageInfo={this.props.controller.getErrorMessage(this.props.propertyId)} />
 			</div>
 		);

--- a/canvas_modules/common-canvas/src/common-properties/controls/checkbox/checkbox.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/checkbox/checkbox.jsx
@@ -21,7 +21,7 @@ import { isEmpty } from "lodash";
 import { Checkbox } from "carbon-components-react";
 import ValidationMessage from "./../../components/validation-message";
 import * as ControlUtils from "./../../util/control-utils";
-import { TOOL_TIP_DELAY, STATES, CARBON_ICONS } from "./../../constants/constants.js";
+import { STATES, CARBON_ICONS } from "./../../constants/constants.js";
 import Tooltip from "./../../../tooltip/tooltip.jsx";
 import { v4 as uuid4 } from "uuid";
 import classNames from "classnames";
@@ -52,7 +52,6 @@ class CheckboxControl extends React.Component {
 				id={tooltipId}
 				tip={tooltip}
 				direction="bottom"
-				delay={TOOL_TIP_DELAY}
 				className="properties-tooltips"
 			>
 				<Icon type={CARBON_ICONS.INFORMATION} className="properties-control-description-icon-info" />

--- a/canvas_modules/common-canvas/src/common-properties/controls/checkbox/checkbox.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/checkbox/checkbox.scss
@@ -15,6 +15,17 @@
  */
 
 .properties-checkbox {
+	display: flex;
+	align-items: center;
+	.tooltip-container {
+		margin-left: $spacing-02;
+		.tooltip-trigger {
+			display: flex;
+		}
+	}
+	.bx--form-item.bx--checkbox-wrapper {
+		flex: initial; // override carbon style to show tooltipIcon next to checkbox label
+	}
 	&.hide {
 		display: none;
 	}
@@ -23,15 +34,5 @@
 	.bx--form-item.bx--checkbox-wrapper:first-of-type {
 		margin-top: 0;
 		padding: 1px; // Allow space for checkbox borders to show when embedded within a table.
-	}
-}
-.properties-checkbox-label {
-	display: flex;
-	align-items: center;
-	.tooltip-container {
-		margin-left: $spacing-02;
-		.tooltip-trigger {
-			display: flex;
-		}
 	}
 }

--- a/canvas_modules/common-canvas/src/common-properties/controls/checkbox/checkbox.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/checkbox/checkbox.scss
@@ -19,7 +19,8 @@
 	align-items: center;
 	flex-wrap: wrap;
 	.tooltip-container {
-		margin-left: $spacing-02;
+		margin-left: $spacing-03;
+		cursor: pointer;
 		.tooltip-trigger {
 			display: flex;
 		}

--- a/canvas_modules/common-canvas/src/common-properties/controls/checkbox/checkbox.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/checkbox/checkbox.scss
@@ -17,6 +17,7 @@
 .properties-checkbox {
 	display: flex;
 	align-items: center;
+	flex-wrap: wrap;
 	.tooltip-container {
 		margin-left: $spacing-02;
 		.tooltip-trigger {
@@ -25,6 +26,9 @@
 	}
 	.bx--form-item.bx--checkbox-wrapper {
 		flex: initial; // override carbon style to show tooltipIcon next to checkbox label
+	}
+	.properties-validation-message {
+		flex: 0 1 100%;
 	}
 	&.hide {
 		display: none;

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-operator.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-operator.jsx
@@ -18,7 +18,6 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Button } from "carbon-components-react";
 
-import { TOOL_TIP_DELAY } from "./../../../constants/constants";
 import Tooltip from "./../../../../tooltip/tooltip";
 import { v4 as uuid4 } from "uuid";
 import classNames from "classnames";
@@ -48,7 +47,6 @@ export default class ExpressionSelectOperator extends React.Component {
 							id={tooltipId}
 							tip={tooltip}
 							direction="left"
-							delay={TOOL_TIP_DELAY}
 							className="properties-tooltips"
 						>
 							<Button

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-operator.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-operator.jsx
@@ -46,7 +46,7 @@ export default class ExpressionSelectOperator extends React.Component {
 						<Tooltip
 							id={tooltipId}
 							tip={tooltip}
-							direction="left"
+							direction="bottom"
 							className="properties-tooltips"
 						>
 							<Button

--- a/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.jsx
@@ -19,7 +19,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import * as ControlUtils from "./../../util/control-utils";
 import ValidationMessage from "./../../components/validation-message";
-import { STATES, TOOL_TIP_DELAY, DATA_TYPE } from "./../../constants/constants";
+import { STATES, DATA_TYPE } from "./../../constants/constants";
 import Tooltip from "./../../../tooltip/tooltip";
 import Icon from "./../../../icons/icon";
 import { v4 as uuid4 } from "uuid";
@@ -120,7 +120,6 @@ class ReadonlyControl extends React.Component {
 				id={tooltipId}
 				tip={tooltip}
 				direction="bottom"
-				delay={TOOL_TIP_DELAY}
 				className="properties-tooltips"
 				disable={disabled}
 				showToolTipIfTruncated

--- a/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.jsx
@@ -119,7 +119,7 @@ class ReadonlyControl extends React.Component {
 			display = (<Tooltip
 				id={tooltipId}
 				tip={tooltip}
-				direction="top"
+				direction="bottom"
 				delay={TOOL_TIP_DELAY}
 				className="properties-tooltips"
 				disable={disabled}

--- a/canvas_modules/common-canvas/src/common-properties/controls/textarea/textarea.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/textarea/textarea.jsx
@@ -22,7 +22,7 @@ import ValidationMessage from "./../../components/validation-message";
 import * as ControlUtils from "./../../util/control-utils";
 import { formatMessage } from "./../../util/property-utils";
 import { STATES } from "./../../constants/constants.js";
-import { TOOL_TIP_DELAY, CONDITION_MESSAGE_TYPE, MESSAGE_KEYS, TRUNCATE_LIMIT } from "./../../constants/constants.js";
+import { CONDITION_MESSAGE_TYPE, MESSAGE_KEYS, TRUNCATE_LIMIT } from "./../../constants/constants.js";
 import classNames from "classnames";
 import Tooltip from "./../../../tooltip/tooltip.jsx";
 import { v4 as uuid4 } from "uuid";
@@ -102,7 +102,6 @@ class TextareaControl extends React.Component {
 				id={tooltipId}
 				tip={tooltip}
 				direction="bottom"
-				delay={TOOL_TIP_DELAY}
 				className="properties-tooltips"
 				disable={disabled}
 			>

--- a/canvas_modules/common-canvas/src/common-properties/controls/textarea/textarea.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/textarea/textarea.jsx
@@ -101,7 +101,7 @@ class TextareaControl extends React.Component {
 			display = (<Tooltip
 				id={tooltipId}
 				tip={tooltip}
-				direction="top"
+				direction="bottom"
 				delay={TOOL_TIP_DELAY}
 				className="properties-tooltips"
 				disable={disabled}

--- a/canvas_modules/common-canvas/src/common-properties/controls/textfield/textfield.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/textfield/textfield.jsx
@@ -119,7 +119,7 @@ class TextfieldControl extends React.Component {
 			display = (<Tooltip
 				id={tooltipId}
 				tip={tooltip}
-				direction="top"
+				direction="bottom"
 				delay={TOOL_TIP_DELAY}
 				className="properties-tooltips"
 				disable={disabled}

--- a/canvas_modules/common-canvas/src/common-properties/controls/textfield/textfield.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/textfield/textfield.jsx
@@ -23,7 +23,7 @@ import ValidationMessage from "./../../components/validation-message";
 import * as ControlUtils from "./../../util/control-utils";
 import { formatMessage } from "./../../util/property-utils";
 import { STATES } from "./../../constants/constants.js";
-import { TOOL_TIP_DELAY, CONDITION_MESSAGE_TYPE, MESSAGE_KEYS, TRUNCATE_LIMIT } from "./../../constants/constants.js";
+import { CONDITION_MESSAGE_TYPE, MESSAGE_KEYS, TRUNCATE_LIMIT } from "./../../constants/constants.js";
 import Tooltip from "./../../../tooltip/tooltip.jsx";
 import classNames from "classnames";
 import { v4 as uuid4 } from "uuid";
@@ -120,7 +120,6 @@ class TextfieldControl extends React.Component {
 				id={tooltipId}
 				tip={tooltip}
 				direction="bottom"
-				delay={TOOL_TIP_DELAY}
 				className="properties-tooltips"
 				disable={disabled}
 			>

--- a/canvas_modules/common-canvas/src/common-properties/panels/sub-panel/cell.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/sub-panel/cell.jsx
@@ -23,7 +23,6 @@ import Tooltip from "./../../../tooltip/tooltip.jsx";
 import { cloneDeep } from "lodash";
 
 import { MESSAGE_KEYS } from "./../../constants/constants";
-import { TOOL_TIP_DELAY } from "./../../constants/constants.js";
 
 
 import SubPanelInvoker from "./invoker.jsx";
@@ -73,7 +72,6 @@ export default class SubPanelCell extends React.Component {
 						id={uuid4() + "-" + tooltipId}
 						tip={subPanelToolTip}
 						direction="left"
-						delay={TOOL_TIP_DELAY}
 						className="properties-tooltips"
 					>
 						<Button

--- a/canvas_modules/common-canvas/src/common-properties/panels/sub-panel/cell.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/sub-panel/cell.jsx
@@ -72,7 +72,7 @@ export default class SubPanelCell extends React.Component {
 						id={uuid4() + "-" + tooltipId}
 						tip={subPanelToolTip}
 						direction="left"
-						className="properties-tooltips"
+						className="properties-tooltips icon-tooltip"
 					>
 						<Button
 							className="properties-subpanel-button"

--- a/canvas_modules/common-canvas/src/toolbar/toolbar-action-item.jsx
+++ b/canvas_modules/common-canvas/src/toolbar/toolbar-action-item.jsx
@@ -139,7 +139,7 @@ class ToolbarActionItem extends React.Component {
 			const tooltipId = actionName + "-" + this.props.instanceId + "-tooltip";
 
 			return (
-				<Tooltip id={tooltipId} tip={tipText} disable={false} >
+				<Tooltip id={tooltipId} tip={tipText} disable={false} className="icon-tooltip" >
 					{content}
 				</Tooltip>
 			);

--- a/canvas_modules/common-canvas/src/tooltip/tooltip-wrapper.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip-wrapper.jsx
@@ -134,7 +134,6 @@ export default class TooltipWrapper extends React.Component {
 			id={this.props.id}
 			targetObj={this.props.targetObj}
 			mousePos={this.props.mousePos}
-			delay={0}
 		/>) : null;
 	}
 }

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
@@ -29,15 +29,18 @@ class ToolTip extends React.Component {
 		};
 
 		this.pendingTooltip = null;
+		this.hideTooltipOnScroll = this.hideTooltipOnScroll.bind(this);
 	}
 
 	componentDidMount() {
+		window.addEventListener("scroll", this.hideTooltipOnScroll, true);
 		if (this.props.targetObj) {
 			this.setTooltipVisible(true);
 		}
 	}
 
 	componentWillUnmount() {
+		window.removeEventListener("scroll", this.hideTooltipOnScroll, true);
 		if (this.pendingTooltip) {
 			clearTimeout(this.pendingTooltip);
 		}
@@ -308,6 +311,12 @@ class ToolTip extends React.Component {
 			this.setTooltipVisible(false);
 		} else {
 			this.setTooltipVisible(true);
+		}
+	}
+
+	hideTooltipOnScroll(evt) {
+		if (this.state.isTooltipVisible) {
+			this.setTooltipVisible(false);
 		}
 	}
 

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
@@ -42,7 +42,7 @@ class ToolTip extends React.Component {
 
 	componentWillUnmount() {
 		window.removeEventListener("scroll", this.hideTooltipOnScrollAndResize, true);
-		window.addEventListener("resize", this.hideTooltipOnScrollAndResize, true);
+		window.removeEventListener("resize", this.hideTooltipOnScrollAndResize, true);
 		if (this.pendingTooltip) {
 			clearTimeout(this.pendingTooltip);
 		}

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
@@ -20,14 +20,12 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Portal } from "react-portal";
-import classNames from "classnames";
 
 class ToolTip extends React.Component {
 	constructor(props) {
 		super(props);
 		this.state = {
-			isTooltipVisible: false,
-			singleLineTooltip: true
+			isTooltipVisible: false
 		};
 
 		this.pendingTooltip = null;
@@ -71,23 +69,7 @@ class ToolTip extends React.Component {
 					tooltipTrigger = document.querySelector("[data-id='" + this.props.id + "-trigger']");
 				}
 				if (tooltipTrigger && tooltip) {
-					if (tooltip.offsetHeight > 20 && this.state.singleLineTooltip) {
-						// Multi-line tooltips
-						this.setState({ singleLineTooltip: false }, () => {
-							this.updateTooltipLayout(tooltip, tooltipTrigger, tooltip.getAttribute("direction"));
-						});
-					} else if (tooltip.offsetHeight <= 48 && !this.state.singleLineTooltip) {
-						// tooltip.offsetHeight <= 48 is a 2 line tooltip. It is possible 2nd line contains a single word.
-						// Right flyout panel is resizable. Tooltip is a 2 line tooltip when flyout size is "small".
-						// When right flyout panel is resized to "medium" or "large" and tooltip width is smaller than max-width of .common-canvas-tooltip,
-						// tooltip becomes a single line tooltip.
-						this.setState({ singleLineTooltip: true }, () => {
-							this.updateTooltipLayout(tooltip, tooltipTrigger, tooltip.getAttribute("direction"));
-						});
-					} else {
-						// Single line tooltips
-						this.updateTooltipLayout(tooltip, tooltipTrigger, tooltip.getAttribute("direction"));
-					}
+					this.updateTooltipLayout(tooltip, tooltipTrigger, tooltip.getAttribute("direction"));
 				}
 			}
 		}
@@ -377,14 +359,12 @@ class ToolTip extends React.Component {
 		if (this.props.className) {
 			tipClass += " " + this.props.className;
 		}
-		// Different padding for single line and multi-line tooltips
-		const tooltipLengthClass = this.state.singleLineTooltip ? "single-line-tooltip" : "multi-line-tooltip";
 
 		return (
 			<div className="tooltip-container">
 				{triggerContent}
 				<Portal>
-					<div data-id={this.props.id} className={classNames(tipClass, tooltipLengthClass)} aria-hidden={!this.state.isTooltipVisible} direction={this.props.direction}>
+					<div data-id={this.props.id} className={tipClass} aria-hidden={!this.state.isTooltipVisible} direction={this.props.direction}>
 						<svg id="tipArrow" x="0px" y="0px" viewBox="0 0 9.1 16.1">
 							<polyline points="9.1,15.7 1.4,8.1 9.1,0.5" />
 							<polygon points="8.1,16.1 0,8.1 8.1,0 8.1,1.4 1.4,8.1 8.1,14.7" />

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
@@ -29,18 +29,20 @@ class ToolTip extends React.Component {
 		};
 
 		this.pendingTooltip = null;
-		this.hideTooltipOnScroll = this.hideTooltipOnScroll.bind(this);
+		this.hideTooltipOnScrollAndResize = this.hideTooltipOnScrollAndResize.bind(this);
 	}
 
 	componentDidMount() {
-		window.addEventListener("scroll", this.hideTooltipOnScroll, true);
+		window.addEventListener("scroll", this.hideTooltipOnScrollAndResize, true);
+		window.addEventListener("resize", this.hideTooltipOnScrollAndResize, true);
 		if (this.props.targetObj) {
 			this.setTooltipVisible(true);
 		}
 	}
 
 	componentWillUnmount() {
-		window.removeEventListener("scroll", this.hideTooltipOnScroll, true);
+		window.removeEventListener("scroll", this.hideTooltipOnScrollAndResize, true);
+		window.addEventListener("resize", this.hideTooltipOnScrollAndResize, true);
 		if (this.pendingTooltip) {
 			clearTimeout(this.pendingTooltip);
 		}
@@ -314,7 +316,7 @@ class ToolTip extends React.Component {
 		}
 	}
 
-	hideTooltipOnScroll(evt) {
+	hideTooltipOnScrollAndResize(evt) {
 		if (this.state.isTooltipVisible) {
 			this.setTooltipVisible(false);
 		}

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
@@ -325,7 +325,13 @@ class ToolTip extends React.Component {
 				// click event shouldn't call onBlur
 				evt.stopPropagation();
 				evt.preventDefault();
-				this.showTooltipWithDelay();
+				if (this.state.showToolTip) {
+					// Tooltip is visible, clicked on i icon again -> hide tooltip
+					this.setTooltipVisible(false);
+				} else {
+					// Tooltip is hidden
+					this.setTooltipVisible(true);
+				}
 			};
 
 			triggerContent = (<div

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
@@ -329,7 +329,13 @@ class ToolTip extends React.Component {
 			// when children are passed in, tooltip will handle show/hide, otherwise consumer has to hide show/hide tooltip
 			const mouseover = () => this.setTooltipVisible(true);
 			const mouseleave = () => this.setTooltipVisible(false);
-			const mousedown = () => this.setTooltipVisible(false);
+			const mousedown = (evt) => {
+				// Hide tooltip after clicking (mousedown) on toolbar icons, node, palette category
+				// After `mousedown` event is complete, `focus` event occurs which shows the tooltip.
+				// Using preventDefault to make sure `focus` event is not triggered.
+				evt.preventDefault();
+				this.setTooltipVisible(false);
+			};
 			// `focus` event occurs before `click`. Adding timeout in onFocus function to ensure click is executed first.
 			// Ref - https://stackoverflow.com/a/49512400
 			const onFocus = () => this.showTooltipWithDelay();

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
@@ -329,13 +329,7 @@ class ToolTip extends React.Component {
 			// when children are passed in, tooltip will handle show/hide, otherwise consumer has to hide show/hide tooltip
 			const mouseover = () => this.setTooltipVisible(true);
 			const mouseleave = () => this.setTooltipVisible(false);
-			const mousedown = (evt) => {
-				// Hide tooltip after clicking (mousedown) on toolbar icons, node, palette category
-				// After `mousedown` event is complete, `focus` event occurs which shows the tooltip.
-				// Using preventDefault to make sure `focus` event is not triggered.
-				evt.preventDefault();
-				this.setTooltipVisible(false);
-			};
+			const mousedown = () => this.setTooltipVisible(false);
 			// `focus` event occurs before `click`. Adding timeout in onFocus function to ensure click is executed first.
 			// Ref - https://stackoverflow.com/a/49512400
 			const onFocus = () => this.showTooltipWithDelay();

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
@@ -71,13 +71,19 @@ class ToolTip extends React.Component {
 					tooltipTrigger = document.querySelector("[data-id='" + this.props.id + "-trigger']");
 				}
 				if (tooltipTrigger && tooltip) {
-					this.updateTooltipLayout(tooltip, tooltipTrigger, tooltip.getAttribute("direction"));
-					// Multi-line tooltips have offsetHeight > 20
 					if (tooltip.offsetHeight > 20 && this.state.singleLineTooltip) {
-						this.setState({ singleLineTooltip: false });
+						// Multi-line tooltips
+						this.setState({ singleLineTooltip: false }, () => {
+							this.updateTooltipLayout(tooltip, tooltipTrigger, tooltip.getAttribute("direction"));
+						});
 					} else if (tooltip.offsetHeight <= 48 && !this.state.singleLineTooltip) {
 						// Multi-line tooltip initially but after resizing right flyout panel, tooltip is in single line
-						this.setState({ singleLineTooltip: true });
+						this.setState({ singleLineTooltip: true }, () => {
+							this.updateTooltipLayout(tooltip, tooltipTrigger, tooltip.getAttribute("direction"));
+						});
+					} else {
+						// Single line tooltips
+						this.updateTooltipLayout(tooltip, tooltipTrigger, tooltip.getAttribute("direction"));
 					}
 				}
 			}
@@ -325,7 +331,6 @@ class ToolTip extends React.Component {
 		let triggerContent = null;
 		if (this.props.children) {
 			// when children are passed in, tooltip will handle show/hide, otherwise consumer has to hide show/hide tooltip
-			// If showToolTipOnClick enabled, don't show tooltip on mouseover and mouseleave
 			const mouseover = () => this.setTooltipVisible(true);
 			const mouseleave = () => this.setTooltipVisible(false);
 			const mousedown = () => this.setTooltipVisible(false);
@@ -335,6 +340,7 @@ class ToolTip extends React.Component {
 			const onBlur = () => this.setTooltipVisible(false);
 			const click = (evt) => this.toggleTooltipOnClick(evt);
 
+			// If showToolTipOnClick enabled, don't show tooltip on mouseover and mouseleave
 			triggerContent = (<div
 				tabIndex={0}
 				data-id={this.props.id + "-trigger"}

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
@@ -77,7 +77,10 @@ class ToolTip extends React.Component {
 							this.updateTooltipLayout(tooltip, tooltipTrigger, tooltip.getAttribute("direction"));
 						});
 					} else if (tooltip.offsetHeight <= 48 && !this.state.singleLineTooltip) {
-						// Multi-line tooltip initially but after resizing right flyout panel, tooltip is in single line
+						// tooltip.offsetHeight <= 48 is a 2 line tooltip. It is possible 2nd line contains a single word.
+						// Right flyout panel is resizable. Tooltip is a 2 line tooltip when flyout size is "small".
+						// When right flyout panel is resized to "medium" or "large" and tooltip width is smaller than max-width of .common-canvas-tooltip,
+						// tooltip becomes a single line tooltip.
 						this.setState({ singleLineTooltip: true }, () => {
 							this.updateTooltipLayout(tooltip, tooltipTrigger, tooltip.getAttribute("direction"));
 						});
@@ -340,7 +343,6 @@ class ToolTip extends React.Component {
 			const onBlur = () => this.setTooltipVisible(false);
 			const click = (evt) => this.toggleTooltipOnClick(evt);
 
-			// If showToolTipOnClick enabled, don't show tooltip on mouseover and mouseleave
 			triggerContent = (<div
 				tabIndex={0}
 				data-id={this.props.id + "-trigger"}

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.scss
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.scss
@@ -121,7 +121,7 @@
 	width: 12px;
 	height: 12px;
 	right: $spacing-05;
-	top: $spacing-02;
+	top: $spacing-05;
 	&.warning {
 		fill: $support-03;
 	}

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.scss
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.scss
@@ -21,20 +21,18 @@
 .common-canvas-tooltip {
 	font-size: 12px;
 	position: fixed;
-	padding: 5px 10px;
 	background-color: $inverse-02;
 	border: 1px solid $inverse-02;
 	font-weight: 400;
 	opacity: 90%;
 	color: $inverse-01;
 	line-height: 1.2;
-	text-align: center;
-	z-index: 8000;
+	text-align: left;
+	z-index: 10000; // Modal layout has z-index 9000. Show tooltip on top of modal.
 	pointer-events: none;
 	word-wrap: break-word;
 	max-width: 228px;
 	border-radius: 2px;
-	transition: opacity 0.1s ease-in-out, visibility 0.1s ease-in-out, transform 0.1s cubic-bezier(0.71, 1.7, 0.77, 1.24);
 }
 
 .common-canvas-tooltip[direction="right"] {
@@ -51,6 +49,14 @@
 
 .common-canvas-tooltip[direction="bottom"] {
 	transform: translate3d(0, -22px, 0);
+}
+
+.single-line-tooltip {
+	padding: $spacing-01 $spacing-05;
+}
+
+.multi-line-tooltip {
+	padding: $spacing-05;
 }
 
 .common-canvas-tooltip #tipArrow {
@@ -117,8 +123,8 @@
 	position: absolute;
 	width: 12px;
 	height: 12px;
-	right: 10px;
-	top: 10px;
+	right: $spacing-05;
+	top: $spacing-02;
 	&.warning {
 		fill: $support-03;
 	}

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.scss
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.scss
@@ -21,6 +21,7 @@
 .common-canvas-tooltip {
 	font-size: 12px;
 	position: fixed;
+	padding: $spacing-05;
 	background-color: $inverse-02;
 	border: 1px solid $inverse-02;
 	font-weight: 400;
@@ -51,12 +52,8 @@
 	transform: translate3d(0, -22px, 0);
 }
 
-.single-line-tooltip {
+.icon-tooltip {
 	padding: $spacing-01 $spacing-05;
-}
-
-.multi-line-tooltip {
-	padding: $spacing-05;
 }
 
 .common-canvas-tooltip #tipArrow {

--- a/canvas_modules/harness/cypress/integration/canvas/tips.js
+++ b/canvas_modules/harness/cypress/integration/canvas/tips.js
@@ -89,6 +89,40 @@ describe("Test to check if tips don't show up for the palette, nodes, ports and 
 	});
 });
 
+describe("Test to check if tips are hidden on scroll", function() {
+	beforeEach(() => {
+		cy.visit("/");
+		cy.openCanvasPalette("modelerPalette.json");
+		cy.openPropertyDefinition("action_paramDef.json");
+	});
+
+	it("Test to check if palette tips are hidden on scroll", function() {
+		cy.clickToolbarPaletteOpen();
+
+		// Open multiple categories so that palette is scrollable
+		cy.clickCategory("Import");
+		cy.clickCategory("Record Ops");
+		cy.clickCategory("Modeling");
+
+		cy.hoverOverCategory("Import");
+		cy.verifyTipForCategory("Import");
+
+		cy.get(".palette-flyout-categories")
+			.scrollTo("bottom", { ensureScrollable: false });
+		cy.verifyTipDoesNotShowForCategory("Import");
+	});
+
+	it("Test to check if properties tips are hidden on scroll", function() {
+		cy.get("div[data-id='properties-ctrl-number']")
+			.find(".tooltip-container")
+			.click();
+		cy.verifyTipForLabelIsVisibleAtLocation("Integer", "bottom", "Try pressing Increment or Descrement buttons");
+		cy.get(".properties-custom-container")
+			.scrollTo("bottom", { ensureScrollable: false });
+		cy.verifyTipForLabelIsHidden("Integer", "Try pressing Increment or Descrement buttons");
+	});
+});
+
 describe("Test changing node name to update node tip", function() {
 	beforeEach(() => {
 		cy.visit("/");

--- a/canvas_modules/harness/cypress/integration/canvas/tips.js
+++ b/canvas_modules/harness/cypress/integration/canvas/tips.js
@@ -161,12 +161,12 @@ describe("Test tip location adjusted based on boundaries of browser", function()
 	});
 
 	it("Test tip location adjusted based on boundaries of browser", function() {
-		cy.moveMouseToCoordinatesInCommonProperties(65, 100);
-		cy.verifyTipForLabelIsVisibleAtLocation("Mode", "top", "Include or discard rows");
+		cy.clickAtCoordinatesInCommonProperties(65, 100);
+		cy.verifyTipForLabelIsVisibleAtLocation("Mode", "bottom", "Include or discard rows");
 
-		cy.moveMouseToCoordinatesInCommonProperties(245, 160);
+		cy.clickAtCoordinatesInCommonProperties(245, 160);
 		cy.verifyTipForLabelIsVisibleAtLocation(
-			"Modeler CLEM Condition Expression", "top", "Enter a boolean expression to use for filtering rows"
+			"Modeler CLEM Condition Expression", "bottom", "Enter a boolean expression to use for filtering rows"
 		);
 	});
 });

--- a/canvas_modules/harness/cypress/support/canvas/verification-cmds.js
+++ b/canvas_modules/harness/cypress/support/canvas/verification-cmds.js
@@ -946,6 +946,15 @@ Cypress.Commands.add("verifyTipForNodeInCategory", (nodeName, nodeCategory) => {
 		});
 });
 
+Cypress.Commands.add("verifyTipDoesNotShowForCategory", (nodeCategory) => {
+	cy.findCategory(nodeCategory)
+		.invoke("attr", "data-id")
+		.then((dataId) => {
+			cy.get(`div[data-id='paletteTip_${dataId}']`)
+				.should("have.attr", "aria-hidden", "true");
+		});
+});
+
 Cypress.Commands.add("verifyTipDoesNotShowForNodeInCategory", (nodeName) => {
 	// Verify the tip doesn't show for node in category
 	cy.get(".tip-palette-item")

--- a/canvas_modules/harness/cypress/support/properties/properties-cmds.js
+++ b/canvas_modules/harness/cypress/support/properties/properties-cmds.js
@@ -96,9 +96,10 @@ Cypress.Commands.add("enterNewPropertiesFlyoutTitle", (newTitle) => {
 		.type(newTitle);
 });
 
-Cypress.Commands.add("moveMouseToCoordinatesInCommonProperties", (x, y) => {
+Cypress.Commands.add("clickAtCoordinatesInCommonProperties", (x, y) => {
+	// common-properties tooltip will be displayed onclick
 	cy.get(".right-flyout-panel")
-		.trigger("mouseover", x, y);
+		.trigger("click", x, y);
 });
 
 Cypress.Commands.add("getControlContainerFromName", (givenName) => {

--- a/canvas_modules/harness/cypress/support/properties/properties-verification-cmds.js
+++ b/canvas_modules/harness/cypress/support/properties/properties-verification-cmds.js
@@ -84,6 +84,32 @@ Cypress.Commands.add("verifyTipForLabelIsVisibleAtLocation", (label, tipLocation
 		});
 });
 
+/** Verify the tooltip over the given text is 'hidden'
+* @param label: label of the container shown in the UI
+* @param text: text shown in the tip
+*/
+Cypress.Commands.add("verifyTipForLabelIsHidden", (label, text) => {
+	cy.getControlContainerFromName(label)
+		.then((container) => {
+			cy.get(".common-canvas-tooltip")
+				.then((tips) => {
+					// Get the tip
+					let hiddenTip;
+					for (var idx = 0; idx < tips.length; idx++) {
+						if (tips[idx].textContent === text) {
+							hiddenTip = tips[idx];
+							break;
+						}
+					}
+
+					if (hiddenTip) {
+						// Verify tip is hidden
+						cy.wrap(hiddenTip).should("be.hidden");
+					}
+				});
+		});
+});
+
 /** Verify the tooltip over the given text in the summaryPanel is 'visible'
 * @param text: value displayed in summary panels
 * @param summaryName: name of summaryPanel

--- a/canvas_modules/harness/src/client/components/custom-canvases/explain2/explain2.scss
+++ b/canvas_modules/harness/src/client/components/custom-canvases/explain2/explain2.scss
@@ -81,8 +81,3 @@
 .tipTable > tbody > tr > td {
 	padding-right: 5px;
 }
-
-// Override the max width for common-canvas tooltips
-.common-canvas-tooltip {
-	max-width: 400px;
-}


### PR DESCRIPTION
Fixes https://github.com/elyra-ai/canvas/issues/731

- For common-properties, tooltip will be visible on clicking "i" icon.
- For common-canvas, toolbar, palette - tooltip will be visible on mouse hover. 
- Updated tooltip CSS to match with carbon. 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

