### PR TITLE
#1391 Accessibility: Fixed Properties tearsheet does not have associated name

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.jsx
@@ -199,6 +199,7 @@ class EditorForm extends React.Component {
 				}
 				tabContent.push(
 					<Tab
+						id={"tab." + this._getContainerIndex(hasAlertsTab, i) + "-" + key}
 						key={this._getContainerIndex(hasAlertsTab, i) + "-" + key}
 						tabIndex={i}
 						label={tab.text}

--- a/canvas_modules/common-canvas/src/common-properties/panels/subtabs/subtabs.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/subtabs/subtabs.jsx
@@ -50,6 +50,7 @@ class Subtabs extends React.Component {
 
 				subTabs.push(
 					<Tab
+						id={"subtabs.tab." + i}
 						key={"subtabs.tab." + i}
 						disabled={panelState === STATES.DISABLED}
 						className={classNames("properties-subtab", { "properties-leftnav-subtab-item": this.props.leftnav })}

--- a/canvas_modules/common-canvas/src/common-properties/panels/tearsheet/tearsheet.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/tearsheet/tearsheet.jsx
@@ -47,6 +47,7 @@ class TearSheet extends Component {
 					className={classNames("properties-tearsheet-panel", { "properties-tearsheet-stacked": this.props.stacked })}
 					open={this.props.open}
 					size="lg"
+					aria-label={title}
 					preventCloseOnClickOutside
 				>
 					<ModalHeader


### PR DESCRIPTION
Fixes #1391 

**Interactive component with ARIA role 'dialog' does not have a programmatically associated name**
Before -
![Screenshot 2023-03-08 at 11 20 57 AM](https://user-images.githubusercontent.com/25124000/223870208-85a02b52-8502-40ed-b4aa-cbd1d26e8eda.png)

After -
![Screenshot 2023-03-08 at 2 49 20 PM](https://user-images.githubusercontent.com/25124000/223870279-8276f066-41e5-47f3-98cd-5b6cb48f8db6.png)

**Interactive component with ARIA role 'tabpanel' does not have a programmatically associated name**
Before - 
![Screenshot 2023-03-08 at 2 51 26 PM](https://user-images.githubusercontent.com/25124000/223870362-100b240d-b3b6-4017-a42e-24f2ab19f1bc.png)

After -
![Screenshot 2023-03-08 at 2 50 43 PM](https://user-images.githubusercontent.com/25124000/223870454-377c656d-70ec-4cc3-a9b8-ba2ee8eba66a.png)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

