### PR TITLE
#890 Added callback to allow Undo/Redo label override for Save properties action

### DIFF
--- a/canvas_modules/common-canvas/locales/command-actions/locales/en.json
+++ b/canvas_modules/common-canvas/locales/command-actions/locales/en.json
@@ -3,6 +3,7 @@
 	"action.arrangeLayout": "Arrange layout",
 	"action.attachNodeToLinks": "Attach {node_label} node to link",
 	"action.collapseSuperNodeInPlace": "Collapse supernode",
+	"action.commonProperties": "Save properties",
 	"action.convertSuperNodeExternalToLocal": "Convert external supernode {node_label} to local",
 	"action.convertSuperNodeLocalToExternal": "Convert local supernode {node_label} to external",
 	"action.createComment": "Create comment",

--- a/canvas_modules/common-canvas/locales/command-actions/locales/eo.json
+++ b/canvas_modules/common-canvas/locales/command-actions/locales/eo.json
@@ -3,6 +3,7 @@
 	"action.arrangeLayout": "[Esperanto~Arrange layout~~~~~~~eo]",
 	"action.attachNodeToLinks": "[Esperanto~Attach {node_label} node to link~~~~~~~eo]",
 	"action.collapseSuperNodeInPlace": "[Esperanto~Collapse supernode~~~~~~~eo]",
+	"action.commonProperties": "[Esperanto~Save properties~~~~~~~eo]",
 	"action.convertSuperNodeExternalToLocal": "[Esperanto~Convert external supernode {node_label} to local~~~~~~~eo]",
 	"action.convertSuperNodeLocalToExternal": "[Esperanto~Convert local supernode {node_label} to external~~~~~~~eo]",
 	"action.createComment": "[Esperanto~Create comment~~~~~~~eo]",

--- a/canvas_modules/common-canvas/src/command-actions/commonPropertiesAction.js
+++ b/canvas_modules/common-canvas/src/command-actions/commonPropertiesAction.js
@@ -14,14 +14,18 @@
  * limitations under the License.
  */
 import Action from "../command-stack/action.js";
