### PR TITLE
#1210 Added padding for empty table placeholder text

### DIFF
--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/structurelisteditor_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/structurelisteditor_paramDef.json
@@ -846,7 +846,7 @@
           "default": "Empty table with no add-remove buttons"
         },
         "place_holder_text": {
-          "default": "Empty table placeholder text"
+          "default": "Empty table placeholder text. This is a multi-line long long long long long text. It should have some left and right padding."
         }
       },
       {

--- a/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.scss
@@ -134,6 +134,7 @@ $row-left-padding: $spacing-02;
 	display: flex;
 	justify-content: center;
 	align-items: center;
+	padding: 0 $spacing-05;
 	@include carbon--type-style("body-long-01");
 }
 

--- a/canvas_modules/harness/test_resources/parameterDefs/structurelisteditor_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/structurelisteditor_paramDef.json
@@ -846,7 +846,7 @@
           "default": "Empty table with no add-remove buttons"
         },
         "place_holder_text": {
-          "default": "Empty table placeholder text"
+          "default": "Empty table placeholder text. This is a multi-line long long long long long text. It should have some left and right padding."
         }
       },
       {


### PR DESCRIPTION
Fixes #1210 

Multi-line text -
![Screen Shot 2022-10-17 at 5 16 43 PM](https://user-images.githubusercontent.com/25124000/196306744-82cdbbc8-50dc-4b88-a747-3a952bb4f7ef.png)

Single line text -
![Screen Shot 2022-10-17 at 5 16 57 PM](https://user-images.githubusercontent.com/25124000/196306770-46a5c4a6-dbd1-42f2-8ad6-edbea549a4a7.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

