### PR TITLE
#994 Expression/code control python method name in codemirror express…

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.scss
@@ -45,7 +45,7 @@
 
 .cm-s-custom .cm-number { color: $text-02; }
 
-.cm-s-custom .cm-def { color: $ui-01; }
+.cm-s-custom .cm-def { color: $support-01; }
 
 .cm-s-custom .cm-variable,
 .cm-s-custom .cm-punctuation,


### PR DESCRIPTION
…ion isn't visible

Fixes : #994 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

