### PR TITLE
#1148 Use transparent background for detached-canvas sample app nodes

### DIFF
--- a/canvas_modules/harness/src/client/components/custom-canvases/detached-links/detached.scss
+++ b/canvas_modules/harness/src/client/components/custom-canvases/detached-links/detached.scss
@@ -25,8 +25,8 @@
 	.d3-node-group {
 		// Style the node body so it doesn't appear.
 		.d3-node-body-outline {
-			fill: $ui-background;
-			stroke: $ui-background;
+			fill: transparent;
+			stroke: transparent;
 		}
 
 		&.d3-node-supernode-expanded > .d3-node-body-outline {


### PR DESCRIPTION
Fixes: #1148 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

