### PR TITLE
#1094 Filter error messages for control type hidden when filterHiddenDisable is set

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/properties-controller-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/properties-controller-test.js
@@ -66,6 +66,17 @@ const controls = [
 		}
 	},
 	{
+		name: "hidden_required_control",
+		controlType: "hidden",
+		required: true,
+		valueDef: {
+			defaultValue: undefined,
+			isList: false,
+			isMap: false,
+			propType: "string"
+		}
+	},
+	{
 		name: "param_enum",
 		valueDef: {
 			isList: true,
@@ -1696,6 +1707,14 @@ describe("Properties Controller getRequiredDefinitionIds", () => {
 
 describe("Properties Controller getRequiredErrorMessages", () => {
 	const requiredErrors = {
+		"hidden_required_control": {
+			"type": "error",
+			"text": "You must provide your hidden_required_control.",
+			"validation_id": "required_hidden_required_control_424.43891381281946",
+			"required": true,
+			"propertyId": { "name": "hidden_required_control" },
+			"displayError": false
+		},
 		"numberfieldMaxBins": {
 			"type": "error",
 			"text": "You must provide your Maximum number of bins.",
@@ -1818,6 +1837,14 @@ describe("Properties Controller getRequiredErrorMessages", () => {
 
 	it("should return all required error messages with hidden/disabled errors removed", () => {
 		controller.setErrorMessages(requiredErrors);
+		// hidden_required_control has controlType "hidden" and required "true"
+		const allErrorMessages = controller.getErrorMessages(false, false, false, false);
+		expect(allErrorMessages).to.have.property("hidden_required_control");
+		// set filterHiddenDisable: true
+		const filterHiddenDisableErrors = controller.getErrorMessages(false, true, false, false);
+		// Verify error for hidden_required_control is filtered
+		expect(filterHiddenDisableErrors).to.not.have.property("hidden_required_control");
+
 		controller.updateControlState(requiredErrors.textfieldName.propertyId, "hidden");
 		const actualRequiredErrors = controller.getRequiredErrorMessages();
 		const expectedRequiredErrors = {
@@ -1832,6 +1859,8 @@ describe("Properties Controller getRequiredErrorMessages", () => {
 			}
 		};
 		expect(actualRequiredErrors).to.eql(expectedRequiredErrors);
+		// getRequiredErrorMessages() filters error messages for controls having controlType: hidden
+		expect(actualRequiredErrors).to.not.have.property("hidden_required_control");
 
 		controller.updateControlState(requiredErrors.numberfieldMaxBins.propertyId, "disabled");
 		const actualRequiredErrors2 = controller.getRequiredErrorMessages();

--- a/canvas_modules/common-canvas/src/common-properties/properties-controller.js
+++ b/canvas_modules/common-canvas/src/common-properties/properties-controller.js
@@ -1346,7 +1346,8 @@ export default class PropertiesController {
 		// don't return hidden message
 		if (filterHiddenDisable) {
 			const controlState = this.getControlState(propertyId);
-			if (controlState === STATES.DISABLED || controlState === STATES.HIDDEN) {
+			const controlType = this.getControlType(propertyId);
+			if (controlState === STATES.DISABLED || controlState === STATES.HIDDEN || controlType === ControlType.HIDDEN) {
 				return null;
 			}
 		}
@@ -1444,7 +1445,8 @@ export default class PropertiesController {
 	_filterHiddenDisabledErrors(messages) {
 		const filterCondition = (testMessage, propertyId) => {
 			const controlState = this.getControlState(propertyId);
-			return controlState !== "hidden" && controlState !== "disabled";
+			const controlType = this.getControlType(propertyId);
+			return controlState !== STATES.HIDDEN && controlState !== STATES.DISABLED && controlType !== ControlType.HIDDEN;
 		};
 		const filteredMessages = this._filterErrors(messages, filterCondition);
 		return filteredMessages;
@@ -1632,6 +1634,9 @@ export default class PropertiesController {
 	}
 
 	getControlType(propertyId) {
+		if (typeof propertyId === "undefined") {
+			return null;
+		}
 		const control = this.getControl(propertyId);
 		if (control) {
 			return control.controlType;


### PR DESCRIPTION
Fixes #1094 

To test, use this paramDef - [DRJobs-3339.json.zip](https://github.com/elyra-ai/canvas/files/8931855/DRJobs-3339.json.zip)

`table_name` is a hidden required property. Verify error message for `table_name` is filtered in [getRequiredErrorMessages()](https://github.com/elyra-ai/canvas/blob/main/canvas_modules/common-canvas/src/common-properties/properties-controller.js#L1397) and [applyPropertyChanges()](https://github.com/elyra-ai/canvas/blob/main/canvas_modules/harness/src/client/App.js#L1322) methods when filterHiddenDisable is set to true. 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

