### PR TITLE
#1458 Don’t render properties title when paramDef doesn't have titleDefinition

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/components/title-editor-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/components/title-editor-test.js
@@ -352,4 +352,21 @@ describe("title-editor renders correctly", () => {
 		expect(helpButton).to.have.length(1);
 
 	});
+
+	it("Don't render TitleEditor when title is null", () => {
+		controller.setTitle(null);
+		helpClickHandler.resetHistory();
+		const wrapper = mountWithIntl(
+			<TitleEditor
+				store={controller.getStore()}
+				controller={controller}
+				labelEditable
+				help={help}
+			/>
+		);
+
+		// Verify TitleEditor isn't rendered
+		const titleEditor = wrapper.find(".properties-title-editor");
+		expect(titleEditor).to.have.length(0);
+	});
 });

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -93,6 +93,9 @@ class TitleEditor extends Component {
 	}
 
 	render() {
+		if (this.props.title === null) {
+			return null;
+		}
 		const propertiesTitleEditButtonLabel = PropertyUtils.formatMessage(this.props.controller.getReactIntl(), MESSAGE_KEYS.TITLE_EDITOR_LABEL);
 		const helpButtonLabel = PropertyUtils.formatMessage(this.props.controller.getReactIntl(), MESSAGE_KEYS.TITLE_EDITOR_HELPBUTTON_LABEL);
 		const closeButtonLabel = PropertyUtils.formatMessage(this.props.controller.getReactIntl(), MESSAGE_KEYS.PROPERTIESEDIT_CLOSEBUTTON_LABEL);

--- a/canvas_modules/common-canvas/src/common-properties/form/PropertyDef.js
+++ b/canvas_modules/common-canvas/src/common-properties/form/PropertyDef.js
@@ -62,7 +62,7 @@ export class PropertyDef {
 		const actionMetadata = ActionMetadata.makeActionMetadata(propertyOf(uihints)("action_info"));
 		const groupMetadata = GroupMetadata.makeGroupMetadata(propertyOf(uihints)("group_info"), parameterMetadata.getParameters());
 
-		const label = titleDefinition && titleDefinition.title ? titleDefinition.title : "";
+		const label = titleDefinition && titleDefinition.title ? titleDefinition.title : null;
 		const labelEditable = titleDefinition && typeof titleDefinition.editable !== "undefined" ? titleDefinition.editable : DEFAULT_LABEL_EDITABLE;
 
 		return new PropertyDef(

--- a/canvas_modules/common-canvas/src/common-properties/panels/tearsheet/tearsheet.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/tearsheet/tearsheet.jsx
@@ -16,11 +16,12 @@
 
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { injectIntl } from "react-intl";
 import classNames from "classnames";
-
+import { formatMessage } from "./../../util/property-utils";
 import { ComposedModal, ModalHeader, ModalBody } from "carbon-components-react";
 import { Portal } from "react-portal";
-
+import { MESSAGE_KEYS } from "./../../constants/constants";
 import PropertiesButtons from "../../components/properties-buttons";
 
 class TearSheet extends Component {
@@ -47,19 +48,22 @@ class TearSheet extends Component {
 					className={classNames("properties-tearsheet-panel", { "properties-tearsheet-stacked": this.props.stacked })}
 					open={this.props.open}
 					size="lg"
-					aria-label={title}
+					aria-label={formatMessage(this.props.intl, MESSAGE_KEYS.PROPERTIES_LABEL, { label: title })}
 					preventCloseOnClickOutside
 				>
-					<ModalHeader
-						className={classNames("properties-tearsheet-header",
-							{ "with-buttons": displayFooterButtons },
-							{ "with-tabs": displayTabs },
-							{ "hide-close-button": typeof this.props.onCloseCallback !== "function" })}
-						title={title}
-						buttonOnClick={this.props.onCloseCallback}
-					>
-						{description ? (<p>{description}</p>) : null}
-					</ModalHeader>
+					{title === null
+						? null
+						: (<ModalHeader
+							className={classNames("properties-tearsheet-header",
+								{ "with-buttons": displayFooterButtons },
+								{ "with-tabs": displayTabs },
+								{ "hide-close-button": typeof this.props.onCloseCallback !== "function" })}
+							title={title}
+							buttonOnClick={this.props.onCloseCallback}
+						>
+							{description ? (<p>{description}</p>) : null}
+						</ModalHeader>)
+					}
 					<ModalBody className={classNames("properties-tearsheet-body",
 						{ "with-buttons": displayFooterButtons },
 						{ "with-tabs": displayTabs })}
@@ -76,7 +80,7 @@ TearSheet.propTypes = {
 	stacked: PropTypes.bool,
 	onCloseCallback: PropTypes.func,
 	tearsheet: PropTypes.shape({
-		title: PropTypes.string.isRequired,
+		title: PropTypes.string,
 		description: PropTypes.string,
 		content: PropTypes.oneOfType([
 			PropTypes.array,
@@ -88,7 +92,8 @@ TearSheet.propTypes = {
 	rejectLabel: PropTypes.string, // Required if showPropertiesButtons is true
 	okHandler: PropTypes.func, // Required if showPropertiesButtons is true
 	cancelHandler: PropTypes.func, // Required if showPropertiesButtons is true
-	applyOnBlur: PropTypes.bool.isRequired
+	applyOnBlur: PropTypes.bool.isRequired,
+	intl: PropTypes.object.isRequired
 };
 
 TearSheet.defaultProps = {
@@ -98,4 +103,4 @@ TearSheet.defaultProps = {
 	stacked: false
 };
 
-export default TearSheet;
+export default injectIntl(TearSheet);


### PR DESCRIPTION
Fixes #1458 

After removing `titleDefinition` from `checkbox_paramDef.json` -

Right flyout -
<img width="328" alt="Screenshot 2023-04-24 at 3 32 32 PM" src="https://user-images.githubusercontent.com/25124000/234130721-241a1c57-a003-4edc-b1e4-ba754a350a34.png">


Tearsheet - 
<img width="1605" alt="Screenshot 2023-04-24 at 3 32 54 PM" src="https://user-images.githubusercontent.com/25124000/234130741-5d344f2e-fdc2-4086-ab5a-2602bd3b73fe.png">



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

