### PR TITLE
#1324 Support 'max' option for editor_size in common-properties

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/common-properties-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/common-properties-test.js
@@ -368,6 +368,27 @@ describe("CommonProperties works correctly in flyout", () => {
 		expect(wrapper.find("aside.properties-medium").get(0).props.style).to.have.property("width", "400px");
 	});
 
+	it("When enableResize=true and editor_size=large and pixel_width min and max are set resize button should be rendered", () => {
+		const newPropertiesInfo = JSON.parse(JSON.stringify(propertiesInfo));
+		newPropertiesInfo.parameterDef.uihints.editor_size = "large";
+		newPropertiesInfo.parameterDef.uihints.pixel_width = { min: 400, max: 800 };
+		const renderedObject = propertyUtils.flyoutEditorForm(newPropertiesInfo.parameterDef, { enableResize: true });
+		wrapper = renderedObject.wrapper;
+		const resizeBtn = wrapper.find("button.properties-btn-resize");
+		expect(resizeBtn).to.have.length(1);
+		expect(wrapper.find("aside.properties-large")).to.have.length(1);
+		expect(wrapper.find("aside.properties-max")).to.have.length(0);
+		expect(wrapper.find("aside.properties-large").get(0).props.style).to.have.property("width", "400px");
+		resizeBtn.simulate("click");
+		expect(wrapper.find("aside.properties-large")).to.have.length(0);
+		expect(wrapper.find("aside.properties-max")).to.have.length(1);
+		expect(wrapper.find("aside.properties-max").get(0).props.style).to.have.property("width", "800px");
+		resizeBtn.simulate("click");
+		expect(wrapper.find("aside.properties-large")).to.have.length(1);
+		expect(wrapper.find("aside.properties-max")).to.have.length(0);
+		expect(wrapper.find("aside.properties-large").get(0).props.style).to.have.property("width", "400px");
+	});
+
 	it("When enableResize=true and editor_size=small and pixel_width min and max are the same the resize button should not be rendered", () => {
 		const newPropertiesInfo = JSON.parse(JSON.stringify(propertiesInfo));
 		newPropertiesInfo.parameterDef.uihints.editor_size = "small";
@@ -392,26 +413,38 @@ describe("CommonProperties works correctly in flyout", () => {
 		expect(wrapper.find("aside.properties-medium").get(0).props.style).to.have.property("width", "800px");
 	});
 
-	it("When enableResize=true and editor_size=large and pixel_width is ommited the resize button should not be rendered", () => {
+	it("When enableResize=true and editor_size=large and pixel_width min and max are the same the resize button should not be rendered", () => {
 		const newPropertiesInfo = JSON.parse(JSON.stringify(propertiesInfo));
 		newPropertiesInfo.parameterDef.uihints.editor_size = "large";
-		const renderedObject = propertyUtils.flyoutEditorForm(newPropertiesInfo.parameterDef, { enableResize: true });
-		wrapper = renderedObject.wrapper;
-		const resizeBtn = wrapper.find("button.properties-btn-resize");
-		expect(resizeBtn).to.have.length(0);
-		expect(wrapper.find("aside.properties-large")).to.have.length(1);
-	});
-
-	it("When enableResize=true and editor_size=large and pixel_width min and max is provided the resize button should not be rendered", () => {
-		const newPropertiesInfo = JSON.parse(JSON.stringify(propertiesInfo));
-		newPropertiesInfo.parameterDef.uihints.editor_size = "large";
-		newPropertiesInfo.parameterDef.uihints.pixel_width = { min: 400, max: 800 };
+		newPropertiesInfo.parameterDef.uihints.pixel_width = { min: 800, max: 800 };
 		const renderedObject = propertyUtils.flyoutEditorForm(newPropertiesInfo.parameterDef, { enableResize: true });
 		wrapper = renderedObject.wrapper;
 		const resizeBtn = wrapper.find("button.properties-btn-resize");
 		expect(resizeBtn).to.have.length(0);
 		expect(wrapper.find("aside.properties-large")).to.have.length(1);
 		expect(wrapper.find("aside.properties-large").get(0).props.style).to.have.property("width", "800px");
+	});
+
+	it("When enableResize=true and editor_size=max and pixel_width is ommited the resize button should not be rendered", () => {
+		const newPropertiesInfo = JSON.parse(JSON.stringify(propertiesInfo));
+		newPropertiesInfo.parameterDef.uihints.editor_size = "max";
+		const renderedObject = propertyUtils.flyoutEditorForm(newPropertiesInfo.parameterDef, { enableResize: true });
+		wrapper = renderedObject.wrapper;
+		const resizeBtn = wrapper.find("button.properties-btn-resize");
+		expect(resizeBtn).to.have.length(0);
+		expect(wrapper.find("aside.properties-max")).to.have.length(1);
+	});
+
+	it("When enableResize=true and editor_size=max and pixel_width min and max is provided the resize button should not be rendered", () => {
+		const newPropertiesInfo = JSON.parse(JSON.stringify(propertiesInfo));
+		newPropertiesInfo.parameterDef.uihints.editor_size = "max";
+		newPropertiesInfo.parameterDef.uihints.pixel_width = { min: 400, max: 1000 }; // set pixel_width more than width of "max" editor_size
+		const renderedObject = propertyUtils.flyoutEditorForm(newPropertiesInfo.parameterDef, { enableResize: true });
+		wrapper = renderedObject.wrapper;
+		const resizeBtn = wrapper.find("button.properties-btn-resize");
+		expect(resizeBtn).to.have.length(0);
+		expect(wrapper.find("aside.properties-max")).to.have.length(1);
+		expect(wrapper.find("aside.properties-max").get(0).props.style).to.have.property("width", "1000px");
 	});
 
 	it("When enableResize=true and editor_size is omitted and pixel_width min and max are the same the resize button should not be rendered", () => {
@@ -492,6 +525,25 @@ describe("CommonProperties works correctly in flyout", () => {
 		expect(wrapper.find("aside.properties-medium")).to.have.length(1);
 	});
 
+	it("should set editorSize to defaultEditorSize when defaultEditorSize='medium' and initialEditorSize='max'", () => {
+		// defaultEditorSize is medium & initialEditorSize is max
+		const newPropertiesInfo = JSON.parse(JSON.stringify(propertiesInfo));
+		newPropertiesInfo.parameterDef.uihints.editor_size = "medium";
+		newPropertiesInfo.initialEditorSize = "max";
+
+		wrapper = mount(
+			<IntlProvider key="IntlProvider2" locale={ locale }>
+				<CommonProperties
+					propertiesInfo={newPropertiesInfo}
+					callbacks={callbacks}
+				/>
+			</IntlProvider>
+		);
+		// Right flyout panel should have editorSize medium
+		expect(wrapper.find("aside.properties-max")).to.have.length(0);
+		expect(wrapper.find("aside.properties-medium")).to.have.length(1);
+	});
+
 	it("should set editorSize in controller on clicking resize button", () => {
 		// Default editorSize is small & initialEditorSize is undefined
 		const newPropertiesInfo = JSON.parse(JSON.stringify(propertiesInfo));
@@ -511,6 +563,27 @@ describe("CommonProperties works correctly in flyout", () => {
 		// Right flyout panel should have editorSize medium
 		expect(wrapper.find("aside.properties-small")).to.have.length(0);
 		expect(wrapper.find("aside.properties-medium")).to.have.length(1);
+	});
+
+	it("should be able to resize rightFlyout from large to max", () => {
+		// Default editorSize is large & initialEditorSize is undefined
+		const newPropertiesInfo = JSON.parse(JSON.stringify(propertiesInfo));
+		newPropertiesInfo.parameterDef.uihints.editor_size = "large";
+		const renderedObject = propertyUtils.flyoutEditorForm(newPropertiesInfo.parameterDef);
+		wrapper = renderedObject.wrapper;
+
+		// Right flyout panel should have editorSize large
+		expect(wrapper.find("aside.properties-large")).to.have.length(1);
+		expect(wrapper.find("aside.properties-max")).to.have.length(0);
+
+		// Click on resize button
+		wrapper.find("button.properties-btn-resize").simulate("click");
+
+		//	controller should set editorSize to max
+		expect(renderedObject.controller.getEditorSize()).to.equal("max");
+		// Right flyout panel should have editorSize max
+		expect(wrapper.find("aside.properties-large")).to.have.length(0);
+		expect(wrapper.find("aside.properties-max")).to.have.length(1);
 	});
 
 	it("when light=true, common properties should render with light mode enabled", () => {
@@ -567,6 +640,14 @@ describe("Common properties modals return the correct Carbon modal size", () => 
 
 	it("should return 'lg' when editor_size is 'large'", () => {
 		newPropertiesInfo.parameterDef.uihints.editor_size = "large";
+		const renderedObject = propertyUtils.flyoutEditorForm(newPropertiesInfo.parameterDef, { containerType: "Modal" });
+		wrapper = renderedObject.wrapper;
+		const modalInstance = wrapper.find(PropertiesDialog).instance();
+		expect(modalInstance.getCarbonModalSize()).to.equal(CARBON_MODAL_SIZE_LARGE);
+	});
+
+	it("should return 'lg' when editor_size is 'max'", () => {
+		newPropertiesInfo.parameterDef.uihints.editor_size = "max";
 		const renderedObject = propertyUtils.flyoutEditorForm(newPropertiesInfo.parameterDef, { containerType: "Modal" });
 		wrapper = renderedObject.wrapper;
 		const modalInstance = wrapper.find(PropertiesDialog).instance();

--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/Filter_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/Filter_paramDef.json
@@ -79,7 +79,7 @@
     "label": {
       "default": "Filter Test"
     },
-    "editor_size": "medium",
+    "editor_size": "max",
     "complex_type_info": [
       {
         "complex_type_ref": "fieldFilterEntry",

--- a/canvas_modules/common-canvas/src/common-properties/components/properties-modal/properties-modal.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/properties-modal/properties-modal.jsx
@@ -29,6 +29,7 @@ export default class PropertiesModal extends Component {
 		switch (this.props.bsSize) {
 		case Size.SMALL: return CARBON_MODAL_SIZE_XSMALL;
 		case Size.LARGE: return CARBON_MODAL_SIZE_LARGE;
+		case Size.MAX: return CARBON_MODAL_SIZE_LARGE;
 		case Size.MEDIUM:
 		default: return CARBON_MODAL_SIZE_SMALL;
 		}
@@ -70,4 +71,3 @@ PropertiesModal.propTypes = {
 	rejectLabel: PropTypes.string,
 	classNames: PropTypes.string
 };
-

--- a/canvas_modules/common-canvas/src/common-properties/constants/form-constants.js
+++ b/canvas_modules/common-canvas/src/common-properties/constants/form-constants.js
@@ -36,6 +36,7 @@ const EditStyle = {
 };
 
 const Size = {
+	MAX: "max",
 	LARGE: "large",
 	MEDIUM: "medium",
 	SMALL: "small"

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main-widths.scss
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main-widths.scss
@@ -17,11 +17,13 @@
 $common-properties-small-flyout-width: 320px; // This aligns the right-flyout with the divider in DSX header
 $common-properties-medium-flyout-width: 480px; // This is an arbitrary width for medium sized flyout panels
 $common-properties-large-flyout-width: 640px; // This is an arbitrary width for large sized flyout panels
+$common-properties-max-flyout-width: 900px; // This is an arbitrary width for max sized flyout panels
 
 // sass-lint:disable no-misspelled-properties
 :export {
 	flyoutWidthSmall: $common-properties-small-flyout-width;
 	flyoutWidthMedium: $common-properties-medium-flyout-width;
 	flyoutWidthLarge: $common-properties-large-flyout-width;
+	flyoutWidthMax: $common-properties-max-flyout-width;
 }
 // sass-lint:enable no-misspelled-properties

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.scss
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.scss
@@ -34,6 +34,9 @@ $properties-modal-buttons-height: $spacing-10;
 	&.properties-large {
 		width: $common-properties-large-flyout-width;
 	}
+	&.properties-max {
+		width: $common-properties-max-flyout-width;
+	}
 	&:hover {
 		.properties-btn-resize {
 			visibility: visible;

--- a/canvas_modules/harness/src/client/components/sidepanel-properties.jsx
+++ b/canvas_modules/harness/src/client/components/sidepanel-properties.jsx
@@ -571,6 +571,10 @@ export default class SidePanelModal extends React.Component {
 				id: EDITOR_SIZE.LARGE,
 				label: EDITOR_SIZE.LARGE,
 			},
+			{
+				id: EDITOR_SIZE.MAX,
+				label: EDITOR_SIZE.MAX,
+			}
 		];
 
 		const persistEditorSize = (

--- a/canvas_modules/harness/src/client/constants/constants.js
+++ b/canvas_modules/harness/src/client/constants/constants.js
@@ -152,5 +152,6 @@ _defineConstant("EDITOR_SIZE", {
 	UNSET: "unset",
 	SMALL: "small",
 	MEDIUM: "medium",
-	LARGE: "large"
+	LARGE: "large",
+	MAX: "max"
 });

--- a/canvas_modules/harness/test_resources/parameterDefs/Filter_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/Filter_paramDef.json
@@ -79,7 +79,7 @@
     "label": {
       "default": "Filter Test"
     },
-    "editor_size": "medium",
+    "editor_size": "max",
     "complex_type_info": [
       {
         "complex_type_ref": "fieldFilterEntry",


### PR DESCRIPTION
Fixes #1324 
Signed-off-by: Neha-Gokhale <Neha.Gokhale@ibm.com>

- Supports "max" option in [Editor size](https://github.com/elyra-ai/canvas/wiki/3.2-Common-Properties--UI-Hints#ui-hints) having 900px width.
- When "large" is specified the properties panel has a width of 640px and with a resize button that allows the panel to be increased in size up to the "max" size which is 900px.
- When "max" is specified the properties panel is has a width of 900px and no resize button is displayed.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

