### PR TITLE
#1372 Add a line break when tooltip contains \n

### DIFF
--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/checkbox_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/checkbox_paramDef.json
@@ -136,7 +136,7 @@
           "default": "checkbox default"
         },
         "description": {
-          "default": "checkbox with a default value of 'true'"
+          "default": "checkbox with a default value of 'true'\nThis text should be on a new line.\nThis text should also be on a new line."
         }
       },
       {

--- a/canvas_modules/common-canvas/src/tooltip/tooltip.scss
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.scss
@@ -34,6 +34,7 @@
 	word-wrap: break-word;
 	max-width: 228px;
 	border-radius: 2px;
+	white-space: pre-wrap; // Add a line break for \n in tooltip
 	.bx--link {
 		display: block;
 		color: $inverse-link;

--- a/canvas_modules/harness/test_resources/parameterDefs/checkbox_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/checkbox_paramDef.json
@@ -136,7 +136,7 @@
           "default": "checkbox default"
         },
         "description": {
-          "default": "checkbox with a default value of 'true'"
+          "default": "checkbox with a default value of 'true'\nThis text should be on a new line.\nThis text should also be on a new line."
         }
       },
       {


### PR DESCRIPTION
Fixes #1372 
Signed-off-by: Neha-Gokhale <Neha.Gokhale@ibm.com>

![Screen Shot 2023-02-11 at 6 02 36 PM](https://user-images.githubusercontent.com/25124000/218289605-21b72825-ac2a-4972-96c1-6d62dec8e4ba.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