+import defaultMessages from "../../locales/command-actions/locales/en.json";
 
 export default class CommonPropertiesAction extends Action {
-	constructor(newValues, initialValues, appData, applyPropertyChanges) {
+	constructor(newValues, initialValues, appData, applyPropertyChanges, propertiesActionLabelHandler, intl) {
 		super(newValues);
 		this.newValues = newValues;
 		this.initialValues = initialValues;
 		this.appData = appData;
 		this.applyPropertyChanges = applyPropertyChanges;
+		this.propertiesActionLabelHandler = propertiesActionLabelHandler;
+		this.intl = intl;
+		this.defaultMessages = defaultMessages;
 	}
 
 	// Standard methods
@@ -37,9 +41,23 @@ export default class CommonPropertiesAction extends Action {
 		this.applyPropertyChanges(this.newValues.properties, this.appData, this.newValues.additionalInfo, this.newValues.undoInfo, this.newValues.uiProperties);
 	}
 
-	// TODO - Implement this to get the command action label from translation
-	// file or call a getActionLabel callback.
 	getLabel() {
-		return "";
+		if (this.propertiesActionLabelHandler) {
+			const label = this.propertiesActionLabelHandler();
+			if (label) {
+				return label;
+			}
+		}
+		return this.getDefaultLabel("action.commonProperties");
+	}
+
+	getDefaultLabel(key) {
+		let formattedMessage;
+		if (typeof this.intl !== "undefined" && this.intl !== null) {
+			formattedMessage = this.intl.formatMessage({ id: key, defaultMessage: this.defaultMessages[key] });
+		} else {
+			formattedMessage = this.defaultMessages[key];
+		}
+		return formattedMessage;
 	}
 }

--- a/canvas_modules/common-canvas/src/command-actions/commonPropertiesAction.js
+++ b/canvas_modules/common-canvas/src/command-actions/commonPropertiesAction.js
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 import Action from "../command-stack/action.js";
-import defaultMessages from "../../locales/command-actions/locales/en.json";
 
 export default class CommonPropertiesAction extends Action {
-	constructor(newValues, initialValues, appData, applyPropertyChanges, propertiesActionLabelHandler, intl) {
+	constructor(newValues, initialValues, appData, applyPropertyChanges, propertiesActionLabel) {
 		super(newValues);
 		this.newValues = newValues;
 		this.initialValues = initialValues;
 		this.appData = appData;
 		this.applyPropertyChanges = applyPropertyChanges;
-		this.propertiesActionLabelHandler = propertiesActionLabelHandler;
-		this.intl = intl;
-		this.defaultMessages = defaultMessages;
+		this.propertiesActionLabel = propertiesActionLabel;
 	}
 
 	// Standard methods
@@ -42,22 +39,6 @@ export default class CommonPropertiesAction extends Action {
 	}
 
 	getLabel() {
-		if (this.propertiesActionLabelHandler) {
-			const label = this.propertiesActionLabelHandler();
-			if (label) {
-				return label;
-			}
-		}
-		return this.getDefaultLabel("action.commonProperties");
-	}
-
-	getDefaultLabel(key) {
-		let formattedMessage;
-		if (typeof this.intl !== "undefined" && this.intl !== null) {
-			formattedMessage = this.intl.formatMessage({ id: key, defaultMessage: this.defaultMessages[key] });
-		} else {
-			formattedMessage = this.defaultMessages[key];
-		}
-		return formattedMessage;
+		return this.propertiesActionLabel;
 	}
 }

--- a/canvas_modules/common-canvas/src/common-properties/common-properties.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/common-properties.jsx
@@ -256,7 +256,8 @@ CommonProperties.propTypes = {
 		helpClickHandler: PropTypes.func,
 		buttonHandler: PropTypes.func,
 		validationHandler: PropTypes.func,
-		titleChangeHandler: PropTypes.func
+		titleChangeHandler: PropTypes.func,
+		propertiesActionLabelHandler: PropTypes.func
 	}),
 	customPanels: PropTypes.array,
 	customControls: PropTypes.array,

--- a/canvas_modules/common-canvas/src/common-properties/constants/constants.js
+++ b/canvas_modules/common-canvas/src/common-properties/constants/constants.js
@@ -103,6 +103,7 @@ _defineConstant("MESSAGE_KEYS", {
 	DROPDOWN_TOOLTIP_CLEARSELECTION: "dropdown.tooltip.clear.selection",
 	TRUNCATE_LONG_STRING_ERROR: "truncate.long.string.error",
 	PROPERTIES_LABEL: "properties.label",
+	PROPERTIES_ACTION_LABEL: "action.commonProperties",
 	READONLYTABLE_EDIT_BUTTON_LABEL: "readonlytable.edit.button.label",
 	TOGGLETEXT_ICON_DESCRIPTION: "toggletext.icon.description",
 	MULTISELECT_DROPDOWN_EMPTY_LABEL: "multiselect.dropdown.empty.label",

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -181,6 +181,16 @@ class PropertiesMain extends React.Component {
 		return PropertyUtils.formatMessage(this.props.intl, MESSAGE_KEYS.PROPERTIESEDIT_REJECTBUTTON_LABEL);
 	}
 
+	getPropertiesActionLabel() {
+		if (this.props.callbacks.propertiesActionLabelHandler) {
+			const label = this.props.callbacks.propertiesActionLabelHandler();
+			if (label) {
+				return label;
+			}
+		}
+		return PropertyUtils.formatMessage(this.props.intl, MESSAGE_KEYS.PROPERTIES_ACTION_LABEL);
+	}
+
 	getEditorSize() {
 		// Determine whether to persist initialEditorSize or set the defaultEditorSize in certain cases
 		const defaultEditorSize = this.propertiesController.getForm().editorSize;
@@ -352,8 +362,9 @@ class PropertiesMain extends React.Component {
 			if (this.propertiesController.getTitle()) {
 				valueInfo.additionalInfo.title = this.propertiesController.getTitle();
 			}
+			const propertiesActionLabel = this.getPropertiesActionLabel();
 			const command = new CommonPropertiesAction(valueInfo, this.initialValueInfo,
-				this.props.propertiesInfo.appData, this.props.callbacks.applyPropertyChanges, this.props.callbacks.propertiesActionLabelHandler, this.props.intl);
+				this.props.propertiesInfo.appData, this.props.callbacks.applyPropertyChanges, propertiesActionLabel);
 			this.propertiesController.getCommandStack().do(command);
 
 			// if we don't close the dialog, set the currentParameters to the new parameters

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -32,7 +32,6 @@ import Icon from "./../../icons/icon.jsx";
 import { Button } from "carbon-components-react";
 import { Provider } from "react-redux";
 import logger from "../../../utils/logger";
-
 import TitleEditor from "./../components/title-editor";
 import classNames from "classnames";
 
@@ -354,7 +353,7 @@ class PropertiesMain extends React.Component {
 				valueInfo.additionalInfo.title = this.propertiesController.getTitle();
 			}
 			const command = new CommonPropertiesAction(valueInfo, this.initialValueInfo,
-				this.props.propertiesInfo.appData, this.props.callbacks.applyPropertyChanges);
+				this.props.propertiesInfo.appData, this.props.callbacks.applyPropertyChanges, this.props.callbacks.propertiesActionLabelHandler, this.props.intl);
 			this.propertiesController.getCommandStack().do(command);
 
 			// if we don't close the dialog, set the currentParameters to the new parameters
@@ -554,7 +553,8 @@ PropertiesMain.propTypes = {
 		setPropertiesHasMounted: PropTypes.func,
 		buttonHandler: PropTypes.func,
 		validationHandler: PropTypes.func,
-		titleChangeHandler: PropTypes.func
+		titleChangeHandler: PropTypes.func,
+		propertiesActionLabelHandler: PropTypes.func
 	}),
 	customPanels: PropTypes.array, // array of custom panels
 	customControls: PropTypes.array, // array of custom controls

--- a/canvas_modules/common-canvas/src/common-properties/util/property-utils.js
+++ b/canvas_modules/common-canvas/src/common-properties/util/property-utils.js
@@ -21,7 +21,8 @@ import { ParamRole } from "../constants/form-constants";
 import { DATA_TYPE, CARBON_ICONS } from "../constants/constants";
 import { cloneDeep } from "lodash";
 import { v4 as uuid4 } from "uuid";
-import defaultMessages from "../../../locales/common-properties/locales/en.json";
+import defaultMessages1 from "../../../locales/common-properties/locales/en.json";
+import defaultMessages2 from "../../../locales/command-actions/locales/en.json";
 
 /**
  * A better type identifier than a simple 'typeOf' call:
@@ -50,6 +51,7 @@ function copy(obj) {
 }
 
 function formatMessage(intl, key, substituteObj) {
+	const defaultMessages = { ...defaultMessages1, ...defaultMessages2 };
 	let formattedMessage;
 	if (typeof intl !== "undefined" && intl !== null) {
 		formattedMessage = intl.formatMessage({ id: key, defaultMessage: defaultMessages[key] }, substituteObj);

--- a/canvas_modules/harness/cypress/integration/canvas/tips.js
+++ b/canvas_modules/harness/cypress/integration/canvas/tips.js
@@ -392,3 +392,112 @@ describe("Test to check if tips show up for toolbar items", function() {
 		cy.mouseoutToolbarItem(".toggleNotificationPanel-action");
 	});
 });
+
+describe("Test undo redo tooltips for different actions", function() {
+	beforeEach(() => {
+		cy.visit("/");
+	});
+
+	it("Test undo redo tooltips for common properties action", function() {
+		cy.openPropertyDefinition("readonly_paramDef.json");
+		// Save properties flyout
+		cy.saveFlyout();
+
+		cy.hoverOverToolbarItem(".undo-action");
+		cy.verifyTipForToolbarItem(".undo-action", "Undo: Save properties custom label");
+		cy.mouseoutToolbarItem(".undo-action");
+		cy.clickToolbarUndo();
+
+		cy.hoverOverToolbarItem(".redo-action");
+		cy.verifyTipForToolbarItem(".redo-action", "Redo: Save properties custom label");
+		cy.mouseoutToolbarItem(".redo-action");
+		cy.clickToolbarRedo();
+	});
+
+	it("Test undo redo tooltips for common canvas actions", function() {
+		cy.openCanvasPalette("modelerPalette.json");
+		// Add a node on canvas
+		cy.clickToolbarPaletteOpen();
+		cy.clickCategory("Import");
+		cy.dragNodeToPosition("Var. File", 300, 200);
+		// Verify undo/redo tooltip after adding node
+		cy.hoverOverToolbarItem(".undo-action");
+		cy.verifyTipForToolbarItem(".undo-action", "Undo: Create Var. File node");
+		cy.mouseoutToolbarItem(".undo-action");
+		cy.clickToolbarUndo();
+
+		cy.hoverOverToolbarItem(".redo-action");
+		cy.verifyTipForToolbarItem(".redo-action", "Redo: Create Var. File node");
+		cy.mouseoutToolbarItem(".redo-action");
+		cy.clickToolbarRedo();
+
+		// Add another node on canvas & link two nodes
+		cy.clickCategory("Record Ops");
+		cy.dragNodeToPosition("Select", 400, 200);
+		cy.linkNodes("Var. File", "Select");
+		// Verify undo/redo tooltip after linking nodes
+		cy.hoverOverToolbarItem(".undo-action");
+		cy.verifyTipForToolbarItem(".undo-action", "Undo: Create link to Select node");
+		cy.mouseoutToolbarItem(".undo-action");
+		cy.clickToolbarUndo();
+
+		cy.hoverOverToolbarItem(".redo-action");
+		cy.verifyTipForToolbarItem(".redo-action", "Redo: Create link to Select node");
+		cy.mouseoutToolbarItem(".redo-action");
+		cy.clickToolbarRedo();
+
+		// Add a comment for node
+		cy.clickNode("Select");
+		cy.clickToolbarAddComment();
+		// Verify undo/redo tooltip after adding comment
+		cy.hoverOverToolbarItem(".undo-action");
+		cy.verifyTipForToolbarItem(".undo-action", "Undo: Create comment");
+		cy.mouseoutToolbarItem(".undo-action");
+		cy.clickToolbarUndo();
+
+		cy.hoverOverToolbarItem(".redo-action");
+		cy.verifyTipForToolbarItem(".redo-action", "Redo: Create comment");
+		cy.mouseoutToolbarItem(".redo-action");
+		cy.clickToolbarRedo();
+
+		// Edit comment
+		cy.editTextInComment("", "This is a select node");
+		// Verify undo/redo tooltip after editing comment
+		cy.hoverOverToolbarItem(".undo-action");
+		cy.verifyTipForToolbarItem(".undo-action", "Undo: Edit comment");
+		cy.mouseoutToolbarItem(".undo-action");
+		cy.clickToolbarUndo();
+
+		cy.hoverOverToolbarItem(".redo-action");
+		cy.verifyTipForToolbarItem(".redo-action", "Redo: Edit comment");
+		cy.mouseoutToolbarItem(".redo-action");
+		cy.clickToolbarRedo();
+
+		// Delete a node
+		cy.clickNode("Var. File");
+		cy.clickToolbarDelete();
+		// Verify undo/redo tooltip after deleting node
+		cy.hoverOverToolbarItem(".undo-action");
+		cy.verifyTipForToolbarItem(".undo-action", "Undo: Delete all objects");
+		cy.mouseoutToolbarItem(".undo-action");
+		cy.clickToolbarUndo();
+
+		cy.hoverOverToolbarItem(".redo-action");
+		cy.verifyTipForToolbarItem(".redo-action", "Redo: Delete all objects");
+		cy.mouseoutToolbarItem(".redo-action");
+		cy.clickToolbarRedo();
+
+		// Delete a comment
+		cy.deleteCommentUsingToolbar("This is a select node");
+		// Verify undo/redo tooltip after deleting comment
+		cy.hoverOverToolbarItem(".undo-action");
+		cy.verifyTipForToolbarItem(".undo-action", "Undo: Delete all objects");
+		cy.mouseoutToolbarItem(".undo-action");
+		cy.clickToolbarUndo();
+
+		cy.hoverOverToolbarItem(".redo-action");
+		cy.verifyTipForToolbarItem(".redo-action", "Redo: Delete all objects");
+		cy.mouseoutToolbarItem(".redo-action");
+		cy.clickToolbarRedo();
+	});
+});

--- a/canvas_modules/harness/src/client/App.js
+++ b/canvas_modules/harness/src/client/App.js
@@ -336,6 +336,7 @@ class App extends React.Component {
 		this.selectionChangeHandler2 = this.selectionChangeHandler2.bind(this);
 		this.tipHandler = this.tipHandler.bind(this);
 		this.actionLabelHandler = this.actionLabelHandler.bind(this);
+		this.propertiesActionLabelHandler = this.propertiesActionLabelHandler.bind(this);
 
 		this.getNodeForm = this.getNodeForm.bind(this);
 		this.refreshContent = this.refreshContent.bind(this);
@@ -1629,6 +1630,11 @@ class App extends React.Component {
 		return null;
 	}
 
+	// Set custom label for "Save properties" action
+	propertiesActionLabelHandler() {
+		return "Save properties custom label";
+	}
+
 	refreshContent(streamId, diagramId) {
 		this.log("refreshContent()");
 	}
@@ -1819,7 +1825,8 @@ class App extends React.Component {
 			closePropertiesDialog: this.closePropertiesEditorDialog,
 			helpClickHandler: this.helpClickHandler,
 			buttonHandler: this.buttonHandler,
-			titleChangeHandler: this.titleChangeHandler
+			titleChangeHandler: this.titleChangeHandler,
+			propertiesActionLabelHandler: this.propertiesActionLabelHandler
 		};
 		if (this.state.propertiesValidationHandler) {
 			callbacks.validationHandler = this.validationHandler;


### PR DESCRIPTION
Fixes #890 
Added callback method `propertiesActionLabelHandler()`.

Setting custom label for "Save properties" action in test harness -
![Screen Shot 2021-12-14 at 2 14 21 PM](https://user-images.githubusercontent.com/25124000/146087917-d264e399-4e15-440b-84a5-c1a6e4e357ee.png)

![Screen Shot 2021-12-14 at 2 14 27 PM](https://user-images.githubusercontent.com/25124000/146087921-f6a5a51e-bf0b-4aa5-af5a-4edb025fc79f.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

