### PR TITLE
#751 Fixed toolbar tooltip issues

### DIFF
--- a/canvas_modules/common-canvas/src/toolbar/toolbar-action-item.jsx
+++ b/canvas_modules/common-canvas/src/toolbar/toolbar-action-item.jsx
@@ -137,9 +137,10 @@ class ToolbarActionItem extends React.Component {
 			const actionName = this.generateActionName();
 			const tipText = this.props.actionObj.tooltip ? this.props.actionObj.tooltip : this.props.actionObj.label;
 			const tooltipId = actionName + "-" + this.props.instanceId + "-tooltip";
+			const enableTooltip = this.props.actionObj.enable ? this.props.actionObj.enable : false;
 
 			return (
-				<Tooltip id={tooltipId} tip={tipText} disable={false} className="icon-tooltip" >
+				<Tooltip id={tooltipId} tip={tipText} disable={!enableTooltip} className="icon-tooltip" >
 					{content}
 				</Tooltip>
 			);

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
@@ -322,21 +322,12 @@ class ToolTip extends React.Component {
 		}
 	}
 
-	showTooltipOnMouseOver(evt) {
-		// closest() method traverses the Element and its parents until it finds a node that matches the provided selector string.
-		// Will return itself or the matching ancestor. If no such element exists, it returns null.
-		const toolbarItem = event.target.closest(".toolbar-item-content");
-		if (!(toolbarItem !== null && toolbarItem.classList.contains("disabled"))) {
-			this.setTooltipVisible(true);
-		}
-	}
-
 	render() {
 		let tooltipContent = null;
 		let triggerContent = null;
 		if (this.props.children) {
 			// when children are passed in, tooltip will handle show/hide, otherwise consumer has to hide show/hide tooltip
-			const mouseover = (evt) => this.showTooltipOnMouseOver(evt);
+			const mouseover = () => this.setTooltipVisible(true);
 			const mouseleave = () => this.setTooltipVisible(false);
 			const mousedown = () => this.setTooltipVisible(false);
 			// `focus` event occurs before `click`. Adding timeout in onFocus function to ensure click is executed first.

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
@@ -322,12 +322,21 @@ class ToolTip extends React.Component {
 		}
 	}
 
+	showTooltipOnMouseOver(evt) {
+		// closest() method traverses the Element and its parents until it finds a node that matches the provided selector string.
+		// Will return itself or the matching ancestor. If no such element exists, it returns null.
+		const toolbarItem = event.target.closest(".toolbar-item-content");
+		if (!(toolbarItem !== null && toolbarItem.classList.contains("disabled"))) {
+			this.setTooltipVisible(true);
+		}
+	}
+
 	render() {
 		let tooltipContent = null;
 		let triggerContent = null;
 		if (this.props.children) {
 			// when children are passed in, tooltip will handle show/hide, otherwise consumer has to hide show/hide tooltip
-			const mouseover = () => this.setTooltipVisible(true);
+			const mouseover = (evt) => this.showTooltipOnMouseOver(evt);
 			const mouseleave = () => this.setTooltipVisible(false);
 			const mousedown = () => this.setTooltipVisible(false);
 			// `focus` event occurs before `click`. Adding timeout in onFocus function to ensure click is executed first.
@@ -337,15 +346,15 @@ class ToolTip extends React.Component {
 			const click = (evt) => this.toggleTooltipOnClick(evt);
 
 			triggerContent = (<div
-				tabIndex={0}
 				data-id={this.props.id + "-trigger"}
 				className="tooltip-trigger"
 				onMouseOver={!this.props.showToolTipOnClick ? mouseover : null}
 				onMouseLeave={!this.props.showToolTipOnClick ? mouseleave : null}
 				onMouseDown={!this.props.showToolTipOnClick ? mousedown : null}
 				onClick={this.props.showToolTipOnClick ? click : null}
-				onFocus={onFocus} // When focused using keyboard
-				onBlur={onBlur}
+				onFocus={this.props.showToolTipOnClick ? onFocus : null} // When focused using keyboard
+				onBlur={this.props.showToolTipOnClick ? onBlur : null}
+				tabIndex={this.props.showToolTipOnClick ? 0 : null}
 				ref={(ref) => (this.triggerRef = ref)}
 			>
 				{this.props.children}


### PR DESCRIPTION
Fixes #751 

- Events for common-canvas, toolbar, palette - mouseover, mouseleave, mousedown
- Events for common-properties - click, focus, blur, tabIndex
- Not showing tootips for disabled toolbar icons

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

