### PR TITLE
#910 Set textfield to null when no default value is provided

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/textfield-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/textfield-test.js
@@ -307,7 +307,7 @@ describe("textfield list works correctly", () => {
 		expect(controller.getPropertyValue(propertyId)).to.eql(["value 1", "value 2", "value 3"]);
 	});
 
-	it("textfield should set value to undefined when no default value is provided", () => {
+	it("textfield should set value to null when no default value is provided", () => {
 		const wrapper = mount(
 			<Textfield
 				store={controller.getStore()}
@@ -319,7 +319,7 @@ describe("textfield list works correctly", () => {
 		const textWrapper = wrapper.find("div[data-id='properties-test-text-list']");
 		const input = textWrapper.find("input");
 		input.simulate("change", { target: { value: "" } });
-		expect(controller.getPropertyValue(propertyId)).to.be.undefined;
+		expect(controller.getPropertyValue(propertyId)).to.be.null;
 	});
 
 	it("textfield should set value to default value when no value is entered", () => {

--- a/canvas_modules/common-canvas/src/common-properties/controls/textfield/textfield.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/textfield/textfield.jsx
@@ -54,7 +54,7 @@ class TextfieldControl extends React.Component {
 			value = ControlUtils.splitNewlines(value, arrayValueDelimiter);
 		}
 		if (value.length === 0 && (typeof this.defaultValue === "undefined" || this.defaultValue === null)) {
-			value = this.defaultValue;
+			value = null;
 		}
 		this.props.controller.updatePropertyValue(this.props.propertyId, value);
 	}


### PR DESCRIPTION
Fixes #910 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

