### PR TITLE
#1450 Accessibility: Fixed The <button> element has the id 'subtabs.tab.0' that is already in use

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/panels/subtabs/subtabs.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/subtabs/subtabs.jsx
@@ -20,6 +20,7 @@ import classNames from "classnames";
 import { Tabs, Tab } from "carbon-components-react";
 import { getDataId } from "./../../util/control-utils";
 import { STATES } from "./../../constants/constants.js";
+import { v4 as uuid4 } from "uuid";
 
 class Subtabs extends React.Component {
 	constructor(props) {
@@ -27,6 +28,7 @@ class Subtabs extends React.Component {
 		this.state = {
 			activeTabId: ""
 		};
+		this.uuid = uuid4();
 	}
 
 	onClick(tabId) {
@@ -50,8 +52,8 @@ class Subtabs extends React.Component {
 
 				subTabs.push(
 					<Tab
-						id={"subtabs.tab." + i}
-						key={"subtabs.tab." + i}
+						id={`subtabs.tab.${i}-${this.uuid}`}
+						key={`subtabs.tab.${i}-${this.uuid}`}
 						disabled={panelState === STATES.DISABLED}
 						className={classNames("properties-subtab", { "properties-leftnav-subtab-item": this.props.leftnav })}
 						tabIndex={tabIdx}


### PR DESCRIPTION
Fixes #1450 

Before - 
![Screenshot 2023-04-18 at 4 04 10 PM](https://user-images.githubusercontent.com/25124000/232924475-5c0f5863-9c26-4ebc-9751-e19892b7e4f3.png)


After -
![Screenshot 2023-04-18 at 4 08 23 PM](https://user-images.githubusercontent.com/25124000/232924489-0df6431f-fd6e-4ea6-a7f4-340b96205ede.png)



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

