### PR TITLE
#1547 Set flexible table height in ‘px’ instead of ‘rem’

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/selectcolumns-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/selectcolumns-test.js
@@ -405,7 +405,7 @@ describe("selectcolumns control displays the proper number of rows", () => {
 		const columnSelect = wrapper.find("div[data-id='properties-ft-columnSelect']");
 		const heightDiv = columnSelect.find("div.properties-ft-container-wrapper");
 		const heightStyle = heightDiv.at(0).prop("style");
-		expect(heightStyle).to.eql({ "height": "8rem" }); // includes header
+		expect(heightStyle).to.eql({ "height": 128 }); // includes header
 	});
 
 	it("should display 5 rows in select columns in subpanel", () => {
@@ -424,7 +424,7 @@ describe("selectcolumns control displays the proper number of rows", () => {
 
 		const heightDiv = selectColumnsWrapper.find("div.properties-ft-container-wrapper");
 		const heightStyle = heightDiv.prop("style");
-		expect(heightStyle).to.eql({ "height": "6rem" }); // includes header
+		expect(heightStyle).to.eql({ "height": 96 }); // includes header
 	});
 
 	it("should display 5.5 rows by default in select columns in onpanel", () => {
@@ -454,9 +454,9 @@ describe("selectcolumns control displays the proper number of rows", () => {
 
 		const heightDiv = tableWrapper.find("div.properties-ft-container-wrapper");
 		const heightStyle = heightDiv.prop("style");
-		// header height = 2rem, each row height = 2 rem. Total height = 2 + 5.5*(2) = 13rem
+		// header height = 2rem, each row height = 2 rem. Total height = 2 + 5.5*(2) = 13rem * 16 = 208px
 		// This means only 5.5 rows are visible
-		expect(heightStyle).to.eql({ "height": "13rem" }); // includes header
+		expect(heightStyle).to.eql({ "height": 208 }); // includes header
 	});
 });
 

--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/structuretable-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/structuretable-test.js
@@ -831,10 +831,10 @@ describe("structuretable multiselect edit works", () => {
 		selectedEditRow = wrapper.find("div.properties-at-selectedEditRows").find(".properties-vt-row-checkbox");
 		expect(selectedEditRow).to.have.length(1);
 
-		// verify the select header row is 2rem in height
+		// verify the select header row is 32px in height
 		const selectHeaderTable = wrapper.find("div.properties-at-selectedEditRows").find("div.properties-ft-container-wrapper");
 		const heightStyle = selectHeaderTable.prop("style");
-		expect(heightStyle).to.eql({ "height": "2rem" });
+		expect(heightStyle).to.eql({ "height": 32 });
 	});
 });
 

--- a/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
@@ -251,11 +251,11 @@ class FlexibleTable extends React.Component {
 		let dynamicH = this.state.dynamicHeight;
 		const multiSelectTableHeight = REM_ROW_HEIGHT + REM_HEADER_HEIGHT;
 		if (Array.isArray(this.props.data) && this.props.data.length < this.state.rows) {
-			newHeight = (REM_ROW_HEIGHT * this.props.data.length + REM_HEADER_HEIGHT + (this.props.selectedEditRow ? multiSelectTableHeight : 0)) + "rem";
+			newHeight = (REM_ROW_HEIGHT * this.props.data.length + REM_HEADER_HEIGHT + (this.props.selectedEditRow ? multiSelectTableHeight : 0)) * ONE_REM_HEIGHT;
 		} else if (this.state.rows > 0) {
-			newHeight = (REM_ROW_HEIGHT * this.state.rows + REM_HEADER_HEIGHT + (this.props.selectedEditRow ? multiSelectTableHeight : 0)) + "rem";
+			newHeight = (REM_ROW_HEIGHT * this.state.rows + REM_HEADER_HEIGHT + (this.props.selectedEditRow ? multiSelectTableHeight : 0)) * ONE_REM_HEIGHT;
 		} else if (this.state.rows === 0) { // only display header
-			newHeight = REM_HEADER_HEIGHT + "rem";
+			newHeight = REM_HEADER_HEIGHT * ONE_REM_HEIGHT;
 		} else if (this.state.rows === -1) {
 			if (this.flexibleTable) {
 				const labelAndDescriptionHeight = 50; // possible dynamically set this in the future
@@ -267,7 +267,7 @@ class FlexibleTable extends React.Component {
 					dynamicH = -1;
 				} else {
 					const totalHeight = flyoutHeight !== 0 ? flyoutHeight : tearsheetHeight;
-					newHeight = `calc(${totalHeight - ftHeaderHeight - labelAndDescriptionHeight}px - 3.5rem)`; // 3.5rem to adjust padding
+					newHeight = `calc(${totalHeight - ftHeaderHeight - labelAndDescriptionHeight}px - ${(3.5 * ONE_REM_HEIGHT)}px)`; // 3.5rem to adjust padding
 					dynamicH = (totalHeight - ftHeaderHeight - labelAndDescriptionHeight) - (3.5 * 16);
 				}
 			}
@@ -528,7 +528,7 @@ class FlexibleTable extends React.Component {
 		const multiSelectEditRowsPixels = multiSelectEditRowsRem * ONE_REM_HEIGHT;
 		if (this.state.rows !== -1 && this.state.tableHeight) {
 			const remHeight = parseInt(this.state.tableHeight, 10);
-			tableHeight = (remHeight - (this.props.selectedEditRow ? multiSelectEditRowsRem : 0)) * ONE_REM_HEIGHT;
+			tableHeight = (remHeight - (this.props.selectedEditRow ? multiSelectEditRowsRem : 0));
 		} else if (this.state.rows === -1 && this.state.dynamicHeight && this.state.dynamicHeight !== -1) {
 			tableHeight = this.state.dynamicHeight - (this.props.selectedEditRow ? multiSelectEditRowsPixels : 0);
 		}


### PR DESCRIPTION
Fixes #1547 
 
![Screenshot 2023-08-15 at 3 33 19 PM](https://github.com/elyra-ai/canvas/assets/25124000/5d923a98-576e-443d-bad3-788a2ffe0617)

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

