### PR TITLE
Update clone instructions to valid git URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See [here](https://github.com/elyra-ai/canvas/tree/master/canvas_modules/harness
 ## Using local version of common-canvas and/or common-properties
 Clone elyra/canvas
 ```sh
-git clone git@github.com:elyra/canvas.git
+git clone git@github.com:elyra-ai/canvas.git
 
 # Build common-canvas and common-properties
 ./<elyra/canvas>/canvas_modules/common-canvas/build.sh


### PR DESCRIPTION
The URL provided in the readme instructions doesn't point to this repo:

```
$ git clone git@github.com:elyra/canvas.git
Cloning into 'canvas'...
ERROR: Repository not found.
fatal: Could not read from remote repository.
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

