### PR TITLE
#980 Fixed left aligned long tooltip overlaps tooltip-trigger element

### DIFF
--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/action_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/action_paramDef.json
@@ -424,7 +424,7 @@
             "height": 60,
             "width": 60
           },
-          "tooltip_direction": "left"
+          "tooltip_direction": "bottom"
         }
       },
       {
@@ -454,7 +454,7 @@
           "resource_key": "fall"
         },
         "description": {
-          "resource_key": "fall"
+          "resource_key": "This is a long tooltip for action image. Adding this line makes it a multi-line tooltip."
         },
         "control": "image",
         "data": {
@@ -467,7 +467,7 @@
             "height": 60,
             "width": 60
           },
-          "tooltip_direction": "bottom"
+          "tooltip_direction": "left"
         }
       },
       {

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
@@ -175,7 +175,10 @@ class ToolTip extends React.Component {
 					tooltip.style.left = this.getStyleValue(viewPortWidth - tooltip.offsetWidth); // hitting right border
 				}
 			} else if (tooltipDirection === "left") {
-				tooltip.style.left = this.getStyleValue(triggerLayout.left - tooltip.offsetWidth - pointerLayout.width);
+				// For long tooltips, tooltip.offsetWidth is updated after setting tooltip.style.left. Ensure tooltip doesn't overlap tooltipTrigger element.
+				while ((tooltip.offsetLeft + tooltip.offsetWidth + pointerLayout.width) > triggerLayout.left) {
+					tooltip.style.left = this.getStyleValue(triggerLayout.left - tooltip.offsetWidth - pointerLayout.width);
+				}
 			} else if (tooltipDirection === "right") {
 				tooltip.style.left = this.getStyleValue(triggerLayout.right + pointerLayout.width);
 			}

--- a/canvas_modules/harness/cypress/integration/properties/actions.js
+++ b/canvas_modules/harness/cypress/integration/properties/actions.js
@@ -21,9 +21,13 @@ describe("Test of action image tooltip direction", function() {
 	});
 
 	it("action image tooltip direction left", function() {
-		// For "winter" image, tooltip_direction is set to "left" in paramDef
-		cy.hoverOverActionImage("winter");
-		cy.verifyTipDirectionForAction("winter", "Winter", "left");
+		// For "fall" image, tooltip_direction is set to "left" in paramDef
+		cy.hoverOverActionImage("fall");
+		cy.verifyTipDirectionForAction(
+			"fall",
+			"This is a long tooltip for action image. Adding this line makes it a multi-line tooltip.",
+			"left"
+		);
 	});
 
 	it("action image tooltip direction right", function() {
@@ -39,9 +43,9 @@ describe("Test of action image tooltip direction", function() {
 	});
 
 	it("action image tooltip direction bottom", function() {
-		// For "fall" image, tooltip_direction is set to "bottom" in paramDef
-		cy.hoverOverActionImage("fall");
-		cy.verifyTipDirectionForAction("fall", "Fall", "bottom");
+		// For "winter" image, tooltip_direction is set to "bottom" in paramDef
+		cy.hoverOverActionImage("winter");
+		cy.verifyTipDirectionForAction("winter", "Winter", "bottom");
 	});
 
 	it("When tooltip_direction is not specified, default direction is bottom", function() {

--- a/canvas_modules/harness/test_resources/parameterDefs/action_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/action_paramDef.json
@@ -424,7 +424,7 @@
             "height": 60,
             "width": 60
           },
-          "tooltip_direction": "left"
+          "tooltip_direction": "bottom"
         }
       },
       {
@@ -454,7 +454,7 @@
           "resource_key": "fall"
         },
         "description": {
-          "resource_key": "fall"
+          "resource_key": "This is a long tooltip for action image. Adding this line makes it a multi-line tooltip."
         },
         "control": "image",
         "data": {
@@ -467,7 +467,7 @@
             "height": 60,
             "width": 60
           },
-          "tooltip_direction": "bottom"
+          "tooltip_direction": "left"
         }
       },
       {


### PR DESCRIPTION
Fixes #980 

![Screen Shot 2022-03-31 at 10 46 43 AM](https://user-images.githubusercontent.com/25124000/161117889-db54d01d-b406-4bd9-b775-9b7bd8ad6fd6.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

