### PR TITLE
#1215 Support info icons in table header labels

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/structuretable-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/structuretable-test.js
@@ -375,6 +375,28 @@ describe("structuretable control renders correctly", () => {
 		expect(moveableRowsContainer.find("button.table-row-move-button[disabled=true]")).to.have.length(4);
 	});
 
+	it("Should display header labels with tooltip and info icon correctly", () => {
+		const renderedObject = propertyUtils.flyoutEditorForm(structuretableParamDef);
+		const wrapper = renderedObject.wrapper;
+
+		const table = propertyUtils.openSummaryPanel(wrapper, "structuretableReadonlyColumnDefaultIndex-summary-panel");
+		const header = tableUtils.getTableHeaderRows(table);
+		expect(header).to.have.length(1);
+		// console.log(header.debug());
+
+		const columns = header.find(".properties-vt-column");
+		expect(columns).to.have.length(7);
+
+		expect(columns.at(0).find(".tooltip-container")).to.have.length(1);
+		expect(columns.at(1).find(".tooltip-container")).to.have.length(1);
+		expect(columns.at(2).find(".tooltip-container")).to.have.length(2);
+		expect(columns.at(2).find(".properties-vt-info-icon")).to.have.length(1);
+		expect(columns.at(3).find(".tooltip-container")).to.have.length(1);
+		expect(columns.at(4).find(".tooltip-container")).to.have.length(2);
+		expect(columns.at(4).find(".properties-vt-info-icon")).to.have.length(1);
+		expect(columns.at(5).find(".tooltip-container")).to.have.length(2);
+		expect(columns.at(5).find(".properties-vt-info-icon")).to.have.length(1);
+	});
 
 	it("should select add columns button and field picker should display", () => {
 		setPropertyValue();

--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/structuretable-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/structuretable-test.js
@@ -390,12 +390,12 @@ describe("structuretable control renders correctly", () => {
 		expect(columns.at(0).find(".tooltip-container")).to.have.length(1);
 		expect(columns.at(1).find(".tooltip-container")).to.have.length(1);
 		expect(columns.at(2).find(".tooltip-container")).to.have.length(2);
-		expect(columns.at(2).find(".properties-vt-info-icon")).to.have.length(1);
+		expect(columns.at(2).find("svg.properties-vt-info-icon")).to.have.length(1);
 		expect(columns.at(3).find(".tooltip-container")).to.have.length(1);
 		expect(columns.at(4).find(".tooltip-container")).to.have.length(2);
-		expect(columns.at(4).find(".properties-vt-info-icon")).to.have.length(1);
+		expect(columns.at(4).find("svg.properties-vt-info-icon")).to.have.length(1);
 		expect(columns.at(5).find(".tooltip-container")).to.have.length(2);
-		expect(columns.at(5).find(".properties-vt-info-icon")).to.have.length(1);
+		expect(columns.at(5).find("svg.properties-vt-info-icon")).to.have.length(1);
 	});
 
 	it("should select add columns button and field picker should display", () => {

--- a/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
@@ -17,9 +17,9 @@
 import { Column, Table, AutoSizer } from "react-virtualized";
 import Draggable from "react-draggable";
 import { Checkbox, Loading } from "carbon-components-react";
-import { ArrowUp16, ArrowDown16, ArrowsVertical16 } from "@carbon/icons-react";
+import { ArrowUp16, ArrowDown16, ArrowsVertical16, Information16 } from "@carbon/icons-react";
 import Tooltip from "./../../../tooltip/tooltip.jsx";
-import { SORT_DIRECTION, STATES, ROW_SELECTION, MINIMUM_COLUMN_WIDTH, MINIMUM_COLUMN_WIDTH_WITHOUT_LABEL } from "./../../constants/constants";
+import { SORT_DIRECTION, STATES, ROW_SELECTION, MINIMUM_COLUMN_WIDTH, MINIMUM_COLUMN_WIDTH_WITHOUT_LABEL, CARBON_ICONS } from "./../../constants/constants";
 import { injectIntl } from "react-intl";
 import defaultMessages from "../../../../locales/common-properties/locales/en.json";
 
@@ -234,28 +234,25 @@ class VirtualizedTable extends React.Component {
 			</span>);
 		}
 
-		let tooltip = null;
-		if (columnData.description && columnData.headerLabel) {
-			tooltip = (
-				<div className="properties-tooltips">
-					<span style= {{ fontWeight: "bold" }}>{columnData.headerLabel}</span>
-					<br />
-					{columnData.description}
-				</div>
-			);
-		} else if (columnData.description) {
-			tooltip = (
-				<div className="properties-tooltips">
-					{columnData.description}
-				</div>
-			);
-		} else if (columnData.headerLabel) {
-			tooltip = (
-				<div className="properties-tooltips">
-					<span style= {{ fontWeight: "bold" }}>{columnData.headerLabel}</span>
-				</div>
-			);
-		}
+		const tooltip = columnData.headerLabel
+			? (<div className="properties-tooltips">
+				<span style= {{ fontWeight: "bold" }}>{columnData.headerLabel}</span>
+			</div>)
+			: null;
+
+		const infoIcon = isEmpty(columnData.description)
+			? null
+			: (<div className="properties-vt-info-icon-tip">
+				<Tooltip
+					id={`properties-tooltip-${columnData.headerLabel}-info`}
+					tip={columnData.description}
+					direction="bottom"
+					className="properties-tooltips"
+					showToolTipOnClick
+				>
+					<Information16 className="properties-vt-info-icon" />
+				</Tooltip>
+			</div>);
 
 		const tooltipId = uuid4() + "-tooltip-column-" + dataKey;
 
@@ -279,20 +276,27 @@ class VirtualizedTable extends React.Component {
 			</Draggable>)
 			: "";
 
+		const header = isEmpty(tooltip)
+			? (<div className="properties-vt-label-icon">
+				{label}
+				{infoIcon}
+			</div>)
+			: (<div className="properties-vt-label-tip-icon">
+				<Tooltip
+					id={tooltipId}
+					tip={tooltip}
+					direction="bottom"
+					className="properties-tooltips"
+				>
+					{label}
+				</Tooltip>
+				{infoIcon}
+			</div>);
+
 		return (
 			<div className={classNames({ "properties-vt-column-with-resize": resizeElem !== "", "properties-vt-column-without-resize": resizeElem === "" })}>
 				<div className={classNames("properties-vt-column properties-tooltips-container", { "sort-column-active": dataKey === this.props.sortBy })}>
-					{ isEmpty(tooltip)
-						? label
-						: <Tooltip
-							id={tooltipId}
-							tip={tooltip}
-							direction="bottom"
-							className="properties-tooltips"
-						>
-							{label}
-						</Tooltip>
-					}
+					{header}
 					{disableSort === false && sortIcon}
 				</div>
 				{ resizeElem }

--- a/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.jsx
@@ -19,7 +19,7 @@ import Draggable from "react-draggable";
 import { Checkbox, Loading } from "carbon-components-react";
 import { ArrowUp16, ArrowDown16, ArrowsVertical16, Information16 } from "@carbon/icons-react";
 import Tooltip from "./../../../tooltip/tooltip.jsx";
-import { SORT_DIRECTION, STATES, ROW_SELECTION, MINIMUM_COLUMN_WIDTH, MINIMUM_COLUMN_WIDTH_WITHOUT_LABEL, CARBON_ICONS } from "./../../constants/constants";
+import { SORT_DIRECTION, STATES, ROW_SELECTION, MINIMUM_COLUMN_WIDTH, MINIMUM_COLUMN_WIDTH_WITHOUT_LABEL } from "./../../constants/constants";
 import { injectIntl } from "react-intl";
 import defaultMessages from "../../../../locales/common-properties/locales/en.json";
 

--- a/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.scss
@@ -108,6 +108,12 @@
 		.properties-vt-info-icon-tip {
 			height: $spacing-05;
 			margin-left: $spacing-03;
+
+			.properties-vt-info-icon {
+				&:hover {
+					cursor: pointer;
+				}
+			}
 		}
 	}
 

--- a/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/virtualized-table/virtualized-table.scss
@@ -100,6 +100,17 @@
 		}
 	}
 
+	.properties-vt-label-tip-icon {
+		width: inherit;
+		display: flex;
+		align-items: center;
+
+		.properties-vt-info-icon-tip {
+			height: $spacing-05;
+			margin-left: $spacing-03;
+		}
+	}
+
 	.properties-vt-row-checkbox {
 		height: $spacing-07;
 		margin-left: $spacing-05;


### PR DESCRIPTION
closes #1215 
 
![table header info icon description](https://user-images.githubusercontent.com/1628100/197265083-e9f7706a-d085-42e2-808e-ef8d59a67e6b.gif)


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

