### PR TITLE
#894 Integer and double fields show numeric values in expression builder

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/expression-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/expression-test.js
@@ -101,6 +101,36 @@ const dataModel = [{
 					"ldl bad"
 				]
 			}
+		},
+		{
+			"name": "Ag",
+			"type": "integer",
+			"metadata": {
+				"description": "",
+				"measure": "discrete",
+				"modeling_role": "input",
+				"values": [
+					10,
+					20,
+					"30",
+					"40"
+				]
+			}
+		},
+		{
+			"name": "Na",
+			"type": "double",
+			"metadata": {
+				"description": "",
+				"measure": "discrete",
+				"modeling_role": "input",
+				"values": [
+					1.23,
+					"10.23",
+					"100.23",
+					"1000px"
+				]
+			}
 		}
 	]
 }];
@@ -334,6 +364,67 @@ describe("expression-builder select from tables correctly", () => {
 		expect(controller.getPropertyValue(propertyId)).to.equal(" \"female\"");
 	});
 
+	it("expression builder select a field value of type integer", () => {
+		reset();
+		const wrapper = mountWithIntl(
+			<Provider store={controller.getStore()}>
+				<ExpressionBuilder
+					control={control}
+					controller={controller}
+					propertyId={propertyId}
+				/>
+			</Provider>
+		);
+		// "Ag" field has type integer and we're passing some values as strings for Ag
+		// Verify all the values are converted into numbers
+		const ag = controller.getDatasetMetadataFields().find((field) => field.name === "Ag");
+		const allValuesNumbers = ag.metadata.values.every((val) => typeof val === "number");
+		expect(allValuesNumbers).to.equal(true);
+
+		// select a field with integer values
+		const fieldTable = wrapper.find("div.properties-field-table-container");
+		tableUtils.clickTableRows(fieldTable, [4]);
+		// select any value from value table.
+		const valueTable = wrapper.find("div.properties-value-table-container");
+		tableUtils.dblClickTableRows(valueTable, [2]);
+		expect(controller.getPropertyValue(propertyId)).to.equal(" 30");
+	});
+
+	it("expression builder select a field value of type double", () => {
+		reset();
+		const wrapper = mountWithIntl(
+			<Provider store={controller.getStore()}>
+				<ExpressionBuilder
+					control={control}
+					controller={controller}
+					propertyId={propertyId}
+				/>
+			</Provider>
+		);
+		// "Na" field has type double and we're passing some values as strings and invalid number
+		// Verify valid numbers are converted into numbers
+		const na = controller.getDatasetMetadataFields().find((field) => field.name === "Na");
+		const validValuesNumbers = na.metadata.values.filter((val) => typeof val === "number");
+		expect(validValuesNumbers).to.have.length(3);
+		expect(validValuesNumbers).to.eql([1.23, 10.23, 100.23]);
+
+		// Verify invalid number is set as it is
+		const invalidNumber = na.metadata.values.filter((val) => typeof val !== "number");
+		expect(invalidNumber).to.have.length(1);
+		expect(invalidNumber).to.eql(["1000px"]);
+
+		// select a field with double values
+		const fieldTable = wrapper.find("div.properties-field-table-container");
+		tableUtils.clickTableRows(fieldTable, [5]);
+		// select any value from value table.
+		const valueTable = wrapper.find("div.properties-value-table-container");
+		tableUtils.dblClickTableRows(valueTable, [2]);
+		expect(controller.getPropertyValue(propertyId)).to.equal(" 100.23");
+		// select invalid number which is displayed as string
+		tableUtils.dblClickTableRows(valueTable, [3]);
+		expect(controller.getPropertyValue(propertyId)).to.equal(" 100.23 \"1000px\"");
+	});
+
 	it("expression builder select a function", () => {
 		reset();
 		const wrapper = mountWithIntl(
@@ -389,7 +480,7 @@ describe("expression-builder select from tables correctly", () => {
 		searchInput.simulate("change", { target: { value: "" } });
 		fieldTable = wrapper.find("div.properties-field-table-container");
 		rows = tableUtils.getTableRows(fieldTable);
-		expect(rows).to.have.length(4);
+		expect(rows).to.have.length(6);
 		firstRowClassName = rows.at(0).prop("className");
 		expect(firstRowClassName.indexOf("properties-vt-row-selected")).to.be.lessThan(0);
 		const fourthRowClassName = rows.at(3).prop("className");
@@ -574,7 +665,7 @@ describe("ExpressionBuilder filters and sorts correctly", () => {
 		);
 		let fieldTable = wrapper.find("div.properties-field-table-container");
 		let rows = tableUtils.getTableRows(fieldTable);
-		expect(rows).to.have.length(4);
+		expect(rows).to.have.length(6);
 		expect(rows.at(1).text()).to.equal("Sexstring");
 		const searchInput = fieldTable.find("div.properties-ft-search-container input");
 		expect(searchInput).to.have.length(1);
@@ -654,17 +745,17 @@ describe("ExpressionBuilder filters and sorts correctly", () => {
 		);
 		const fieldTable = wrapper.find("div.properties-field-table-container");
 		const rows = tableUtils.getTableRows(fieldTable);
-		expect(rows).to.have.length(4);
+		expect(rows).to.have.length(6);
 		expect(rows.at(1).text()).to.equal("Sexstring");
 
 		const sortHeaders = fieldTable.find(".ReactVirtualized__Table__sortableHeaderColumn");
 		expect(sortHeaders).to.have.length(2);
 
 		tableUtils.clickHeaderColumnSort(fieldTable, 0);
-		expect(rows.at(1).text()).to.equal("BPstring");
+		expect(rows.at(2).text()).to.equal("BPstring");
 
 		tableUtils.clickHeaderColumnSort(fieldTable, 0);
-		expect(rows.at(1).text()).to.equal("Cholesterolstring");
+		expect(rows.at(2).text()).to.equal("Cholesterolstring");
 	});
 	it("expression builder sorts value table", () => {
 		reset();
@@ -732,7 +823,7 @@ describe("expression builder correctly runs Recently Used dropdown options", () 
 		expect(wrapper.find("div.properties-expression-field-select span").text()).to.equal("Fields");
 		let fieldRows = fieldRows = tableUtils.getTableRows(wrapper.find("div.properties-field-table-container"));
 
-		expect(fieldRows).to.have.length(4);
+		expect(fieldRows).to.have.length(6);
 		// navigate to Recently Used fields and check that it is empty
 		var dropDown = wrapper.find("div.properties-expression-field-select .bx--list-box__field");
 		dropDown.simulate("click");

--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/expressionControl_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/expressionControl_paramDef.json
@@ -507,12 +507,14 @@
           "type": "integer",
           "metadata": {
             "description": "",
-            "measure": "range",
+            "measure": "discrete",
             "modeling_role": "input",
-            "range": {
-              "min": 18,
-              "max": 35
-            }
+            "values": [
+              10,
+              20,
+              "30",
+              "40"
+            ]
           }
         }
       ]
@@ -587,12 +589,14 @@
           "type": "double",
           "metadata": {
             "description": "",
-            "measure": "range",
+            "measure": "discrete",
             "modeling_role": "input",
-            "range": {
-              "min": -2,
-              "max": 1.5
-            }
+            "values": [
+              1.23,
+              "10.23",
+              "100.23",
+              "1000px"
+            ]
           }
         },
         {

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
@@ -19,7 +19,7 @@ import PropTypes from "prop-types";
 import { Switch, ContentSwitcher, Dropdown } from "carbon-components-react";
 import FlexibleTable from "./../../../components/flexible-table/flexible-table";
 import TruncatedContentTooltip from "./../../../components/truncated-content-tooltip";
-import { MESSAGE_KEYS, EXPRESSION_TABLE_ROWS, SORT_DIRECTION, ROW_SELECTION } from "./../../../constants/constants";
+import { MESSAGE_KEYS, EXPRESSION_TABLE_ROWS, SORT_DIRECTION, ROW_SELECTION, DATA_TYPE } from "./../../../constants/constants";
 import { formatMessage } from "./../../../util/property-utils";
 import { sortBy } from "lodash";
 import { v4 as uuid4 } from "uuid";
@@ -294,6 +294,10 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 					}
 				]
 			};
+			// For integer or double fields, convert all the values into numbers. If number is invalid, display given value as it is.
+			if (field.metadata.values && (field.type === DATA_TYPE.INTEGER || field.type === DATA_TYPE.DOUBLE)) {
+				field.metadata.values = field.metadata.values.map((val) => (isNaN(Number(val)) ? val : Number(val)));
+			}
 			if (field.metadata.values) {
 				entry.values = [];
 				field.metadata.values.forEach((val) => {

--- a/canvas_modules/harness/test_resources/parameterDefs/expressionControl_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/expressionControl_paramDef.json
@@ -507,12 +507,14 @@
           "type": "integer",
           "metadata": {
             "description": "",
-            "measure": "range",
+            "measure": "discrete",
             "modeling_role": "input",
-            "range": {
-              "min": 18,
-              "max": 35
-            }
+            "values": [
+              10,
+              20,
+              "30",
+              "40"
+            ]
           }
         }
       ]
@@ -587,12 +589,14 @@
           "type": "double",
           "metadata": {
             "description": "",
-            "measure": "range",
+            "measure": "discrete",
             "modeling_role": "input",
-            "range": {
-              "min": -2,
-              "max": 1.5
-            }
+            "values": [
+              1.23,
+              "10.23",
+              "100.23",
+              "1000px"
+            ]
           }
         },
         {


### PR DESCRIPTION
Fixes #894 

Integer field -
![Screen Shot 2021-12-15 at 5 26 30 PM](https://user-images.githubusercontent.com/25124000/146291024-002dd145-c442-4d77-a0a0-08b230fd32ef.png)

Double field -
![Screen Shot 2021-12-15 at 5 26 50 PM](https://user-images.githubusercontent.com/25124000/146291049-3dd02197-4503-400c-a453-57b41fecdfbf.png)

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

