### PR TITLE
#1562 For oneofselect with custom_value_allowed, don't display error message on initial render

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
@@ -181,7 +181,7 @@ class DropDown extends React.Component {
 		const currentValue = this.props.controller.getPropertyValue(this.props.propertyId);
 
 		// Don't update property value during initial render
-		if (typeof currentValue === "undefined" && evt === "") {
+		if ((typeof currentValue === "undefined" && evt === "") || evt === null) {
 			return;
 		}
 

--- a/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
@@ -178,7 +178,14 @@ class DropDown extends React.Component {
 
 	// evt is null when onBlur, empty string when clicking the 'x' to clear input
 	handleOnInputChange(evt) {
-		if (evt !== null) {
+		const currentValue = this.props.controller.getPropertyValue(this.props.propertyId);
+
+		// Don't update property value during initial render
+		if (typeof currentValue === "undefined" && evt === "") {
+			return;
+		}
+
+		if (evt !== null && evt !== currentValue) {
 			const value = evt;
 			this.props.controller.updatePropertyValue(this.props.propertyId, value);
 		}

--- a/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
@@ -181,7 +181,7 @@ class DropDown extends React.Component {
 		const currentValue = this.props.controller.getPropertyValue(this.props.propertyId);
 
 		// Don't update property value during initial render
-		if ((typeof currentValue === "undefined" && evt === "") || evt === null) {
+		if ((typeof currentValue === "undefined" || currentValue === null) && evt === "") {
 			return;
 		}
 

--- a/canvas_modules/harness/test_resources/parameterDefs/oneofselect_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/oneofselect_paramDef.json
@@ -5,6 +5,7 @@
   "current_parameters": {
     "oneofselect": "blue",
     "oneofselect_custom_value": "custom",
+    "oneofselect_custom_value_null": null,
     "oneofselect_null": null,
     "oneofselect_empty_string": "",
     "oneofselect_placeholder": "",
@@ -48,6 +49,30 @@
     },
     {
       "id": "oneofselect_custom_value",
+      "enum": [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "purple"
+      ],
+      "required": true
+    },
+    {
+      "id": "oneofselect_custom_value_null",
+      "enum": [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "purple"
+      ],
+      "required": true
+    },
+    {
+      "id": "oneofselect_custom_value_undefined",
       "enum": [
         "red",
         "orange",
@@ -358,6 +383,26 @@
         "custom_value_allowed": true
       },
       {
+        "parameter_ref": "oneofselect_custom_value_null",
+        "label": {
+          "default": "oneofselect custom value allowed with parameter value set to 'null'"
+        },
+        "description": {
+          "default": "oneofselect with option to enter a custom value"
+        },
+        "custom_value_allowed": true
+      },
+      {
+        "parameter_ref": "oneofselect_custom_value_undefined",
+        "label": {
+          "default": "oneofselect custom value allowed with parameter value not set"
+        },
+        "description": {
+          "default": "oneofselect with option to enter a custom value"
+        },
+        "custom_value_allowed": true
+      },
+      {
         "parameter_ref": "oneofselect_null",
         "label": {
           "default": "oneofselect null"
@@ -618,6 +663,8 @@
         "parameter_refs": [
           "oneofselect",
           "oneofselect_custom_value",
+          "oneofselect_custom_value_null",
+          "oneofselect_custom_value_undefined",
           "oneofselect_null",
           "oneofselect_empty_string",
           "oneofselect_undefined",


### PR DESCRIPTION
Closes #1562 

To test this PR, remove `oneofselect_custom_value` from current_parameters - https://github.com/elyra-ai/canvas/blob/main/canvas_modules/harness/test_resources/parameterDefs/oneofselect_paramDef.json#L7

For initial render, verify there's no error message for this control - 
<img width="329" alt="Screenshot 2023-09-11 at 2 42 07 PM" src="https://github.com/elyra-ai/canvas/assets/25124000/6f87f8b0-e140-4f58-85f8-267b2164da3e">



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

