### PR TITLE
#969 Replaced Close button with X icon when applyOnBlur is set

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/common-properties-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/common-properties-test.js
@@ -172,11 +172,14 @@ describe("CommonProperties works correctly in flyout", () => {
 		wrapper.unmount();
 	});
 
-	it("When applyOnBlur=true only the `Close` button should be rendered", () => {
+	it("When applyOnBlur=true, `X` icon in properties title should be rendered", () => {
 		const renderedObject = propertyUtils.flyoutEditorForm(propertiesInfo.parameterDef); // default is applyOnBlur=true
 		wrapper = renderedObject.wrapper;
+		const closeIcon = wrapper.find("div.properties-close-button").find("button");
+		expect(closeIcon).to.have.length(1);
+		// Verify modal buttons are not rendered
 		const buttonWrapper = wrapper.find("div.properties-modal-buttons");
-		expect(buttonWrapper.find("button[data-id='properties-apply-button']").text()).to.equal("Close");
+		expect(buttonWrapper.find("button[data-id='properties-apply-button']")).to.have.length(0);
 		expect(buttonWrapper.find("button[data-id='properties-cancel-button']")).to.have.length(0);
 	});
 
@@ -584,15 +587,15 @@ describe("CommonProperties validates on close in flyout", () => {
 		wrapper.unmount();
 	});
 
-	it("Validate input when applyOnBlur=true the `Close` button pressed", () => {
+	it("Validate input when applyOnBlur=true and `X` icon pressed", () => {
 		const renderedObject = propertyUtils.flyoutEditorForm(numberfieldResource); // default is applyOnBlur=true
 		wrapper = renderedObject.wrapper;
 		const controller = renderedObject.controller;
 		// should not have any messages to start
 		expect(JSON.stringify(controller.getErrorMessages())).to.equal(JSON.stringify({}));
-		// click close and expect validation error messsages
-		wrapper.find("button[data-id='properties-apply-button']")
-			.at(0)
+		// click close icon and expect validation error messsages
+		wrapper.find("div.properties-close-button")
+			.find("button")
 			.simulate("click");
 		expect(JSON.stringify(controller.getErrorMessages())).to.equal(JSON.stringify(validationErrorMessages));
 	});
@@ -645,8 +648,8 @@ describe("CommonProperties validates on close in flyout", () => {
 		const renderedObject = propertyUtils.flyoutEditorForm(numberfieldResource, { conditionReturnValueHandling: "value" },
 			{ applyPropertyChanges: myApplyPropertyChanges });
 		wrapper = renderedObject.wrapper;
-		wrapper.find("button[data-id='properties-apply-button']")
-			.at(0)
+		wrapper.find("div.properties-close-button")
+			.find("button")
 			.simulate("click");
 	});
 
@@ -658,8 +661,8 @@ describe("CommonProperties validates on close in flyout", () => {
 		const renderedObject = propertyUtils.flyoutEditorForm(numberfieldResource, null,
 			{ applyPropertyChanges: myApplyPropertyChanges });
 		wrapper = renderedObject.wrapper;
-		wrapper.find("button[data-id='properties-apply-button']")
-			.at(0)
+		wrapper.find("div.properties-close-button")
+			.find("button")
 			.simulate("click");
 	});
 
@@ -671,8 +674,8 @@ describe("CommonProperties validates on close in flyout", () => {
 		const renderedObject = propertyUtils.flyoutEditorForm(numberfieldResource, { conditionReturnValueHandling: "null" },
 			{ applyPropertyChanges: myApplyPropertyChanges });
 		wrapper = renderedObject.wrapper;
-		wrapper.find("button[data-id='properties-apply-button']")
-			.at(0)
+		wrapper.find("div.properties-close-button")
+			.find("button")
 			.simulate("click");
 	});
 
@@ -747,8 +750,8 @@ describe("New error messages of a control should be detected and applyPropertyCh
 		const renderedObject = propertyUtils.flyoutEditorForm(expressionTestResource); // default is applyOnBlur=true
 		expect(renderedObject.callbacks.applyPropertyChanges).to.have.property("callCount", 0);
 		expect(renderedObject.callbacks.closePropertiesDialog).to.have.property("callCount", 0);
-		renderedObject.wrapper.find("CommonProperties").find("button[data-id='properties-apply-button']")
-			.at(0)
+		renderedObject.wrapper.find("CommonProperties").find("div.properties-close-button")
+			.find("button")
 			.simulate("click");
 		expect(renderedObject.callbacks.applyPropertyChanges).to.have.property("callCount", 1);
 		expect(renderedObject.callbacks.closePropertiesDialog).to.have.property("callCount", 1);
@@ -842,6 +845,9 @@ describe("PropertiesButtons should render with the correct labels", () => {
 		const wrapper = renderedObject.wrapper;
 		expect(wrapper.find("button[data-id='properties-apply-button']").text()).to.equal("Save");
 		expect(wrapper.find("button[data-id='properties-cancel-button']").text()).to.equal("Cancel");
+		// Verify "X" icon in properties title is not rendered
+		const closeIcon = wrapper.find("div.properties-close-button");
+		expect(closeIcon).to.have.length(0);
 	});
 	it("properties buttons should use a custom label if provided in propertiesConfig", () => {
 		const propertiesConfig = {
@@ -879,17 +885,6 @@ describe("PropertiesButtons should render with the correct labels", () => {
 		const wrapper = renderedObject.wrapper;
 		expect(wrapper.find("button[data-id='properties-apply-button']").text()).to.equal("Save");
 		expect(wrapper.find("button[data-id='properties-cancel-button']").text()).to.equal("test reject");
-	});
-	it("apply button should use a custom reject label if applyOnBlur", () => {
-		const propertiesConfig = {
-			buttonLabels: {
-				primary: "test apply",
-				secondary: "test reject"
-			}
-		};
-		const renderedObject = propertyUtils.flyoutEditorForm(numberfieldResource, propertiesConfig);
-		const wrapper = renderedObject.wrapper;
-		expect(wrapper.find("button[data-id='properties-apply-button']").text()).to.equal("test apply");
 	});
 });
 

--- a/canvas_modules/common-canvas/__tests__/common-properties/common-properties-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/common-properties-test.js
@@ -431,7 +431,8 @@ describe("CommonProperties works correctly in flyout", () => {
 		expect(wrapper.find("aside.properties-wrapper")).to.have.length(1);
 		expect(wrapper.find("div.properties-title-editor")).to.have.length(1);
 		expect(wrapper.find("div.properties-custom-container")).to.have.length(1);
-		expect(wrapper.find("div.properties-modal-buttons")).to.have.length(1);
+		expect(wrapper.find("div.properties-modal-buttons")).to.have.length(0);
+		expect(wrapper.find("div.properties-close-button")).to.have.length(1);
 	});
 
 	it("should set editorSize to initialEditorSize when defaultEditorSize='small' and initialEditorSize='medium'", () => {

--- a/canvas_modules/common-canvas/__tests__/common-properties/components/main-editor-proprties-button-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/components/main-editor-proprties-button-test.js
@@ -143,7 +143,8 @@ describe("main-editor-properties-buttons renders correctly", () => {
 	});
 
 	it("main-editor-properties-buttons should be disabled if required fields are not filled", () => {
-		const renderedObject = propertyUtils.flyoutEditorForm(textfieldParamDef, { disableSaveOnRequiredErrors: true });
+		// disableSaveOnRequiredErrors should be enabled only if 'applyOnBlur' is set to false
+		const renderedObject = propertyUtils.flyoutEditorForm(textfieldParamDef, { applyOnBlur: false, disableSaveOnRequiredErrors: true });
 		const wrapper = renderedObject.wrapper;
 		const rcontroller = renderedObject.controller;
 

--- a/canvas_modules/common-canvas/__tests__/common-properties/ui-parameters-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/ui-parameters-test.js
@@ -67,8 +67,8 @@ describe("Ui parameters are returned correctly", () => {
 		const input = uiParamDiv.find("input");
 		input.simulate("change", { target: { value: "My new value" } });
 		// close the common properties edit
-		const buttons = wrapper.find("div.properties-modal-buttons");
-		buttons.find("button.properties-apply-button").simulate("click");
+		const closeIcon = wrapper.find("div.properties-close-button").find("button");
+		closeIcon.simulate("click");
 		// validation is in the applyPropertiesChanges function above
 	});
 });

--- a/canvas_modules/common-canvas/src/common-properties/components/properties-buttons/properties-buttons.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/properties-buttons/properties-buttons.jsx
@@ -63,15 +63,19 @@ class PropertiesButtons extends Component {
 			);
 		}
 
-		return (
-			<div
-				className={classNames("properties-modal-buttons", { "hide": (typeof (this.props.showPropertiesButtons) !== "undefined" &&
-					!this.props.showPropertiesButtons) })}
-			>
-				{rejectButton}
-				{applyButton}
-			</div>
-		);
+		const propertiesModalButtons = this.props.okHandler || this.props.cancelHandler
+			? (
+				<div
+					className={classNames("properties-modal-buttons", { "hide": (typeof (this.props.showPropertiesButtons) !== "undefined" &&
+						!this.props.showPropertiesButtons) })}
+				>
+					{rejectButton}
+					{applyButton}
+				</div>
+			)
+			: null;
+
+		return propertiesModalButtons;
 	}
 }
 

--- a/canvas_modules/common-canvas/src/common-properties/components/properties-buttons/properties-buttons.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/properties-buttons/properties-buttons.jsx
@@ -47,18 +47,21 @@ class PropertiesButtons extends Component {
 				</Button>
 			);
 		}
-		const applyButton = (
-			<Button
-				data-id="properties-apply-button"
-				className="properties-apply-button"
-				type="button"
-				size="small"
-				onClick={this.props.okHandler}
-				disabled={!this.props.applyButtonEnabled}
-			>
-				{applyButtonLabel}
-			</Button>
-		);
+		let applyButton;
+		if (this.props.okHandler) {
+			applyButton = (
+				<Button
+					data-id="properties-apply-button"
+					className="properties-apply-button"
+					type="button"
+					size="small"
+					onClick={this.props.okHandler}
+					disabled={!this.props.applyButtonEnabled}
+				>
+					{applyButtonLabel}
+				</Button>
+			);
+		}
 
 		return (
 			<div

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -24,7 +24,7 @@ import { TextInput, Button } from "carbon-components-react";
 import { MESSAGE_KEYS, CONDITION_MESSAGE_TYPE } from "./../../constants/constants";
 import * as PropertyUtils from "./../../util/property-utils";
 import classNames from "classnames";
-import { Information16, Edit16 } from "@carbon/icons-react";
+import { Information16, Edit16, Close16 } from "@carbon/icons-react";
 
 
 class TitleEditor extends Component {
@@ -95,6 +95,7 @@ class TitleEditor extends Component {
 	render() {
 		const propertiesTitleEditButtonLabel = PropertyUtils.formatMessage(this.props.controller.getReactIntl(), MESSAGE_KEYS.TITLE_EDITOR_LABEL);
 		const helpButtonLabel = PropertyUtils.formatMessage(this.props.controller.getReactIntl(), MESSAGE_KEYS.TITLE_EDITOR_HELPBUTTON_LABEL);
+		const closeButtonLabel = PropertyUtils.formatMessage(this.props.controller.getReactIntl(), MESSAGE_KEYS.PROPERTIESEDIT_CLOSEBUTTON_LABEL);
 		const titleValidationTypes = [CONDITION_MESSAGE_TYPE.ERROR, CONDITION_MESSAGE_TYPE.WARNING];
 
 		const propertiesTitleEdit = this.props.labelEditable === false || this.state.focused ? <div />
@@ -123,6 +124,21 @@ class TitleEditor extends Component {
 			/>)
 			: null;
 
+		const closeButton = this.props.closeHandler
+			? (<div className="properties-close-button">
+				<Button
+					kind="ghost"
+					size="small"
+					data-id="close"
+					onClick={this.props.closeHandler}
+					tooltipPosition="left"
+					renderIcon={Close16}
+					iconDescription={closeButtonLabel}
+					hasIconOnly
+				/>
+			</div>)
+			: null;
+
 		let heading = null;
 		if (this.headingEnabled) {
 			const label = this.props.heading
@@ -146,6 +162,7 @@ class TitleEditor extends Component {
 			<div className={classNames("properties-title-editor",
 				{ "properties-title-with-heading": this.headingEnabled })}
 			>
+				{closeButton}
 				{heading}
 				<div className={classNames(
 					"properties-title-editor-input",
@@ -180,6 +197,7 @@ class TitleEditor extends Component {
 
 TitleEditor.propTypes = {
 	helpClickHandler: PropTypes.func,
+	closeHandler: PropTypes.func,
 	controller: PropTypes.object.isRequired,
 	labelEditable: PropTypes.bool,
 	help: PropTypes.object,

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -107,6 +107,7 @@ class TitleEditor extends Component {
 				tooltipPosition="bottom"
 				tooltipAlignment="end"
 				renderIcon={Edit16}
+				size="small"
 				iconDescription={propertiesTitleEditButtonLabel}
 				hasIconOnly
 			/>);
@@ -119,6 +120,7 @@ class TitleEditor extends Component {
 				onClick={this.helpClickHandler}
 				tooltipPosition="bottom"
 				renderIcon={Information16}
+				size="small"
 				iconDescription={helpButtonLabel}
 				hasIconOnly
 			/>)
@@ -178,6 +180,7 @@ class TitleEditor extends Component {
 						readOnly={this.props.labelEditable === false} // shows a non editable icon
 						labelText={this.labelText}
 						hideLabel
+						size="sm"
 						onFocus={this.textInputOnFocus}
 						onBlur={this.textInputOnBlur}
 						light={this.props.controller.getLight()}

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -97,6 +97,8 @@ class TitleEditor extends Component {
 		const helpButtonLabel = PropertyUtils.formatMessage(this.props.controller.getReactIntl(), MESSAGE_KEYS.TITLE_EDITOR_HELPBUTTON_LABEL);
 		const closeButtonLabel = PropertyUtils.formatMessage(this.props.controller.getReactIntl(), MESSAGE_KEYS.PROPERTIESEDIT_CLOSEBUTTON_LABEL);
 		const titleValidationTypes = [CONDITION_MESSAGE_TYPE.ERROR, CONDITION_MESSAGE_TYPE.WARNING];
+		const titleWithWarning = get(this.state.titleValidation, "type", null) === CONDITION_MESSAGE_TYPE.WARNING;
+		const titleWithErrror = get(this.state.titleValidation, "type", null) === CONDITION_MESSAGE_TYPE.ERROR;
 
 		const propertiesTitleEdit = this.props.labelEditable === false || this.state.focused ? <div />
 			: (<Button
@@ -168,7 +170,11 @@ class TitleEditor extends Component {
 				{heading}
 				<div className={classNames(
 					"properties-title-editor-input",
-					{ "properties-title-editor-with-help": this.props.help && !this.headingEnabled && !titleValidationTypes.includes(get(this.state.titleValidation, "type")) }
+					{
+						"properties-title-editor-with-help": this.props.help && !this.headingEnabled && !titleValidationTypes.includes(get(this.state.titleValidation, "type")),
+						"properties-title-editor-with-warning": titleWithWarning,
+						"properties-title-editor-with-error": titleWithErrror
+					}
 				)}
 				>
 					<TextInput
@@ -184,9 +190,9 @@ class TitleEditor extends Component {
 						onFocus={this.textInputOnFocus}
 						onBlur={this.textInputOnBlur}
 						light={this.props.controller.getLight()}
-						invalid={get(this.state.titleValidation, "type", null) === CONDITION_MESSAGE_TYPE.ERROR}
+						invalid={titleWithErrror}
 						invalidText={get(this.state.titleValidation, "message")}
-						warn={get(this.state.titleValidation, "type", null) === CONDITION_MESSAGE_TYPE.WARNING}
+						warn={titleWithWarning}
 						warnText={get(this.state.titleValidation, "message")}
 						{... this.state.focused && { className: "properties-title-editor-focused" }}
 					/>

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
@@ -39,14 +39,14 @@
 	}
 }
 .properties-title-editor-input {
-	width: calc(100% - 2px); // subtract 2px for input active right border
+	width: calc(100% - #{$spacing-03}); // subtract 8px to align with Close icon when applyOnBlur is set
 	top: 1px; // align input with bottom border
 	position: relative;
 	display: inline-flex;
 	align-items: center;
 
 	&.properties-title-editor-with-help {
-		width: calc(100% - #{$spacing-08}); // subtract the size of the help button
+		width: calc(100% - #{$spacing-07} - #{$spacing-03}); // subtract the size of the help button and 8px to align with Close icon when applyOnBlur is set
 	}
 	.bx--form-item.bx--text-input-wrapper {
 		// allow edit icon to be at the end of text input
@@ -81,9 +81,9 @@
 
 .properties-title-editor-btn.help, .properties-title-editor-btn.edit {
 	fill: $icon-02;
-	// edit & help buttons size - 40x40
-	width: $spacing-08;
-	min-height: $spacing-08;
+	// edit & help buttons size - 32x32
+	width: $spacing-07;
+	min-height: $spacing-07;
 	padding-left: $spacing-04;
 	padding-right: $spacing-04;
 	&:hover {
@@ -94,33 +94,22 @@
 	}
 }
 
-// Option 1 -
-// Close button CSS without heading
-// .properties-close-button {
-// 	position: relative;
-// 	display: flex;
-// 	align-items: center;
-// 	justify-content: flex-end;
-// 	padding-right: $spacing-03;
-// }
-//
-// // Close button CSS with heading
-// .properties-title-with-heading > .properties-close-button {
-// 	position: absolute;
-// 	top: $spacing-03;
-// 	right: $spacing-03;
-// 	display: flex;
-// 	align-items: center;
-// 	justify-content: center;
-// 	padding: 0;
-// }
-
-// Option 2 - With heading OK. Without heading - overlap with edit icon
+// Close icon without heading
 .properties-close-button {
+	position: relative;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	padding-right: $spacing-03;
+}
+
+// Close icon with heading
+.properties-title-with-heading > .properties-close-button {
 	position: absolute;
 	top: $spacing-03;
 	right: $spacing-03;
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	padding: 0;
 }

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
@@ -79,6 +79,11 @@
 	}
 }
 
+// warning and invalid icons should be aligned with close icon. And input field should stretch full width
+.properties-title-editor-with-warning, .properties-title-editor-with-error {
+	width: calc(100% - 2px); // subtract 2px for input active right border
+}
+
 .properties-title-editor-btn.help, .properties-title-editor-btn.edit {
 	fill: $icon-02;
 	// edit & help buttons size - 32x32

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
@@ -93,3 +93,34 @@
 		background-color: $ui-03;
 	}
 }
+
+// Option 1 -
+// Close button CSS without heading
+// .properties-close-button {
+// 	position: relative;
+// 	display: flex;
+// 	align-items: center;
+// 	justify-content: flex-end;
+// 	padding-right: $spacing-03;
+// }
+//
+// // Close button CSS with heading
+// .properties-title-with-heading > .properties-close-button {
+// 	position: absolute;
+// 	top: $spacing-03;
+// 	right: $spacing-03;
+// 	display: flex;
+// 	align-items: center;
+// 	justify-content: center;
+// 	padding: 0;
+// }
+
+// Option 2 - With heading OK. Without heading - overlap with edit icon
+.properties-close-button {
+	position: absolute;
+	top: $spacing-03;
+	right: $spacing-03;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -404,9 +404,10 @@ class PropertiesMain extends React.Component {
 	}
 
 	render() {
+		const applyOnBlurEnabled = this.props.propertiesConfig.applyOnBlur && this.props.propertiesConfig.rightFlyout;
 		let cancelHandler = this.cancelHandler.bind(this, CANCEL);
 		// when onBlur cancel shouldn't be rendered.
-		if (this.props.propertiesConfig.applyOnBlur && this.props.propertiesConfig.rightFlyout) {
+		if (applyOnBlurEnabled) {
 			cancelHandler = null;
 		}
 		const applyLabel = this.getApplyButtonLabel();
@@ -426,7 +427,7 @@ class PropertiesMain extends React.Component {
 					help={formData.help}
 					controller={this.propertiesController}
 					helpClickHandler={this.props.callbacks.helpClickHandler}
-					closeHandler={this.props.propertiesConfig.applyOnBlur ? this.applyPropertiesEditing.bind(this, true) : null}
+					closeHandler={applyOnBlurEnabled ? this.applyPropertiesEditing.bind(this, true) : null}
 					icon={formData.icon}
 					heading={formData.heading}
 					showHeading={this.props.propertiesConfig.heading}
@@ -436,7 +437,7 @@ class PropertiesMain extends React.Component {
 
 				buttonsContainer = (<MainEditorPropertiesButtons
 					controller={this.propertiesController}
-					okHandler={!this.props.propertiesConfig.applyOnBlur ? this.applyPropertiesEditing.bind(this, true) : null}
+					okHandler={!applyOnBlurEnabled ? this.applyPropertiesEditing.bind(this, true) : null}
 					cancelHandler={cancelHandler}
 					applyLabel={applyLabel}
 					rejectLabel={rejectLabel}
@@ -479,9 +480,17 @@ class PropertiesMain extends React.Component {
 					{editorForm}
 				</PropertiesEditor>);
 			} else if (this.props.propertiesConfig.containerType === "Custom") {
-				propertiesDialog = (<div className={classNames("properties-custom-container", { "properties-custom-container-with-heading": hasHeading })}>
-					{editorForm}
-				</div>);
+				propertiesDialog = (
+					<div className={classNames("properties-custom-container",
+						{
+							"properties-custom-container-with-heading": !applyOnBlurEnabled && hasHeading,
+							"properties-custom-container-applyOnBlur": applyOnBlurEnabled && !hasHeading,
+							"properties-custom-container-applyOnBlur-with-heading": applyOnBlurEnabled && hasHeading
+						}
+					)}
+					>
+						{editorForm}
+					</div>);
 			} else { // Modal
 				propertiesDialog = (<PropertiesModal
 					onHide={this.props.callbacks.closePropertiesDialog}

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -168,10 +168,6 @@ class PropertiesMain extends React.Component {
 		if (this.props.propertiesConfig.buttonLabels && this.props.propertiesConfig.buttonLabels.primary) {
 			return this.props.propertiesConfig.buttonLabels.primary;
 		}
-		// Update apply button text to `Close` when applyOnBlur
-		if (this.props.propertiesConfig.applyOnBlur && this.props.propertiesConfig.rightFlyout) {
-			return PropertyUtils.formatMessage(this.props.intl, MESSAGE_KEYS.PROPERTIESEDIT_CLOSEBUTTON_LABEL);
-		}
 		return PropertyUtils.formatMessage(this.props.intl, MESSAGE_KEYS.PROPERTIESEDIT_APPLYBUTTON_LABEL);
 	}
 
@@ -430,6 +426,7 @@ class PropertiesMain extends React.Component {
 					help={formData.help}
 					controller={this.propertiesController}
 					helpClickHandler={this.props.callbacks.helpClickHandler}
+					closeHandler={this.props.propertiesConfig.applyOnBlur ? this.applyPropertiesEditing.bind(this, true) : null}
 					icon={formData.icon}
 					heading={formData.heading}
 					showHeading={this.props.propertiesConfig.heading}
@@ -439,7 +436,7 @@ class PropertiesMain extends React.Component {
 
 				buttonsContainer = (<MainEditorPropertiesButtons
 					controller={this.propertiesController}
-					okHandler={this.applyPropertiesEditing.bind(this, true)}
+					okHandler={!this.props.propertiesConfig.applyOnBlur ? this.applyPropertiesEditing.bind(this, true) : null}
 					cancelHandler={cancelHandler}
 					applyLabel={applyLabel}
 					rejectLabel={rejectLabel}

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.scss
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.scss
@@ -15,6 +15,7 @@
  */
 
 @import "./properties-main-widths.scss";
+$properties-modal-buttons-height: $spacing-10;
 
 .properties-right-flyout {
 	// Set the font explicitly to 14px to shrink them across the entire properties editor
@@ -67,11 +68,17 @@
 
 
 .properties-right-flyout > .properties-custom-container {
-	height: calc(100% - 136px);
+	height: calc(100% - 65px - #{$properties-modal-buttons-height}); // Properties title - 65px
 	overflow-y: auto;
 	transform: translateZ(0); // https://github.com/elyra-ai/canvas/issues/160
 	&.properties-custom-container-with-heading {
-		height: calc(100% - 160px);
+		height: calc(100% - 89px - #{$properties-modal-buttons-height}); // Properties title - 89px
+	}
+	&.properties-custom-container-applyOnBlur {
+		height: calc(100% - #{$spacing-12}); // Properties title - 97px
+	}
+	&.properties-custom-container-applyOnBlur-with-heading {
+		height: calc(100% - 89px); // Properties title - 89px
 	}
 }
 

--- a/canvas_modules/harness/cypress/integration/canvas/nodes.js
+++ b/canvas_modules/harness/cypress/integration/canvas/nodes.js
@@ -219,7 +219,7 @@ describe("Test changing node properties is reflected in canvas", function() {
 		// Edit the name of properties flyout
 		cy.clickPropertiesFlyoutTitleEditIcon();
 		cy.enterNewPropertiesFlyoutTitle("Var File2");
-		cy.saveFlyout();
+		cy.closeFlyout();
 
 		// Verify name is updated in console
 		verifyNewPropertiesFlyoutTitleEntryInConsole("Var File2");

--- a/canvas_modules/harness/cypress/integration/canvas/tips.js
+++ b/canvas_modules/harness/cypress/integration/canvas/tips.js
@@ -268,10 +268,10 @@ describe("Test tip location adjusted based on boundaries of browser", function()
 	});
 
 	it("Test tip location adjusted based on boundaries of browser", function() {
-		cy.clickAtCoordinatesInCommonProperties(65, 100);
+		cy.clickAtCoordinatesInCommonProperties(65, 108);
 		cy.verifyTipForLabelIsVisibleAtLocation("Mode", "bottom", "Include or discard rows");
 
-		cy.clickAtCoordinatesInCommonProperties(245, 160);
+		cy.clickAtCoordinatesInCommonProperties(245, 168);
 		cy.verifyTipForLabelIsVisibleAtLocation(
 			"Modeler CLEM Condition Expression", "bottom", "Enter a boolean expression to use for filtering rows"
 		);

--- a/canvas_modules/harness/cypress/integration/canvas/tips.js
+++ b/canvas_modules/harness/cypress/integration/canvas/tips.js
@@ -268,10 +268,10 @@ describe("Test tip location adjusted based on boundaries of browser", function()
 	});
 
 	it("Test tip location adjusted based on boundaries of browser", function() {
-		cy.clickAtCoordinatesInCommonProperties(65, 108);
+		cy.clickAtCoordinatesInCommonProperties(65, 92);
 		cy.verifyTipForLabelIsVisibleAtLocation("Mode", "bottom", "Include or discard rows");
 
-		cy.clickAtCoordinatesInCommonProperties(245, 168);
+		cy.clickAtCoordinatesInCommonProperties(245, 152);
 		cy.verifyTipForLabelIsVisibleAtLocation(
 			"Modeler CLEM Condition Expression", "bottom", "Enter a boolean expression to use for filtering rows"
 		);

--- a/canvas_modules/harness/cypress/support/properties/properties-cmds.js
+++ b/canvas_modules/harness/cypress/support/properties/properties-cmds.js
@@ -29,6 +29,10 @@ Cypress.Commands.add("saveFlyout", () => {
 	cy.get(".properties-modal-buttons button[data-id='properties-apply-button']").click();
 });
 
+Cypress.Commands.add("closeFlyout", () => {
+	// When applyOnBlur set to true, show Close icon in properties title
+	cy.get(".properties-close-button > button").click({ force: true });
+});
 
 Cypress.Commands.add("openSubPanel", (title) => {
 	cy.get(".properties-summary-link-button").contains(title)


### PR DESCRIPTION
Fixes #969 

- All buttons and input text in title has height 32px

**Title without heading -**
![Screen Shot 2022-03-28 at 4 10 21 PM](https://user-images.githubusercontent.com/25124000/160502316-a8eaf71f-bfc9-422d-8302-a2da72ea7c4d.png)

![Screen Shot 2022-03-28 at 4 10 50 PM](https://user-images.githubusercontent.com/25124000/160502318-c48be343-8aa6-4ca4-8ddd-d05691e2e646.png)

**Title with heading -**
![Screen Shot 2022-03-28 at 4 09 46 PM](https://user-images.githubusercontent.com/25124000/160502369-fb4ec3e0-0c93-4e2e-bc39-695dbcd9e9c3.png)

**Title with warning/error -**
![Screen Shot 2022-03-29 at 11 11 54 AM](https://user-images.githubusercontent.com/25124000/160677623-9ffefc87-90cf-42d4-8083-7889a76fb211.png)

![Screen Shot 2022-03-29 at 11 12 15 AM](https://user-images.githubusercontent.com/25124000/160677632-115aec23-99af-446d-8dc4-bb449652bc55.png)

 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

