### PR TITLE
#1551 Disabled numberfield controls should not remain in error state

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/controls/numberfield/numberfield.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/numberfield/numberfield.jsx
@@ -195,7 +195,7 @@ NumberfieldControl.propTypes = {
 const mapStateToProps = (state, ownProps) => ({
 	value: ownProps.controller.getPropertyValue(ownProps.propertyId),
 	state: ownProps.controller.getControlState(ownProps.propertyId),
-	messageInfo: ownProps.controller.getErrorMessage(ownProps.propertyId)
+	messageInfo: ownProps.controller.getErrorMessage(ownProps.propertyId, true) // Filter error messages for hidden/disabled controls
 });
 
 export default connect(mapStateToProps, null)(NumberfieldControl);


### PR DESCRIPTION
Fixes #1551 

Using this paramDef - 
[Aadistribution.json.zip](https://github.com/elyra-ai/canvas/files/12381893/Aadistribution.json.zip)

https://github.com/elyra-ai/canvas/assets/25124000/28e1dcda-a0b4-4a84-a6eb-21b738785421


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

