### PR TITLE
#1160 Enable/disable summaryPanel OK button from properties controller

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/properties-controller-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/properties-controller-test.js
@@ -2243,7 +2243,7 @@ describe("Properties Controller custom table buttons", () => {
 	});
 });
 
-describe("Properties Controller setOkButtonDisable", () => {
+describe("Properties Controller setWideFlyoutPrimaryButtonDisabled", () => {
 	beforeEach(() => {
 		reset();
 	});
@@ -2256,33 +2256,33 @@ describe("Properties Controller setOkButtonDisable", () => {
 
 		// Verify OK button is enabled by default
 		let summaryPanel = testUtils.openSummaryPanel(wrapper, id);
-		let okButton = summaryPanel
+		let wideFlyoutPrimaryButton = summaryPanel
 			.find(".properties-wf-content")
 			.find(".properties-modal-buttons")
 			.find("button[data-id='properties-apply-button']");
-		expect(okButton.props()).to.have.property("disabled", false);
-		expect(okButton.prop("className").includes("bx--btn--disabled")).to.equal(false);
+		expect(wideFlyoutPrimaryButton.props()).to.have.property("disabled", false);
+		expect(wideFlyoutPrimaryButton.prop("className").includes("bx--btn--disabled")).to.equal(false);
 
 		// Disable OK button for this summary panel using controller method
-		controller.setOkButtonDisable(summaryPanelId, true);
+		controller.setWideFlyoutPrimaryButtonDisabled(summaryPanelId, true);
 		summaryPanel = testUtils.openSummaryPanel(wrapper, id);
-		okButton = summaryPanel
+		wideFlyoutPrimaryButton = summaryPanel
 			.find(".properties-wf-content")
 			.find(".properties-modal-buttons")
 			.find("button[data-id='properties-apply-button']");
-		expect(okButton.props()).to.have.property("disabled", true);
-		expect(okButton.prop("className").includes("bx--btn--disabled")).to.equal(true);
-		expect(controller.getOkButtonDisable(summaryPanelId)).to.be.true;
+		expect(wideFlyoutPrimaryButton.props()).to.have.property("disabled", true);
+		expect(wideFlyoutPrimaryButton.prop("className").includes("bx--btn--disabled")).to.equal(true);
+		expect(controller.getWideFlyoutPrimaryButtonDisabled(summaryPanelId)).to.be.true;
 
 		// Enable OK button for this summary panel using controller method
-		controller.setOkButtonDisable(summaryPanelId, false);
+		controller.setWideFlyoutPrimaryButtonDisabled(summaryPanelId, false);
 		summaryPanel = testUtils.openSummaryPanel(wrapper, id);
-		okButton = summaryPanel
+		wideFlyoutPrimaryButton = summaryPanel
 			.find(".properties-wf-content")
 			.find(".properties-modal-buttons")
 			.find("button[data-id='properties-apply-button']");
-		expect(okButton.props()).to.have.property("disabled", false);
-		expect(okButton.prop("className").includes("bx--btn--disabled")).to.equal(false);
-		expect(controller.getOkButtonDisable(summaryPanelId)).to.be.false;
+		expect(wideFlyoutPrimaryButton.props()).to.have.property("disabled", false);
+		expect(wideFlyoutPrimaryButton.prop("className").includes("bx--btn--disabled")).to.equal(false);
+		expect(controller.getWideFlyoutPrimaryButtonDisabled(summaryPanelId)).to.be.false;
 	});
 });

--- a/canvas_modules/common-canvas/__tests__/common-properties/properties-controller-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/properties-controller-test.js
@@ -2242,3 +2242,47 @@ describe("Properties Controller custom table buttons", () => {
 		expect(customButtons.at(3).prop("disabled")).to.equal(true);
 	});
 });
+
+describe("Properties Controller setOkButtonDisable", () => {
+	beforeEach(() => {
+		reset();
+	});
+	it("should disable OK button in Wide Flyout panel for given summaryPanel", () => {
+		const renderedObject = testUtils.flyoutEditorForm(structureTableParamDef);
+		controller = renderedObject.controller;
+		const wrapper = renderedObject.wrapper;
+		const id = "structuretableReadonlyColumnStartValue-summary-panel";
+		const summaryPanelId = { name: id };
+
+		// Verify OK button is enabled by default
+		let summaryPanel = testUtils.openSummaryPanel(wrapper, id);
+		let okButton = summaryPanel
+			.find(".properties-wf-content")
+			.find(".properties-modal-buttons")
+			.find("button[data-id='properties-apply-button']");
+		expect(okButton.props()).to.have.property("disabled", false);
+		expect(okButton.prop("className").includes("bx--btn--disabled")).to.equal(false);
+
+		// Disable OK button for this summary panel using controller method
+		controller.setOkButtonDisable(summaryPanelId, true);
+		summaryPanel = testUtils.openSummaryPanel(wrapper, id);
+		okButton = summaryPanel
+			.find(".properties-wf-content")
+			.find(".properties-modal-buttons")
+			.find("button[data-id='properties-apply-button']");
+		expect(okButton.props()).to.have.property("disabled", true);
+		expect(okButton.prop("className").includes("bx--btn--disabled")).to.equal(true);
+		expect(controller.getOkButtonDisable(summaryPanelId)).to.be.true;
+
+		// Enable OK button for this summary panel using controller method
+		controller.setOkButtonDisable(summaryPanelId, false);
+		summaryPanel = testUtils.openSummaryPanel(wrapper, id);
+		okButton = summaryPanel
+			.find(".properties-wf-content")
+			.find(".properties-modal-buttons")
+			.find("button[data-id='properties-apply-button']");
+		expect(okButton.props()).to.have.property("disabled", false);
+		expect(okButton.prop("className").includes("bx--btn--disabled")).to.equal(false);
+		expect(controller.getOkButtonDisable(summaryPanelId)).to.be.false;
+	});
+});

