### PR TITLE
 #1508 Fixed horizontal scrollbar issue in single category

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.scss
@@ -32,8 +32,8 @@ $primary-tab-height: $spacing-08;
 		height: 100%;
 	}
 	.properties-single-category {
-		height: 100%;
 		.properties-sub-tab-container {
+			position: relative;
 			height: 100%;
 		}
 		.properties-subtabs {

--- a/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.scss
@@ -32,6 +32,7 @@ $primary-tab-height: $spacing-08;
 		height: 100%;
 	}
 	.properties-single-category {
+		height: 100%;
 		.properties-sub-tab-container {
 			position: relative;
 			height: 100%;


### PR DESCRIPTION
Fixes #1508 

Horizontal scrollbar was showing up because `properties-sub-tab-container` has width 607px. But `properties-subtabs` has width 639px. This is caused by [CSS](https://github.com/elyra-ai/canvas/pull/1473/files#diff-b91aa08e9d331fac664c0a3ee9f705bd2fb93dc5fb7a6f13f12a782d67ce7fe7R40). Fixed this issue following this thread - https://stackoverflow.com/a/14327156
 

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

