### PR TITLE
#858 Enable tooltips for table cells in fieldpicker and expression control tables

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/components/fieldpicker-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/components/fieldpicker-test.js
@@ -386,7 +386,7 @@ describe("field-picker-control with multi input schemas renders correctly", () =
 		const tableRows = tableUtils.getTableRows(fieldpicker);
 		expect(tableRows.length).to.equal(29);
 		// verify first and last row from each schema
-		tableUtils.verifyFieldPickerRow(tableRows.at(0), "Age", "0");
+		tableUtils.verifyFieldPickerRow(tableRows.at(0), "Age - This is a long truncated label. You can see the entire label in a tooltip.", "0");
 		tableUtils.verifyFieldPickerRow(tableRows.at(5), "Time", "0");
 		tableUtils.verifyFieldPickerRow(tableRows.at(6), "Age", "data_1");
 		tableUtils.verifyFieldPickerRow(tableRows.at(11), "Timestamp", "data_1");
@@ -655,13 +655,13 @@ describe("field-picker-control with multi input schemas renders correctly", () =
 		const tableRows = tableUtils.getTableRows(fieldpicker);
 		expect(tableRows.length).to.equal(5);
 
-		tableUtils.verifyFieldPickerRow(tableRows.at(0), "Age", "0");
+		tableUtils.verifyFieldPickerRow(tableRows.at(0), "Age - This is a long truncated label. You can see the entire label in a tooltip.", "0");
 		tableUtils.verifyFieldPickerRow(tableRows.at(1), "age", "0");
 		tableUtils.verifyFieldPickerRow(tableRows.at(2), "Age", "data_1");
 		tableUtils.verifyFieldPickerRow(tableRows.at(3), "Age", "3");
 		tableUtils.verifyFieldPickerRow(tableRows.at(4), "Age", "schema");
 
-		tableUtils.fieldPicker(wrapper.find("div.properties-fp-table"), ["0.Age", "0.age", "data_1.Age"]);
+		tableUtils.fieldPicker(wrapper.find("div.properties-fp-table"), ["0.age", "data_1.Age", "3.Age"]);
 
 		wrapper.find("button[data-id='properties-apply-button']")
 			.at(0)
@@ -679,9 +679,9 @@ describe("field-picker-control with multi input schemas renders correctly", () =
 			"BADVAR",
 			"0.BADVAR",
 			"3.Cholesterol",
-			"0.Age",
 			"0.age",
-			"data_1.Age"
+			"data_1.Age",
+			"3.Age"
 		];
 
 		for (let idx = 0; idx < summaryRows.length; idx++) {
@@ -798,7 +798,7 @@ describe("field-picker-control with on selectcolumns renders correctly", () => {
 		renderedController.setDatasetMetadata(datasetMetadata);
 		const fieldPicker = tableUtils.openFieldPicker(wrapper, "properties-ft-fields");
 		tableUtils.fieldPicker(fieldPicker, [],
-			["Age", "age", "Sex", "BP", "Cholesterol", "Time", "age5", "BP5", "Na5", "drug5",
+			["Age - This is a long truncated label. You can see the entire label in a tooltip.", "age", "Sex", "BP", "Cholesterol", "Time", "age5", "BP5", "Na5", "drug5",
 				"Age", "Na", "K", "Drug", "Time",
 				"Timestamp", "Drug", "drug", "drug2", "Time", "Timestamp", "Date", "Age", "BP",
 				"Na", "drug", "drug2", "drug3", "Age", "BP", "Na", "drug", "drugs"]

--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/expressionControl_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/expressionControl_paramDef.json
@@ -445,7 +445,7 @@
     {
       "fields": [
         {
-          "name": "Age",
+          "name": "Age - This is a long truncated label. You can see the entire label in a tooltip.",
           "type": "integer",
           "metadata": {
             "description": "",

--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/fieldpicker_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/fieldpicker_paramDef.json
@@ -116,7 +116,8 @@
               "resource_key": "structuretableMultiInputSchema.field.label"
             },
             "width": 26,
-            "summary": true
+            "summary": true,
+            "dm_image": "measure"
           },
           {
             "parameter_ref": "new_name",
@@ -195,7 +196,7 @@
     {
       "fields": [
         {
-          "name": "Age",
+          "name": "Age - This is a long truncated label. You can see the entire label in a tooltip.",
           "type": "integer",
           "metadata": {
             "description": "",

--- a/canvas_modules/common-canvas/src/common-properties/components/components.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/components.scss
@@ -24,5 +24,6 @@
 @import "./properties-buttons/properties-buttons";
 @import "./editor-form/editor-form";
 @import "./flexible-table/flexible-table";
+@import "./truncated-content-tooltip/truncated-content-tooltip";
 @import "./virtualized-table/virtualized-table";
 @import "./empty-table/empty-table";

--- a/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
@@ -162,9 +162,29 @@ export default class FieldPicker extends React.Component {
 					</div>
 				);
 			}
+			const tooltipId = uuid4() + "-tooltip-fieldpicker";
+			const tooltip = (
+				<div className="properties-tooltips">
+					{String(field.origName)}
+				</div>
+			);
+			let disabled = true;
+			if (field.origName) {
+				disabled = false;
+			}
+			const fieldContentWithTooltip = (<Tooltip
+				id={tooltipId}
+				tip={tooltip}
+				direction="bottom"
+				className="properties-tooltips"
+				disable={disabled}
+				showToolTipIfTruncated
+			>
+				{fieldContent}
+			</Tooltip>);
 			columns.push({
 				column: "fieldName",
-				content: fieldContent,
+				content: fieldContentWithTooltip,
 				fieldName: field.origName
 			});
 			if (this.multiSchema) {

--- a/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
@@ -19,6 +19,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import FlexibleTable from "./../flexible-table";
+import TruncatedContentTooltip from "./../truncated-content-tooltip";
 import PropertiesButtons from "./../properties-buttons";
 import * as PropertyUtils from "./../../util/property-utils";
 
@@ -162,26 +163,18 @@ export default class FieldPicker extends React.Component {
 					</div>
 				);
 			}
-			const tooltipId = uuid4() + "-tooltip-fieldpicker";
-			const tooltip = (
-				<div className="properties-tooltips">
-					{String(field.origName)}
-				</div>
-			);
 			let disabled = true;
 			if (field.origName) {
 				disabled = false;
 			}
-			const fieldContentWithTooltip = (<Tooltip
-				id={tooltipId}
-				tip={tooltip}
-				direction="bottom"
-				className="properties-tooltips"
-				disable={disabled}
-				showToolTipIfTruncated
-			>
-				{fieldContent}
-			</Tooltip>);
+			const fieldContentWithTooltip = (
+				<TruncatedContentTooltip
+					uniqueIdentifier="tooltip-fieldpicker"
+					content={fieldContent}
+					tooltipText={field.origName}
+					disabled={disabled}
+				/>
+			);
 			columns.push({
 				column: "fieldName",
 				content: fieldContentWithTooltip,

--- a/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
@@ -152,32 +152,35 @@ export default class FieldPicker extends React.Component {
 				const dmIconType = PropertyUtils.getDMFieldIcon(metadata,
 					field.origName, this.props.dmIcon);
 				const dmIcon = dmIconType ? <Icon type={dmIconType} /> : null;
+				let disabled = true;
+				if (field.origName) {
+					disabled = false;
+				}
+				const fpFieldName = (
+					<span className="properties-fp-field-name">
+						{field.origName}
+					</span>
+				);
+				const fieldNameWithTooltip = (
+					<TruncatedContentTooltip
+						uniqueIdentifier="tooltip-fieldpicker"
+						content={fpFieldName}
+						tooltipText={field.origName}
+						disabled={disabled}
+					/>
+				);
 				fieldContent = (
 					<div className="properties-fp-field">
 						<div className="properties-fp-field-type-icon">
 							{dmIcon}
 						</div>
-						<div className="properties-fp-field-name">
-							{field.origName}
-						</div>
+						{fieldNameWithTooltip}
 					</div>
 				);
 			}
-			let disabled = true;
-			if (field.origName) {
-				disabled = false;
-			}
-			const fieldContentWithTooltip = (
-				<TruncatedContentTooltip
-					uniqueIdentifier="tooltip-fieldpicker"
-					content={fieldContent}
-					tooltipText={field.origName}
-					disabled={disabled}
-				/>
-			);
 			columns.push({
 				column: "fieldName",
-				content: fieldContentWithTooltip,
+				content: fieldContent,
 				fieldName: field.origName
 			});
 			if (this.multiSchema) {

--- a/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.jsx
@@ -163,7 +163,6 @@ export default class FieldPicker extends React.Component {
 				);
 				const fieldNameWithTooltip = (
 					<TruncatedContentTooltip
-						uniqueIdentifier="tooltip-fieldpicker"
 						content={fpFieldName}
 						tooltipText={field.origName}
 						disabled={disabled}

--- a/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.scss
@@ -34,11 +34,6 @@
 	align-items: center;
 }
 
-.properties-fp-field-name {
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
 .properties-fp-schema {
 	padding-left: 12px;
 }

--- a/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.scss
@@ -34,6 +34,13 @@
 	align-items: center;
 }
 
+// Long field name is truncated. Full name visible in tooltip on hover
+.properties-fp-field {
+	.tooltip-container {
+		min-width: 0;
+	}
+}
+
 .properties-fp-schema {
 	padding-left: 12px;
 }

--- a/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.scss
@@ -34,6 +34,11 @@
 	align-items: center;
 }
 
+.properties-fp-field-name {
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .properties-fp-schema {
 	padding-left: 12px;
 }

--- a/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/field-picker/field-picker.scss
@@ -34,13 +34,6 @@
 	align-items: center;
 }
 
-// Long field name is truncated. Full name visible in tooltip on hover
-.properties-fp-field {
-	.tooltip-container {
-		min-width: 0;
-	}
-}
-
 .properties-fp-schema {
 	padding-left: 12px;
 }

--- a/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/index.js
+++ b/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/index.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017-2021 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import TruncatedContentTooltip from "./truncated-content-tooltip.jsx";
+export default TruncatedContentTooltip;

--- a/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.jsx
@@ -29,16 +29,20 @@ export default class TruncatedContentTooltip extends React.Component {
 				{String(this.props.tooltipText)}
 			</div>
 		);
-		return (<Tooltip
-			id={`${uuid4()}-properties`}
-			tip={tooltip}
-			direction="bottom"
-			className="properties-tooltips"
-			disable={has(this.props, "disabled") ? this.props.disabled : true}
-			showToolTipIfTruncated
-		>
-			{this.props.content}
-		</Tooltip>);
+		return (
+			<div className="properties-truncated-tooltip">
+				<Tooltip
+					id={`${uuid4()}-properties`}
+					tip={tooltip}
+					direction="bottom"
+					className="properties-tooltips"
+					disable={has(this.props, "disabled") ? this.props.disabled : true}
+					showToolTipIfTruncated
+				>
+					{this.props.content}
+				</Tooltip>
+			</div>
+		);
 	}
 }
 

--- a/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.jsx
@@ -51,6 +51,5 @@ TruncatedContentTooltip.propTypes = {
 		PropTypes.bool.isRequired,
 		PropTypes.array.isRequired
 	]),
-	// tooltipText: PropTypes.string.isRequired,
 	disabled: PropTypes.bool
 };

--- a/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.jsx
@@ -30,7 +30,7 @@ export default class TruncatedContentTooltip extends React.Component {
 			</div>
 		);
 		return (<Tooltip
-			id={`${uuid4()}-${this.props.uniqueIdentifier}`}
+			id={`${uuid4()}-properties`}
 			tip={tooltip}
 			direction="bottom"
 			className="properties-tooltips"
@@ -43,7 +43,6 @@ export default class TruncatedContentTooltip extends React.Component {
 }
 
 TruncatedContentTooltip.propTypes = {
-	uniqueIdentifier: PropTypes.string.isRequired,
 	content: PropTypes.element.isRequired,
 	tooltipText: PropTypes.oneOfType([
 		PropTypes.string.isRequired,

--- a/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.jsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017-2021 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { v4 as uuid4 } from "uuid";
+import Tooltip from "./../../../tooltip/tooltip.jsx";
+import { has } from "lodash";
+
+// Reusable component to show tooltip if the content is truncated
+export default class TruncatedContentTooltip extends React.Component {
+
+	render() {
+		const tooltip = (
+			<div className="properties-tooltips">
+				{String(this.props.tooltipText)}
+			</div>
+		);
+		return (<Tooltip
+			id={`${uuid4()}-${this.props.uniqueIdentifier}`}
+			tip={tooltip}
+			direction="bottom"
+			className="properties-tooltips"
+			disable={has(this.props, "disabled") ? this.props.disabled : true}
+			showToolTipIfTruncated
+		>
+			{this.props.content}
+		</Tooltip>);
+	}
+}
+
+TruncatedContentTooltip.propTypes = {
+	uniqueIdentifier: PropTypes.string.isRequired,
+	content: PropTypes.element.isRequired,
+	tooltipText: PropTypes.oneOfType([
+		PropTypes.string.isRequired,
+		PropTypes.number.isRequired,
+		PropTypes.bool.isRequired,
+		PropTypes.array.isRequired
+	]),
+	// tooltipText: PropTypes.string.isRequired,
+	disabled: PropTypes.bool
+};

--- a/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.scss
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017-2021 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.tooltip-trigger {
+	width: inherit;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	span {
+		white-space: nowrap;
+	}
+}

--- a/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.scss
@@ -14,12 +14,17 @@
  * limitations under the License.
  */
 
-.tooltip-trigger {
+.properties-readonly .tooltip-trigger,
+.properties-fp-field .tooltip-trigger,
+.properties-table-cell-control .tooltip-trigger {
 	width: inherit;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	span {
 		white-space: nowrap;
+		&[disabled] {
+			opacity: 0.5;
+		}
 	}
 }

--- a/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.scss
@@ -21,11 +21,5 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
-		span {
-			white-space: nowrap;
-			&[disabled] {
-				opacity: 0.5;
-			}
-		}
 	}
 }

--- a/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/truncated-content-tooltip/truncated-content-tooltip.scss
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-.properties-readonly .tooltip-trigger,
-.properties-fp-field .tooltip-trigger,
-.properties-table-cell-control .tooltip-trigger {
-	width: inherit;
+.properties-truncated-tooltip {
 	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	span {
+	.tooltip-trigger {
+		width: inherit;
+		overflow: hidden;
+		text-overflow: ellipsis;
 		white-space: nowrap;
-		&[disabled] {
-			opacity: 0.5;
+		span {
+			white-space: nowrap;
+			&[disabled] {
+				opacity: 0.5;
+			}
 		}
 	}
 }

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
@@ -18,6 +18,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Switch, ContentSwitcher, Dropdown } from "carbon-components-react";
 import FlexibleTable from "./../../../components/flexible-table/flexible-table";
+import Tooltip from "./../../../../tooltip/tooltip.jsx";
 import { MESSAGE_KEYS, EXPRESSION_TABLE_ROWS, SORT_DIRECTION, ROW_SELECTION } from "./../../../constants/constants";
 import { formatMessage } from "./../../../util/property-utils";
 import { sortBy } from "lodash";
@@ -226,7 +227,7 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 	}
 
 	createContentObject(label) {
-		return (
+		const contentObject = (
 			<div className="properties-table-cell-control">
 				<div className="properties-expr-table-cell">
 					<span>
@@ -235,6 +236,28 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 				</div>
 			</div>
 		);
+		const tooltipId = uuid4() + "-tooltip-expr-table-cell";
+		const tooltip = (
+			<div className="properties-tooltips">
+				{String(label)}
+			</div>
+		);
+		let disabled = true;
+		if (label) {
+			disabled = false;
+		}
+		const contentObjectWithTooltip = (<Tooltip
+			id={tooltipId}
+			tip={tooltip}
+			direction="bottom"
+			className="properties-tooltips"
+			disable={disabled}
+			showToolTipIfTruncated
+		>
+			{contentObject}
+		</Tooltip>);
+
+		return contentObjectWithTooltip;
 	}
 
 	_makeDatasetFields(dataset, fieldDataset) {

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
@@ -238,7 +238,6 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 		);
 		const expressionTableCellContentWithTooltip = (
 			<TruncatedContentTooltip
-				uniqueIdentifier="tooltip-expr-table-cell"
 				content={expressionTableCellContent}
 				tooltipText={label}
 				disabled={disabled}

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
@@ -227,29 +227,30 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 	}
 
 	createContentObject(label) {
-		const contentObject = (
-			<div className="properties-table-cell-control">
-				<div className="properties-expr-table-cell">
-					<span>
-						{label}
-					</span>
-				</div>
-			</div>
-		);
 		let disabled = true;
 		if (label) {
 			disabled = false;
 		}
-		const contentObjectWithTooltip = (
+		const expressionTableCellContent = (
+			<span className="properties-expr-table-cell">
+				{label}
+			</span>
+		);
+		const expressionTableCellContentWithTooltip = (
 			<TruncatedContentTooltip
 				uniqueIdentifier="tooltip-expr-table-cell"
-				content={contentObject}
+				content={expressionTableCellContent}
 				tooltipText={label}
 				disabled={disabled}
 			/>
 		);
+		const contentObject = (
+			<div className="properties-table-cell-control">
+				{expressionTableCellContentWithTooltip}
+			</div>
+		);
 
-		return contentObjectWithTooltip;
+		return contentObject;
 	}
 
 	_makeDatasetFields(dataset, fieldDataset) {

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
@@ -18,7 +18,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Switch, ContentSwitcher, Dropdown } from "carbon-components-react";
 import FlexibleTable from "./../../../components/flexible-table/flexible-table";
-import Tooltip from "./../../../../tooltip/tooltip.jsx";
+import TruncatedContentTooltip from "./../../../components/truncated-content-tooltip";
 import { MESSAGE_KEYS, EXPRESSION_TABLE_ROWS, SORT_DIRECTION, ROW_SELECTION } from "./../../../constants/constants";
 import { formatMessage } from "./../../../util/property-utils";
 import { sortBy } from "lodash";
@@ -236,26 +236,18 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 				</div>
 			</div>
 		);
-		const tooltipId = uuid4() + "-tooltip-expr-table-cell";
-		const tooltip = (
-			<div className="properties-tooltips">
-				{String(label)}
-			</div>
-		);
 		let disabled = true;
 		if (label) {
 			disabled = false;
 		}
-		const contentObjectWithTooltip = (<Tooltip
-			id={tooltipId}
-			tip={tooltip}
-			direction="bottom"
-			className="properties-tooltips"
-			disable={disabled}
-			showToolTipIfTruncated
-		>
-			{contentObject}
-		</Tooltip>);
+		const contentObjectWithTooltip = (
+			<TruncatedContentTooltip
+				uniqueIdentifier="tooltip-expr-table-cell"
+				content={contentObject}
+				tooltipText={label}
+				disabled={disabled}
+			/>
+		);
 
 		return contentObjectWithTooltip;
 	}

--- a/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.jsx
@@ -111,7 +111,6 @@ class ReadonlyControl extends React.Component {
 			}
 			display = (
 				<TruncatedContentTooltip
-					uniqueIdentifier={"tooltip-column-" + this.props.propertyId.toString()}
 					content={content}
 					tooltipText={controlValue}
 					disabled={disabled}

--- a/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.jsx
@@ -19,10 +19,9 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import * as ControlUtils from "./../../util/control-utils";
 import ValidationMessage from "./../../components/validation-message";
+import TruncatedContentTooltip from "./../../components/truncated-content-tooltip";
 import { STATES, DATA_TYPE } from "./../../constants/constants";
-import Tooltip from "./../../../tooltip/tooltip";
 import Icon from "./../../../icons/icon";
-import { v4 as uuid4 } from "uuid";
 import moment from "moment";
 import { isEqual, intersection } from "lodash";
 
@@ -96,16 +95,10 @@ class ReadonlyControl extends React.Component {
 		const readOnly = <span className="properties-field-type" disabled={this.props.state === STATES.DISABLED}>{controlValue}</span>;
 		let display = readOnly;
 		if (this.props.tableControl) {
-			const tooltipId = uuid4() + "-tooltip-column-" + this.props.propertyId.toString();
 			let disabled = true;
 			if (controlValue) {
 				disabled = false;
 			}
-			const tooltip = (
-				<div className="properties-tooltips">
-					{String(controlValue)}
-				</div>
-			);
 			let content = readOnly;
 			if (this.props.control.icon) {
 				content = (
@@ -116,16 +109,14 @@ class ReadonlyControl extends React.Component {
 						{readOnly}
 					</div>);
 			}
-			display = (<Tooltip
-				id={tooltipId}
-				tip={tooltip}
-				direction="bottom"
-				className="properties-tooltips"
-				disable={disabled}
-				showToolTipIfTruncated
-			>
-				{content}
-			</Tooltip>);
+			display = (
+				<TruncatedContentTooltip
+					uniqueIdentifier={"tooltip-column-" + this.props.propertyId.toString()}
+					content={content}
+					tooltipText={controlValue}
+					disabled={disabled}
+				/>
+			);
 		}
 		return (
 			<div

--- a/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.scss
@@ -60,9 +60,6 @@
 	.tooltip-trigger {
 		span {
 			white-space: nowrap;
-			&[disabled] {
-				opacity: 0.5;
-			}
 		}
 	}
 }

--- a/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.scss
@@ -57,12 +57,4 @@
 			}
 		}
 	}
-	.tooltip-trigger {
-		span {
-			white-space: nowrap;
-			&[disabled] {
-				opacity: 0.5;
-			}
-		}
-	}
 }

--- a/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.scss
@@ -15,10 +15,6 @@
  */
 
 .properties-readonly {
-	width: inherit;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 	&.hide {
 		display: none;
 	}
@@ -62,10 +58,6 @@
 		}
 	}
 	.tooltip-trigger {
-		width: inherit;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		white-space: nowrap;
 		span {
 			white-space: nowrap;
 			&[disabled] {

--- a/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.scss
@@ -57,4 +57,12 @@
 			}
 		}
 	}
+	.tooltip-trigger {
+		span {
+			white-space: nowrap;
+			&[disabled] {
+				opacity: 0.5;
+			}
+		}
+	}
 }

--- a/canvas_modules/harness/test_resources/parameterDefs/expressionControl_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/expressionControl_paramDef.json
@@ -445,7 +445,7 @@
     {
       "fields": [
         {
-          "name": "Age",
+          "name": "Age - This is a long truncated label. You can see the entire label in a tooltip.",
           "type": "integer",
           "metadata": {
             "description": "",

--- a/canvas_modules/harness/test_resources/parameterDefs/fieldpicker_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/fieldpicker_paramDef.json
@@ -196,7 +196,7 @@
     {
       "fields": [
         {
-          "name": "Age",
+          "name": "Age - This is a long truncated label. You can see the entire label in a tooltip.",
           "type": "integer",
           "metadata": {
             "description": "",


### PR DESCRIPTION
Fixes #858 

Field picker table - 
![Screen Shot 2021-11-29 at 12 36 50 PM](https://user-images.githubusercontent.com/25124000/143939661-da76808b-61ab-4224-a699-484221187b32.png)

Expression control - 
![Screen Shot 2021-11-29 at 12 37 27 PM](https://user-images.githubusercontent.com/25124000/143939678-e8970ef5-4287-4cd1-927d-bfc025ad1ed7.png)
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

