### PR TITLE
#1400 Updated propertiesConfig are not saved

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/common-properties-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/common-properties-test.js
@@ -922,7 +922,7 @@ describe("CommonProperties should setForm correctly", () => {
 });
 
 describe("CommonProperties should set propertiesConfig correctly", () => {
-	it("properties buttons should use a custom label if provided in propertiesConfig", () => {
+	it("propertiesConfig should get set if updated in props", () => {
 		const propertiesConfig = {
 			containerType: "Custom",
 			rightFlyout: true,

--- a/canvas_modules/common-canvas/__tests__/common-properties/common-properties-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/common-properties-test.js
@@ -921,6 +921,43 @@ describe("CommonProperties should setForm correctly", () => {
 	});
 });
 
+describe("CommonProperties should set propertiesConfig correctly", () => {
+	it("properties buttons should use a custom label if provided in propertiesConfig", () => {
+		const propertiesConfig = {
+			containerType: "Custom",
+			rightFlyout: true,
+			applyOnBlur: false,
+			heading: true,
+			showRequiredIndicator: true,
+			trimSpaces: true
+		};
+		const renderedObject = propertyUtils.flyoutEditorForm(numberfieldResource, propertiesConfig);
+		const controller = renderedObject.controller;
+
+		let actualConfig = controller.getPropertiesConfig();
+		expect(actualConfig).to.eql(propertiesConfig);
+
+		const updatedPropertiesConfig = {
+			containerType: "Tearsheet",
+			rightFlyout: false,
+			applyOnBlur: false,
+			heading: true,
+			showRequiredIndicator: true,
+			trimSpaces: true
+		};
+
+		const newCommonProps = (<CommonProperties
+			propertiesInfo={propertiesInfo}
+			propertiesConfig={updatedPropertiesConfig}
+		/>);
+
+		// call "setProps" to update config: https://github.com/enzymejs/enzyme/issues/1925#issuecomment-445442480
+		renderedObject.wrapper.setProps({ children: newCommonProps });
+		actualConfig = controller.getPropertiesConfig();
+		expect(actualConfig).to.eql(updatedPropertiesConfig);
+	});
+});
+
 describe("PropertiesButtons should render with the correct labels", () => {
 	it("When applyOnBlur=false `Cancel` and `Save` buttons should be rendered", () => {
 		const renderedObject = propertyUtils.flyoutEditorForm(propertiesInfo.parameterDef, { applyOnBlur: false });

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -123,6 +123,10 @@ class PropertiesMain extends React.Component {
 				}
 			}
 		}
+
+		if (newProps.propertiesConfig && !isEqual(newProps.propertiesConfig, this.propertiesController.getPropertiesConfig())) {
+			this.propertiesController.setPropertiesConfig(newProps.propertiesConfig);
+		}
 	}
 
 	onBlur(e) {


### PR DESCRIPTION
fixes #1400 
 
This can be recreated in the test harness with some changes in App.js using patch: [0001-recreate-issue.patch.zip](https://github.ibm.com/NGP-TWC/wdp-abstract-canvas/files/1114183/0001-recreate-issue.patch.zip) and test flow: `allTypesCanvas.json`

Before fix:
![recreate issue](https://user-images.githubusercontent.com/1628100/225179080-23e0c9ef-670c-46fe-aeed-0d9b3f8a9853.gif)

After fix:
![update config fixed](https://user-images.githubusercontent.com/1628100/225179108-838da378-50c3-4c2f-8361-16734a56dda4.gif)


Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

