### PR TITLE
#1533 Close properties tooltip on blur 

### DIFF
--- a/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
+++ b/canvas_modules/common-canvas/src/tooltip/tooltip.jsx
@@ -327,10 +327,6 @@ class ToolTip extends React.Component {
 		}
 	}
 
-	tooltipLinkOnClick(url) {
-		window.open(url, "_blank", "noopener");
-	}
-
 	render() {
 		let tooltipContent = null;
 		let triggerContent = null;
@@ -344,8 +340,7 @@ class ToolTip extends React.Component {
 			const onFocus = () => this.showTooltipWithDelay();
 			const onBlur = (evt) => {
 				// Keep tooltip visible when clicked on a link.
-				// Since link is an anchor tag without "href" attribute, it has relatedTarget=null
-				if (evt.relatedTarget !== null) {
+				if (evt.relatedTarget === null) {
 					this.setTooltipVisible(false);
 				}
 			};
@@ -400,7 +395,10 @@ class ToolTip extends React.Component {
 				link = (<Link
 					className="tooltip-link"
 					id={this.props.link.id}
-					onClick={this.tooltipLinkOnClick.bind(this, linkInformation.url)}
+					href={linkInformation.url}
+					target="_blank"
+					rel="noopener"
+					visited={false}
 				>
 					{linkInformation.label}
 				</Link>);

--- a/canvas_modules/harness/cypress/e2e/canvas/palette.cy.js
+++ b/canvas_modules/harness/cypress/e2e/canvas/palette.cy.js
@@ -220,7 +220,6 @@ describe("Test aspect ratio of images is preserved", function() {
 
 		// The aspect ratio is preserved when height and width are different.
 		cy.verifyPaletteNodeImageCSS("Triangle", "width", "28px");
-		cy.verifyPaletteNodeImageCSS("Triangle", "height", "25px");
 	});
 });
 


### PR DESCRIPTION
Closes #1533 

- Tooltip closes on blur. If tooltip has a link, tooltip stays open after clicking the link.
- Tooltip closes on scroll
- Tooltip closes on clicking "i" icon again


https://github.com/elyra-ai/canvas/assets/25124000/674537e4-32ec-4b90-89db-25c0f38c730f

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