--- a/canvas_modules/common-canvas/src/common-properties/actions.js
+++ b/canvas_modules/common-canvas/src/common-properties/actions.js
@@ -37,6 +37,7 @@ export const SET_TITLE = "SET_TITLE";
 export const SET_ACTIVE_TAB = "SET_ACTIVE_TAB";
 export const DISABLE_ROW_MOVE_BUTTONS = "DISABLE_ROW_MOVE_BUTTONS";
 export const SET_SAVE_BUTTON_DISABLE = "SET_SAVE_BUTTON_DISABLE";
+export const SET_OK_BUTTON_DISABLE = "SET_OK_BUTTON_DISABLE";
 export const SET_ADD_REMOVE_ROWS = "SET_ADD_REMOVE_ROWS";
 export const UPDATE_STATIC_ROWS = "UPDATE_STATIC_ROWS";
 export const CLEAR_STATIC_ROWS = "CLEAR_STATIC_ROWS";
@@ -127,6 +128,10 @@ export function disableRowMoveButtons(propertyIds) {
 
 export function setSaveButtonDisable(disableState) {
 	return { type: SET_SAVE_BUTTON_DISABLE, disableState };
+}
+
+export function setOkButtonDisable(info) {
+	return { type: SET_OK_BUTTON_DISABLE, info };
 }
 
 export function setAddRemoveRows(info) {

--- a/canvas_modules/common-canvas/src/common-properties/actions.js
+++ b/canvas_modules/common-canvas/src/common-properties/actions.js
@@ -37,7 +37,7 @@ export const SET_TITLE = "SET_TITLE";
 export const SET_ACTIVE_TAB = "SET_ACTIVE_TAB";
 export const DISABLE_ROW_MOVE_BUTTONS = "DISABLE_ROW_MOVE_BUTTONS";
 export const SET_SAVE_BUTTON_DISABLE = "SET_SAVE_BUTTON_DISABLE";
-export const SET_OK_BUTTON_DISABLE = "SET_OK_BUTTON_DISABLE";
+export const SET_WIDE_FLYOUT_PRIMARY_BUTTON_DISABLED = "SET_WIDE_FLYOUT_PRIMARY_BUTTON_DISABLED";
 export const SET_ADD_REMOVE_ROWS = "SET_ADD_REMOVE_ROWS";
 export const UPDATE_STATIC_ROWS = "UPDATE_STATIC_ROWS";
 export const CLEAR_STATIC_ROWS = "CLEAR_STATIC_ROWS";
@@ -130,8 +130,8 @@ export function setSaveButtonDisable(disableState) {
 	return { type: SET_SAVE_BUTTON_DISABLE, disableState };
 }
 
-export function setOkButtonDisable(info) {
-	return { type: SET_OK_BUTTON_DISABLE, info };
+export function setWideFlyoutPrimaryButtonDisabled(info) {
+	return { type: SET_WIDE_FLYOUT_PRIMARY_BUTTON_DISABLED, info };
 }
 
 export function setAddRemoveRows(info) {

--- a/canvas_modules/common-canvas/src/common-properties/components/wide-flyout/wide-flyout.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/wide-flyout/wide-flyout.jsx
@@ -82,6 +82,7 @@ export default class WideFlyout extends Component {
 				showPropertiesButtons={this.props.showPropertiesButtons}
 				applyLabel={this.props.applyLabel}
 				rejectLabel={this.props.rejectLabel}
+				applyButtonEnabled={this.props.okButtonEnabled}
 			/>);
 			children = (<div className="properties-wf-children"> {this.props.children} </div>);
 		}
@@ -109,9 +110,11 @@ WideFlyout.propTypes = {
 	applyLabel: PropTypes.string,
 	rejectLabel: PropTypes.string,
 	title: PropTypes.string,
-	light: PropTypes.bool
+	light: PropTypes.bool,
+	okButtonEnabled: PropTypes.bool
 };
 
 WideFlyout.defaultProps = {
-	show: false
+	show: false,
+	okButtonEnabled: true
 };

--- a/canvas_modules/common-canvas/src/common-properties/panels/summary/summary.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/summary/summary.jsx
@@ -333,7 +333,7 @@ SummaryPanel.propTypes = {
 
 const mapStateToProps = (state, ownProps) => ({
 	panelState: ownProps.controller.getPanelState({ name: ownProps.panel.id }),
-	okButtonEnabled: !ownProps.controller.getOkButtonDisable({ name: ownProps.panel.id })
+	okButtonEnabled: !ownProps.controller.getWideFlyoutPrimaryButtonDisabled({ name: ownProps.panel.id })
 });
 
 export default connect(mapStateToProps, null)(SummaryPanel);

--- a/canvas_modules/common-canvas/src/common-properties/panels/summary/summary.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/summary/summary.jsx
@@ -299,6 +299,7 @@ class SummaryPanel extends React.Component {
 			rejectLabel={rejectLabel}
 			title={this.props.panel.label}
 			light={this.props.controller.getLight()}
+			okButtonEnabled={this.props.okButtonEnabled}
 		>
 			<div>
 				{this.props.children}
@@ -326,11 +327,13 @@ SummaryPanel.propTypes = {
 	controller: PropTypes.object.isRequired,
 	children: PropTypes.array,
 	panel: PropTypes.object.isRequired,
-	panelState: PropTypes.string // set by redux
+	panelState: PropTypes.string, // set by redux
+	okButtonEnabled: PropTypes.bool // set by redux
 };
 
 const mapStateToProps = (state, ownProps) => ({
-	panelState: ownProps.controller.getPanelState({ name: ownProps.panel.id })
+	panelState: ownProps.controller.getPanelState({ name: ownProps.panel.id }),
+	okButtonEnabled: !ownProps.controller.getOkButtonDisable({ name: ownProps.panel.id })
 });
 
 export default connect(mapStateToProps, null)(SummaryPanel);

--- a/canvas_modules/common-canvas/src/common-properties/properties-controller.js
+++ b/canvas_modules/common-canvas/src/common-properties/properties-controller.js
@@ -1630,6 +1630,22 @@ export default class PropertiesController {
 		return this.propertiesStore.getSaveButtonDisable();
 	}
 
+	/**
+	* Enable/disable OK button for given summary panel
+	* @param panelId {name: panel.id}
+	* @param okDisable boolean
+	*/
+	setOkButtonDisable(panelId, okDisable) {
+		this.propertiesStore.setOkButtonDisable(panelId, okDisable);
+	}
+
+	/**
+	* @param panelId {name: panel.id}
+	*/
+	getOkButtonDisable(panelId) {
+		return this.propertiesStore.getOkButtonDisable(panelId);
+	}
+
 	isRequired(propertyId) {
 		const control = this.getControl(propertyId);
 		if (control) {

--- a/canvas_modules/common-canvas/src/common-properties/properties-controller.js
+++ b/canvas_modules/common-canvas/src/common-properties/properties-controller.js
@@ -1633,17 +1633,17 @@ export default class PropertiesController {
 	/**
 	* Enable/disable OK button for given summary panel
 	* @param panelId {name: panel.id}
-	* @param okDisable boolean
+	* @param wideFlyoutPrimaryButtonDisable boolean
 	*/
-	setOkButtonDisable(panelId, okDisable) {
-		this.propertiesStore.setOkButtonDisable(panelId, okDisable);
+	setWideFlyoutPrimaryButtonDisabled(panelId, wideFlyoutPrimaryButtonDisable) {
+		this.propertiesStore.setWideFlyoutPrimaryButtonDisabled(panelId, wideFlyoutPrimaryButtonDisable);
 	}
 
 	/**
 	* @param panelId {name: panel.id}
 	*/
-	getOkButtonDisable(panelId) {
-		return this.propertiesStore.getOkButtonDisable(panelId);
+	getWideFlyoutPrimaryButtonDisabled(panelId) {
+		return this.propertiesStore.getWideFlyoutPrimaryButtonDisabled(panelId);
 	}
 
 	isRequired(propertyId) {

--- a/canvas_modules/common-canvas/src/common-properties/properties-store.js
+++ b/canvas_modules/common-canvas/src/common-properties/properties-store.js
@@ -25,7 +25,7 @@ import { setActionStates, updateActionState } from "./actions";
 import { clearSelectedRows, updateSelectedRows, disableRowMoveButtons } from "./actions";
 import { clearStaticRows, updateStaticRows } from "./actions";
 import { setErrorMessages, updateErrorMessage, clearErrorMessage } from "./actions";
-import { setDatasetMetadata, setSaveButtonDisable, setOkButtonDisable, setAddRemoveRows, setTableButtonEnabled, setHideEditButton } from "./actions";
+import { setDatasetMetadata, setSaveButtonDisable, setWideFlyoutPrimaryButtonDisabled, setAddRemoveRows, setTableButtonEnabled, setHideEditButton } from "./actions";
 import { setTitle, setActiveTab } from "./actions";
 import propertiesReducer from "./reducers/properties";
 import controlStatesReducer from "./reducers/control-states";
@@ -38,7 +38,7 @@ import rowFreezeReducer from "./reducers/row-static";
 import componentMetadataReducer from "./reducers/component-metadata";
 import disableRowMoveButtonsReducer from "./reducers/disable-row-move-buttons";
 import saveButtonDisableReducer from "./reducers/save-button-disable";
-import okButtonDisableReducer from "./reducers/ok-button-disable";
+import wideFlyoutPrimaryButtonDisableReducer from "./reducers/wide-flyout-primary-button-disable";
 import propertiesSettingsReducer from "./reducers/properties-settings";
 import * as PropertyUtils from "./util/property-utils.js";
 import { CONDITION_MESSAGE_TYPE, MESSAGE_KEYS } from "./constants/constants.js";
@@ -49,7 +49,7 @@ export default class PropertiesStore {
 	constructor() {
 		this.combinedReducer = combineReducers({ propertiesReducer, controlStatesReducer, panelStatesReducer,
 			errorMessagesReducer, datasetMetadataReducer, rowSelectionsReducer, componentMetadataReducer,
-			disableRowMoveButtonsReducer, actionStatesReducer, saveButtonDisableReducer, okButtonDisableReducer, propertiesSettingsReducer, rowFreezeReducer });
+			disableRowMoveButtonsReducer, actionStatesReducer, saveButtonDisableReducer, wideFlyoutPrimaryButtonDisableReducer, propertiesSettingsReducer, rowFreezeReducer });
 		let enableDevTools = false;
 		if (typeof window !== "undefined") {
 			enableDevTools = window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__();
@@ -220,18 +220,18 @@ export default class PropertiesStore {
 		return state.saveButtonDisableReducer.disable;
 	}
 
-	setOkButtonDisable(panelId, disableState) {
-		this.store.dispatch(setOkButtonDisable({ panelId: panelId, disableState: disableState }));
+	setWideFlyoutPrimaryButtonDisabled(panelId, disableState) {
+		this.store.dispatch(setWideFlyoutPrimaryButtonDisabled({ panelId: panelId, disableState: disableState }));
 	}
 
-	getOkButtonDisable(panelId) {
+	getWideFlyoutPrimaryButtonDisabled(panelId) {
 		if (typeof panelId === "undefined") {
 			return null;
 		}
 		const state = this.store.getState();
-		const disableOkButtonForPanel = state.okButtonDisableReducer[panelId.name];
-		if (typeof disableOkButtonForPanel !== "undefined") {
-			return disableOkButtonForPanel;
+		const disablePrimaryButtonForPanel = state.wideFlyoutPrimaryButtonDisableReducer[panelId.name];
+		if (typeof disablePrimaryButtonForPanel !== "undefined") {
+			return disablePrimaryButtonForPanel;
 		}
 		return null;
 	}

--- a/canvas_modules/common-canvas/src/common-properties/properties-store.js
+++ b/canvas_modules/common-canvas/src/common-properties/properties-store.js
@@ -25,7 +25,7 @@ import { setActionStates, updateActionState } from "./actions";
 import { clearSelectedRows, updateSelectedRows, disableRowMoveButtons } from "./actions";
 import { clearStaticRows, updateStaticRows } from "./actions";
 import { setErrorMessages, updateErrorMessage, clearErrorMessage } from "./actions";
-import { setDatasetMetadata, setSaveButtonDisable, setAddRemoveRows, setTableButtonEnabled, setHideEditButton } from "./actions";
+import { setDatasetMetadata, setSaveButtonDisable, setOkButtonDisable, setAddRemoveRows, setTableButtonEnabled, setHideEditButton } from "./actions";
 import { setTitle, setActiveTab } from "./actions";
 import propertiesReducer from "./reducers/properties";
 import controlStatesReducer from "./reducers/control-states";
@@ -38,6 +38,7 @@ import rowFreezeReducer from "./reducers/row-static";
 import componentMetadataReducer from "./reducers/component-metadata";
 import disableRowMoveButtonsReducer from "./reducers/disable-row-move-buttons";
 import saveButtonDisableReducer from "./reducers/save-button-disable";
+import okButtonDisableReducer from "./reducers/ok-button-disable";
 import propertiesSettingsReducer from "./reducers/properties-settings";
 import * as PropertyUtils from "./util/property-utils.js";
 import { CONDITION_MESSAGE_TYPE, MESSAGE_KEYS } from "./constants/constants.js";
@@ -48,7 +49,7 @@ export default class PropertiesStore {
 	constructor() {
 		this.combinedReducer = combineReducers({ propertiesReducer, controlStatesReducer, panelStatesReducer,
 			errorMessagesReducer, datasetMetadataReducer, rowSelectionsReducer, componentMetadataReducer,
-			disableRowMoveButtonsReducer, actionStatesReducer, saveButtonDisableReducer, propertiesSettingsReducer, rowFreezeReducer });
+			disableRowMoveButtonsReducer, actionStatesReducer, saveButtonDisableReducer, okButtonDisableReducer, propertiesSettingsReducer, rowFreezeReducer });
 		let enableDevTools = false;
 		if (typeof window !== "undefined") {
 			enableDevTools = window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__();
@@ -217,6 +218,22 @@ export default class PropertiesStore {
 	getSaveButtonDisable() {
 		const state = this.store.getState();
 		return state.saveButtonDisableReducer.disable;
+	}
+
+	setOkButtonDisable(panelId, disableState) {
+		this.store.dispatch(setOkButtonDisable({ panelId: panelId, disableState: disableState }));
+	}
+
+	getOkButtonDisable(panelId) {
+		if (typeof panelId === "undefined") {
+			return null;
+		}
+		const state = this.store.getState();
+		const disableOkButtonForPanel = state.okButtonDisableReducer[panelId.name];
+		if (typeof disableOkButtonForPanel !== "undefined") {
+			return disableOkButtonForPanel;
+		}
+		return null;
 	}
 
 	/*

--- a/canvas_modules/common-canvas/src/common-properties/reducers/ok-button-disable.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/reducers/ok-button-disable.jsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017-2022 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SET_OK_BUTTON_DISABLE } from "../actions";
+
+function setOkButtonDisable(state = [], action) {
+	switch (action.type) {
+	case SET_OK_BUTTON_DISABLE: {
+		const newState = state;
+		newState[action.info.panelId.name] = action.info.disableState;
+		return Object.assign({}, state, newState);
+	}
+	default:
+		return state;
+	}
+}
+
+export default setOkButtonDisable;

--- a/canvas_modules/common-canvas/src/common-properties/reducers/wide-flyout-primary-button-disable.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/reducers/wide-flyout-primary-button-disable.jsx
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { SET_OK_BUTTON_DISABLE } from "../actions";
+import { SET_WIDE_FLYOUT_PRIMARY_BUTTON_DISABLED } from "../actions";
 
-function setOkButtonDisable(state = [], action) {
+function setWideFlyoutPrimaryButtonDisabled(state = [], action) {
 	switch (action.type) {
-	case SET_OK_BUTTON_DISABLE: {
+	case SET_WIDE_FLYOUT_PRIMARY_BUTTON_DISABLED: {
 		const newState = state;
 		newState[action.info.panelId.name] = action.info.disableState;
 		return Object.assign({}, state, newState);
@@ -28,4 +28,4 @@ function setOkButtonDisable(state = [], action) {
 	}
 }
 
-export default setOkButtonDisable;
+export default setWideFlyoutPrimaryButtonDisabled;

--- a/canvas_modules/harness/src/client/App.js
+++ b/canvas_modules/harness/src/client/App.js
@@ -245,8 +245,8 @@ class App extends React.Component {
 			tableButtonEnabled: true,
 			staticRowsPropertyId: {},
 			staticRowsIndexes: [],
-			disableOkButtonPanelId: {},
-			okButtonDisabled: false,
+			disableWideFlyoutPrimaryButtonForPanelId: {},
+			wideFlyoutPrimaryButtonDisabled: false,
 			expressionBuilder: true,
 			heading: false,
 			light: true,
@@ -342,9 +342,9 @@ class App extends React.Component {
 		this.setStaticRows = this.setStaticRows.bind(this);
 		this.setMaxLengthForMultiLineControls = this.setMaxLengthForMultiLineControls.bind(this);
 		this.setMaxLengthForSingleLineControls = this.setMaxLengthForSingleLineControls.bind(this);
-		this.disableOkButtonPanelId = this.disableOkButtonPanelId.bind(this);
-		this.setOkButtonDisabled = this.setOkButtonDisabled.bind(this);
-		this.disableOkButton = this.disableOkButton.bind(this);
+		this.disableWideFlyoutPrimaryButtonForPanelId = this.disableWideFlyoutPrimaryButtonForPanelId.bind(this);
+		this.setWideFlyoutPrimaryButtonDisabled = this.setWideFlyoutPrimaryButtonDisabled.bind(this);
+		this.disableWideFlyoutPrimaryButton = this.disableWideFlyoutPrimaryButton.bind(this);
 
 		this.clearSavedZoomValues = this.clearSavedZoomValues.bind(this);
 		this.usePropertiesContainerType = this.usePropertiesContainerType.bind(this);
@@ -969,19 +969,19 @@ class App extends React.Component {
 	}
 
 	// Textfield to disable Ok button for given summary panel Id
-	disableOkButtonPanelId(panelId) {
-		this.setState({ disableOkButtonPanelId: panelId });
+	disableWideFlyoutPrimaryButtonForPanelId(panelId) {
+		this.setState({ disableWideFlyoutPrimaryButtonForPanelId: panelId });
 	}
 
 	// Toggle to set OK button enabled or disabled
-	setOkButtonDisabled(disabled) {
-		this.setState({ okButtonDisabled: disabled });
+	setWideFlyoutPrimaryButtonDisabled(disabled) {
+		this.setState({ wideFlyoutPrimaryButtonDisabled: disabled });
 	}
 
 	// Button to call propertiesController to set addRemoveRows
-	disableOkButton() {
+	disableWideFlyoutPrimaryButton() {
 		if (this.propertiesController) {
-			this.propertiesController.setOkButtonDisable(this.state.disableOkButtonPanelId, this.state.okButtonDisabled);
+			this.propertiesController.setWideFlyoutPrimaryButtonDisabled(this.state.disableWideFlyoutPrimaryButtonForPanelId, this.state.wideFlyoutPrimaryButtonDisabled);
 		}
 	}
 
@@ -2705,10 +2705,10 @@ class App extends React.Component {
 			conditionDisabledPropertyHandling: this.state.conditionDisabledPropertyHandling,
 			enablePropertiesValidationHandler: this.enablePropertiesValidationHandler,
 			propertiesValidationHandler: this.state.propertiesValidationHandler,
-			okButtonDisabled: this.state.okButtonDisabled,
-			disableOkButtonPanelId: this.disableOkButtonPanelId,
-			setOkButtonDisabled: this.setOkButtonDisabled,
-			disableOkButton: this.disableOkButton
+			wideFlyoutPrimaryButtonDisabled: this.state.wideFlyoutPrimaryButtonDisabled,
+			disableWideFlyoutPrimaryButtonForPanelId: this.disableWideFlyoutPrimaryButtonForPanelId,
+			setWideFlyoutPrimaryButtonDisabled: this.setWideFlyoutPrimaryButtonDisabled,
+			disableWideFlyoutPrimaryButton: this.disableWideFlyoutPrimaryButton
 		};
 
 		const sidePanelAPIConfig = {

--- a/canvas_modules/harness/src/client/App.js
+++ b/canvas_modules/harness/src/client/App.js
@@ -245,6 +245,8 @@ class App extends React.Component {
 			tableButtonEnabled: true,
 			staticRowsPropertyId: {},
 			staticRowsIndexes: [],
+			disableOkButtonPanelId: {},
+			okButtonDisabled: false,
 			expressionBuilder: true,
 			heading: false,
 			light: true,
@@ -340,6 +342,9 @@ class App extends React.Component {
 		this.setStaticRows = this.setStaticRows.bind(this);
 		this.setMaxLengthForMultiLineControls = this.setMaxLengthForMultiLineControls.bind(this);
 		this.setMaxLengthForSingleLineControls = this.setMaxLengthForSingleLineControls.bind(this);
+		this.disableOkButtonPanelId = this.disableOkButtonPanelId.bind(this);
+		this.setOkButtonDisabled = this.setOkButtonDisabled.bind(this);
+		this.disableOkButton = this.disableOkButton.bind(this);
 
 		this.clearSavedZoomValues = this.clearSavedZoomValues.bind(this);
 		this.usePropertiesContainerType = this.usePropertiesContainerType.bind(this);
@@ -962,6 +967,24 @@ class App extends React.Component {
 			this.propertiesController.updateStaticRows(this.state.staticRowsPropertyId, this.state.staticRowsIndexes);
 		}
 	}
+
+	// Textfield to disable Ok button for given summary panel Id
+	disableOkButtonPanelId(panelId) {
+		this.setState({ disableOkButtonPanelId: panelId });
+	}
+
+	// Toggle to set OK button enabled or disabled
+	setOkButtonDisabled(disabled) {
+		this.setState({ okButtonDisabled: disabled });
+	}
+
+	// Button to call propertiesController to set addRemoveRows
+	disableOkButton() {
+		if (this.propertiesController) {
+			this.propertiesController.setOkButtonDisable(this.state.disableOkButtonPanelId, this.state.okButtonDisabled);
+		}
+	}
+
 
 	initLocale() {
 		const languages = { "en": "en", "eo": "eo" };
@@ -2682,6 +2705,10 @@ class App extends React.Component {
 			conditionDisabledPropertyHandling: this.state.conditionDisabledPropertyHandling,
 			enablePropertiesValidationHandler: this.enablePropertiesValidationHandler,
 			propertiesValidationHandler: this.state.propertiesValidationHandler,
+			okButtonDisabled: this.state.okButtonDisabled,
+			disableOkButtonPanelId: this.disableOkButtonPanelId,
+			setOkButtonDisabled: this.setOkButtonDisabled,
+			disableOkButton: this.disableOkButton
 		};
 
 		const sidePanelAPIConfig = {

--- a/canvas_modules/harness/src/client/components/sidepanel-properties.jsx
+++ b/canvas_modules/harness/src/client/components/sidepanel-properties.jsx
@@ -60,7 +60,7 @@ export default class SidePanelModal extends React.Component {
 			invalidTableButtonPropertyId: true,
 			invalidSetStaticRowPropertyId: true,
 			invalidSetStaticRowIndexes: true,
-			invalidDisableOkButtonPanelId: true
+			invalidDisableWideFlyoutPrimaryButtonPanelId: true
 		};
 
 		this.onPropertiesSelect = this.onPropertiesSelect.bind(this);
@@ -92,9 +92,9 @@ export default class SidePanelModal extends React.Component {
 		this.setStaticRowsPropertyId = this.setStaticRowsPropertyId.bind(this);
 		this.setStaticRowsIndexes = this.setStaticRowsIndexes.bind(this);
 		this.setStaticRows = this.setStaticRows.bind(this);
-		this.disableOkButtonPanelId = this.disableOkButtonPanelId.bind(this);
-		this.setOkButtonDisabled = this.setOkButtonDisabled.bind(this);
-		this.disableOkButton = this.disableOkButton.bind(this);
+		this.disableWideFlyoutPrimaryButtonForPanelId = this.disableWideFlyoutPrimaryButtonForPanelId.bind(this);
+		this.setWideFlyoutPrimaryButtonDisabled = this.setWideFlyoutPrimaryButtonDisabled.bind(this);
+		this.disableWideFlyoutPrimaryButton = this.disableWideFlyoutPrimaryButton.bind(this);
 	}
 	// should be changed to componentDidMount but causes FVT tests to fail
 	UNSAFE_componentWillMount() { // eslint-disable-line camelcase, react/sort-comp
@@ -249,24 +249,24 @@ export default class SidePanelModal extends React.Component {
 	}
 
 	// Toggle to set Ok button enabled or disabled for summary panel
-	setOkButtonDisabled(disabled) {
-		this.props.propertiesConfig.setOkButtonDisabled(disabled);
+	setWideFlyoutPrimaryButtonDisabled(disabled) {
+		this.props.propertiesConfig.setWideFlyoutPrimaryButtonDisabled(disabled);
 	}
 
 	// Textfield to enter the summary panelId for disabling OK button in Wide Flyout panel
-	disableOkButtonPanelId(evt) {
+	disableWideFlyoutPrimaryButtonForPanelId(evt) {
 		try {
 			const panelId = JSON.parse(evt.target.value);
-			this.props.propertiesConfig.disableOkButtonPanelId(panelId);
-			this.setState({ invalidDisableOkButtonPanelId: false });
+			this.props.propertiesConfig.disableWideFlyoutPrimaryButtonForPanelId(panelId);
+			this.setState({ invalidDisableWideFlyoutPrimaryButtonPanelId: false });
 		} catch (ex) {
-			this.setState({ invalidDisableOkButtonPanelId: true });
+			this.setState({ invalidDisableWideFlyoutPrimaryButtonPanelId: true });
 		}
 	}
 
 	// Button to submit disable Ok button data and call propertiesController
-	disableOkButton(evt) {
-		this.props.propertiesConfig.disableOkButton();
+	disableWideFlyoutPrimaryButton(evt) {
+		this.props.propertiesConfig.disableWideFlyoutPrimaryButton();
 	}
 
 	submitProperties() {
@@ -798,36 +798,36 @@ export default class SidePanelModal extends React.Component {
 			</Button>
 		</div>);
 
-		const disableOkButtonPanelId = (
+		const disableWideFlyoutPrimaryButtonForPanelId = (
 			<div className="harness-sidepanel-children" id="sidepanel-properties-disable-ok-button-panelid">
 				<TextInput
 					labelText="Set the summary panel id for enabling/disabling OK button in Wide Flyout"
-					id="harness-panelId-disableOkButton"
+					id="harness-panelId-disableWideFlyoutPrimaryButton"
 					placeholder='{ "name": "panelId" }'
-					invalid={this.state.invalidDisableOkButtonPanelId}
+					invalid={this.state.invalidDisableWideFlyoutPrimaryButtonPanelId}
 					invalidText="Please enter valid JSON"
-					onChange={ this.disableOkButtonPanelId }
+					onChange={ this.disableWideFlyoutPrimaryButtonForPanelId }
 					helperText='PanelId format: {"name": "unique_id_for_panel"}'
 				/>
 			</div>
 		);
 
-		const setOkButtonDisabled = (
+		const setWideFlyoutPrimaryButtonDisabled = (
 			<div className="harness-sidepanel-children" id="sidepanel-properties-set-ok-button-disabled">
 				<Toggle
-					id="harness-sidepanel-setOkButtonDisabled-toggle"
+					id="harness-sidepanel-setWideFlyoutPrimaryButtonDisabled-toggle"
 					labelText="Set OK button disabled for the summary panelId entered above"
 					labelA="Enable Ok button"
 					labelB="Disable OK button"
-					toggled={this.props.propertiesConfig.okButtonDisabled}
-					onToggle={this.setOkButtonDisabled}
+					toggled={this.props.propertiesConfig.wideFlyoutPrimaryButtonDisabled}
+					onToggle={this.setWideFlyoutPrimaryButtonDisabled}
 				/>
 			</div>);
 
-		const disableOkButton = (<div className="harness-sidepanel-children" id="sidepanel-properties-disable-ok-button-submit">
+		const disableWideFlyoutPrimaryButton = (<div className="harness-sidepanel-children" id="sidepanel-properties-disable-ok-button-submit">
 			<Button size="small"
-				disabled={this.state.invalidDisableOkButtonPanelId}
-				onClick={this.props.propertiesConfig.disableOkButton}
+				disabled={this.state.invalidDisableWideFlyoutPrimaryButtonPanelId}
+				onClick={this.props.propertiesConfig.disableWideFlyoutPrimaryButton}
 			>
 				Submit
 			</Button>
@@ -889,9 +889,9 @@ export default class SidePanelModal extends React.Component {
 				{setStaticRowsIndexes}
 				{submitStaticRows}
 				{divider}
-				{disableOkButtonPanelId}
-				{setOkButtonDisabled}
-				{disableOkButton}
+				{disableWideFlyoutPrimaryButtonForPanelId}
+				{setWideFlyoutPrimaryButtonDisabled}
+				{disableWideFlyoutPrimaryButton}
 			</div>
 		);
 	}
@@ -955,9 +955,9 @@ SidePanelModal.propTypes = {
 		conditionDisabledPropertyHandling: PropTypes.string,
 		enablePropertiesValidationHandler: PropTypes.func,
 		propertiesValidationHandler: PropTypes.bool,
-		okButtonDisabled: PropTypes.bool,
-		disableOkButtonPanelId: PropTypes.func,
-		setOkButtonDisabled: PropTypes.func,
-		disableOkButton: PropTypes.func
+		wideFlyoutPrimaryButtonDisabled: PropTypes.bool,
+		disableWideFlyoutPrimaryButtonForPanelId: PropTypes.func,
+		setWideFlyoutPrimaryButtonDisabled: PropTypes.func,
+		disableWideFlyoutPrimaryButton: PropTypes.func
 	})
 };

--- a/canvas_modules/harness/src/client/components/sidepanel-properties.jsx
+++ b/canvas_modules/harness/src/client/components/sidepanel-properties.jsx
@@ -59,7 +59,8 @@ export default class SidePanelModal extends React.Component {
 			invalidSetHideEditButtonPropertyId: true,
 			invalidTableButtonPropertyId: true,
 			invalidSetStaticRowPropertyId: true,
-			invalidSetStaticRowIndexes: true
+			invalidSetStaticRowIndexes: true,
+			invalidDisableOkButtonPanelId: true
 		};
 
 		this.onPropertiesSelect = this.onPropertiesSelect.bind(this);
@@ -91,6 +92,9 @@ export default class SidePanelModal extends React.Component {
 		this.setStaticRowsPropertyId = this.setStaticRowsPropertyId.bind(this);
 		this.setStaticRowsIndexes = this.setStaticRowsIndexes.bind(this);
 		this.setStaticRows = this.setStaticRows.bind(this);
+		this.disableOkButtonPanelId = this.disableOkButtonPanelId.bind(this);
+		this.setOkButtonDisabled = this.setOkButtonDisabled.bind(this);
+		this.disableOkButton = this.disableOkButton.bind(this);
 	}
 	// should be changed to componentDidMount but causes FVT tests to fail
 	UNSAFE_componentWillMount() { // eslint-disable-line camelcase, react/sort-comp
@@ -242,6 +246,27 @@ export default class SidePanelModal extends React.Component {
 	// Button to submit StaticRows data and call propertiesController
 	setStaticRows(evt) {
 		this.props.propertiesConfig.setStaticRows();
+	}
+
+	// Toggle to set Ok button enabled or disabled for summary panel
+	setOkButtonDisabled(disabled) {
+		this.props.propertiesConfig.setOkButtonDisabled(disabled);
+	}
+
+	// Textfield to enter the summary panelId for disabling OK button in Wide Flyout panel
+	disableOkButtonPanelId(evt) {
+		try {
+			const panelId = JSON.parse(evt.target.value);
+			this.props.propertiesConfig.disableOkButtonPanelId(panelId);
+			this.setState({ invalidDisableOkButtonPanelId: false });
+		} catch (ex) {
+			this.setState({ invalidDisableOkButtonPanelId: true });
+		}
+	}
+
+	// Button to submit disable Ok button data and call propertiesController
+	disableOkButton(evt) {
+		this.props.propertiesConfig.disableOkButton();
 	}
 
 	submitProperties() {
@@ -773,6 +798,41 @@ export default class SidePanelModal extends React.Component {
 			</Button>
 		</div>);
 
+		const disableOkButtonPanelId = (
+			<div className="harness-sidepanel-children" id="sidepanel-properties-disable-ok-button-panelid">
+				<TextInput
+					labelText="Set the summary panel id for enabling/disabling OK button in Wide Flyout"
+					id="harness-panelId-disableOkButton"
+					placeholder='{ "name": "panelId" }'
+					invalid={this.state.invalidDisableOkButtonPanelId}
+					invalidText="Please enter valid JSON"
+					onChange={ this.disableOkButtonPanelId }
+					helperText='PanelId format: {"name": "unique_id_for_panel"}'
+				/>
+			</div>
+		);
+
+		const setOkButtonDisabled = (
+			<div className="harness-sidepanel-children" id="sidepanel-properties-set-ok-button-disabled">
+				<Toggle
+					id="harness-sidepanel-setOkButtonDisabled-toggle"
+					labelText="Set OK button disabled for the summary panelId entered above"
+					labelA="Enable Ok button"
+					labelB="Disable OK button"
+					toggled={this.props.propertiesConfig.okButtonDisabled}
+					onToggle={this.setOkButtonDisabled}
+				/>
+			</div>);
+
+		const disableOkButton = (<div className="harness-sidepanel-children" id="sidepanel-properties-disable-ok-button-submit">
+			<Button size="small"
+				disabled={this.state.invalidDisableOkButtonPanelId}
+				onClick={this.props.propertiesConfig.disableOkButton}
+			>
+				Submit
+			</Button>
+		</div>);
+
 		const divider = (<div className="harness-sidepanel-children harness-sidepanel-divider" />);
 		return (
 			<div>
@@ -828,6 +888,10 @@ export default class SidePanelModal extends React.Component {
 				{setStaticRowsPropertyId}
 				{setStaticRowsIndexes}
 				{submitStaticRows}
+				{divider}
+				{disableOkButtonPanelId}
+				{setOkButtonDisabled}
+				{disableOkButton}
 			</div>
 		);
 	}
@@ -890,6 +954,10 @@ SidePanelModal.propTypes = {
 		setConditionDisabledPropertyHandling: PropTypes.func,
 		conditionDisabledPropertyHandling: PropTypes.string,
 		enablePropertiesValidationHandler: PropTypes.func,
-		propertiesValidationHandler: PropTypes.bool
+		propertiesValidationHandler: PropTypes.bool,
+		okButtonDisabled: PropTypes.bool,
+		disableOkButtonPanelId: PropTypes.func,
+		setOkButtonDisabled: PropTypes.func,
+		disableOkButton: PropTypes.func
 	})
 };


### PR DESCRIPTION
Fixes #1160 

For testing, set summaryPanel id here in test harness - 
![Screen Shot 2022-08-23 at 9 34 50 PM](https://user-images.githubusercontent.com/25124000/186331807-37c24323-c6c6-4158-998c-5a6b0ec094b0.png)


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

