### PR TITLE
Fix console error

### DIFF
--- a/canvas_modules/common-canvas/src/common-canvas/cc-contents.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/cc-contents.jsx
@@ -230,7 +230,12 @@ class CanvasContents extends React.Component {
 	// the boundaries of the canvas or sets the mousePos to null. This position
 	// info can be used with keyboard operations.
 	onMouseMove(e) {
-		if (e.target.className.baseVal === "svg-area" || e.target.className.baseVal === "d3-svg-background") {
+		if (e.target &&
+			e.target.className &&
+			(
+				e.target.className.baseVal === "svg-area" ||
+				e.target.className.baseVal === "d3-svg-background"
+			)) {
 			this.mousePos = {
 				x: e.clientX,
 				y: e.clientY


### PR DESCRIPTION
Fixes #1011. An error was showing in the console when the drag event was triggered but the event target didn't have the field `e.target.className.baseVal`. This adds a check for those fields before accessing to prevent an error. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

