### PR TITLE
#1172 Add registry flag in npm publish

### DIFF
--- a/scripts/publish_modules.sh
+++ b/scripts/publish_modules.sh
@@ -59,4 +59,4 @@ commit_changes ${MAIN} "Update Elyra Canvas to version ${NPM_VERSION} [skip ci]"
 
 echo "Publishing Elyra Canvas $NPM_VERSION to Artifactory NPM"
 echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ~/.npmrc
-npm publish --userconfig=~/.npmrc
+npm publish --userconfig=~/.npmrc --registry=https://registry.npmjs.org


### PR DESCRIPTION
#1172 

npm registry URL copied from here - https://docs.npmjs.com/cli/v6/using-npm/registry
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

