### PR TITLE
#1575 When parameterDef is dynamically updated, don't set INITIAL_LOAD on pre-existing properties

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/properties-controller.js
+++ b/canvas_modules/common-canvas/src/common-properties/properties-controller.js
@@ -28,7 +28,7 @@ import { STATES, ACTIONS, CONDITION_TYPE, PANEL_TREE_ROOT, CONDITION_MESSAGE_TYP
 import CommandStack from "../command-stack/command-stack.js";
 import ControlFactory from "./controls/control-factory";
 import { Type, ParamRole, ControlType, ItemType } from "./constants/form-constants";
-import { has, cloneDeep, assign, isEmpty, isEqual, isUndefined, get } from "lodash";
+import { has, cloneDeep, assign, isEmpty, isEqual, isUndefined, get, difference } from "lodash";
 import Form from "./form/Form";
 import { getConditionOps } from "./ui-conditions/condition-ops/condition-ops";
 import { DEFAULT_LOCALE } from "./constants/constants";
@@ -427,7 +427,7 @@ export default class PropertiesController {
 				let differentProperties = [];
 				if (sameParameterDefRendered) {
 					// When a parameterDef is dynamically updated, set difference between old and new controls
-					differentProperties = PropertyUtils.getObjectDifference(this.controls, this.prevControls);
+					differentProperties = difference(Object.keys(this.controls), Object.keys(this.prevControls));
 				}
 
 				if (sameParameterDefRendered && differentProperties.indexOf(control.name) === -1) {

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -110,13 +110,18 @@ class PropertiesMain extends React.Component {
 				(newProps.propertiesInfo.appData && !isEqual(newProps.propertiesInfo.appData, this.props.propertiesInfo.appData))) {
 				// Save prevId first before setting the new one from propertiesInfo
 				this.propertiesController.prevId = this.propertiesController.getId();
-				this.propertiesController.setId(newProps.propertiesInfo.id);
+				if (has(newProps.propertiesInfo, "id")) {
+					this.propertiesController.setId(newProps.propertiesInfo.id);
+				}
 				this.setForm(newProps.propertiesInfo);
 				const newEditorSize = this.propertiesController.getForm().editorSize;
 				if (this.state.editorSize !== newEditorSize) {
 					this.setState({ editorSize: newEditorSize });
 				}
-				this.currentParameters = this.propertiesController.getPropertyValues();
+				// Reset property values for new parameterDef
+				if (has(newProps.propertiesInfo, "id") && (this.propertiesController.prevId !== this.propertiesController.getId())) {
+					this.currentParameters = this.propertiesController.getPropertyValues();
+				}
 				this.propertiesController.setAppData(newProps.propertiesInfo.appData);
 				this.propertiesController.setCustomControls(newProps.customControls);
 				this.propertiesController.setConditionOps(newProps.customConditionOps);

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -58,6 +58,7 @@ class PropertiesMain extends React.Component {
 		this.propertiesController.setLight(props.light);
 		this.propertiesController.setAppData(props.propertiesInfo.appData);
 		this.propertiesController.setExpressionInfo(props.propertiesInfo.expressionInfo);
+		this.propertiesController.setParameterDefId(props.propertiesInfo.parameterDefId);
 		this.propertiesController.setHandlers({
 			controllerHandler: props.callbacks.controllerHandler,
 			propertyListener: props.callbacks.propertyListener,
@@ -107,6 +108,9 @@ class PropertiesMain extends React.Component {
 				(newProps.propertiesInfo.formData && !isEqual(newProps.propertiesInfo.formData, this.props.propertiesInfo.formData)) ||
 				(newProps.propertiesInfo.parameterDef && !isEqual(newProps.propertiesInfo.parameterDef, this.props.propertiesInfo.parameterDef)) ||
 				(newProps.propertiesInfo.appData && !isEqual(newProps.propertiesInfo.appData, this.props.propertiesInfo.appData))) {
+				// Save oldParameterDefId first before setting the new one from propertiesInfo
+				this.propertiesController.setOldParameterDefId(this.propertiesController.getParameterDefId());
+				this.propertiesController.setParameterDefId(newProps.propertiesInfo.parameterDefId);
 				this.setForm(newProps.propertiesInfo);
 				const newEditorSize = this.propertiesController.getForm().editorSize;
 				if (this.state.editorSize !== newEditorSize) {

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -58,7 +58,7 @@ class PropertiesMain extends React.Component {
 		this.propertiesController.setLight(props.light);
 		this.propertiesController.setAppData(props.propertiesInfo.appData);
 		this.propertiesController.setExpressionInfo(props.propertiesInfo.expressionInfo);
-		this.propertiesController.setParameterDefId(props.propertiesInfo.parameterDefId);
+		this.propertiesController.setId(props.propertiesInfo.id);
 		this.propertiesController.setHandlers({
 			controllerHandler: props.callbacks.controllerHandler,
 			propertyListener: props.callbacks.propertyListener,
@@ -108,9 +108,9 @@ class PropertiesMain extends React.Component {
 				(newProps.propertiesInfo.formData && !isEqual(newProps.propertiesInfo.formData, this.props.propertiesInfo.formData)) ||
 				(newProps.propertiesInfo.parameterDef && !isEqual(newProps.propertiesInfo.parameterDef, this.props.propertiesInfo.parameterDef)) ||
 				(newProps.propertiesInfo.appData && !isEqual(newProps.propertiesInfo.appData, this.props.propertiesInfo.appData))) {
-				// Save oldParameterDefId first before setting the new one from propertiesInfo
-				this.propertiesController.setOldParameterDefId(this.propertiesController.getParameterDefId());
-				this.propertiesController.setParameterDefId(newProps.propertiesInfo.parameterDefId);
+				// Save prevId first before setting the new one from propertiesInfo
+				this.propertiesController.prevId = this.propertiesController.getId();
+				this.propertiesController.setId(newProps.propertiesInfo.id);
 				this.setForm(newProps.propertiesInfo);
 				const newEditorSize = this.propertiesController.getForm().editorSize;
 				if (this.state.editorSize !== newEditorSize) {

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -58,7 +58,6 @@ class PropertiesMain extends React.Component {
 		this.propertiesController.setLight(props.light);
 		this.propertiesController.setAppData(props.propertiesInfo.appData);
 		this.propertiesController.setExpressionInfo(props.propertiesInfo.expressionInfo);
-		this.propertiesController.setId(props.propertiesInfo.id);
 		this.propertiesController.setHandlers({
 			controllerHandler: props.callbacks.controllerHandler,
 			propertyListener: props.callbacks.propertyListener,
@@ -69,7 +68,7 @@ class PropertiesMain extends React.Component {
 			titleChangeHandler: props.callbacks.titleChangeHandler,
 			tooltipLinkHandler: props.callbacks.tooltipLinkHandler
 		});
-		this.setForm(props.propertiesInfo);
+		this.setForm(props.propertiesInfo, false);
 		this.previousErrorMessages = {};
 		// this has to be after setForm because setForm clears all error messages.
 		// Validate all validationDefinitions but show warning messages for "colDoesExists" condition only
@@ -108,18 +107,14 @@ class PropertiesMain extends React.Component {
 				(newProps.propertiesInfo.formData && !isEqual(newProps.propertiesInfo.formData, this.props.propertiesInfo.formData)) ||
 				(newProps.propertiesInfo.parameterDef && !isEqual(newProps.propertiesInfo.parameterDef, this.props.propertiesInfo.parameterDef)) ||
 				(newProps.propertiesInfo.appData && !isEqual(newProps.propertiesInfo.appData, this.props.propertiesInfo.appData))) {
-				// Save prevId first before setting the new one from propertiesInfo
-				this.propertiesController.prevId = this.propertiesController.getId();
-				if (has(newProps.propertiesInfo, "id")) {
-					this.propertiesController.setId(newProps.propertiesInfo.id);
-				}
-				this.setForm(newProps.propertiesInfo);
+				const sameParameterDefRendered = newProps.propertiesInfo.id === this.props.propertiesInfo.id;
+				this.setForm(newProps.propertiesInfo, sameParameterDefRendered);
 				const newEditorSize = this.propertiesController.getForm().editorSize;
 				if (this.state.editorSize !== newEditorSize) {
 					this.setState({ editorSize: newEditorSize });
 				}
 				// Reset property values for new parameterDef
-				if (has(newProps.propertiesInfo, "id") && (this.propertiesController.prevId !== this.propertiesController.getId())) {
+				if (newProps.propertiesInfo.id && !sameParameterDefRendered) {
 					this.currentParameters = this.propertiesController.getPropertyValues();
 				}
 				this.propertiesController.setAppData(newProps.propertiesInfo.appData);
@@ -148,7 +143,7 @@ class PropertiesMain extends React.Component {
 		}
 	}
 
-	setForm(propertiesInfo) {
+	setForm(propertiesInfo, sameParameterDefRendered) {
 		let formData = null;
 
 		if (propertiesInfo.formData && Object.keys(propertiesInfo.formData).length !== 0) {
@@ -164,7 +159,7 @@ class PropertiesMain extends React.Component {
 			formData.data.datasetMetadata = PropertyUtils.convertInputDataModel(formData.data.inputDataModel);
 		}
 
-		this.propertiesController.setForm(formData, this.props.intl);
+		this.propertiesController.setForm(formData, this.props.intl, sameParameterDefRendered);
 		if (formData) {
 			this.originalTitle = formData.label;
 		}

--- a/canvas_modules/common-canvas/src/common-properties/util/property-utils.js
+++ b/canvas_modules/common-canvas/src/common-properties/util/property-utils.js
@@ -19,7 +19,7 @@
 import logger from "../../../utils/logger";
 import { ParamRole } from "../constants/form-constants";
 import { DATA_TYPE, CARBON_ICONS } from "../constants/constants";
-import { cloneDeep, isUndefined, isString, isEqual } from "lodash";
+import { cloneDeep, isUndefined, isString } from "lodash";
 import { v4 as uuid4 } from "uuid";
 import defaultMessages1 from "../../../locales/common-properties/locales/en.json";
 import defaultMessages2 from "../../../locales/command-actions/locales/en.json";
@@ -590,19 +590,6 @@ function convertValueDataTypes(currentParameters, controls) {
 	return convertedCurrentParameters;
 }
 
-// Returns an array of keys whose values are different in two objects
-function getObjectDifference(obj1, obj2) {
-	return Object.keys(obj1).reduce((result, key, val) => {
-		if (!(key in obj2)) {
-			result.push(key);
-		} else if (isEqual(obj1[key], obj2[key])) {
-			const resultKeyIndex = result.indexOf(key);
-			result.splice(resultKeyIndex, 1);
-		}
-		return result;
-	}, Object.keys(obj2));
-}
-
 export {
 	toType,
 	formatMessage,
@@ -620,6 +607,5 @@ export {
 	fieldStringToValue,
 	generateId,
 	getDMDefault,
-	getDMFieldIcon,
-	getObjectDifference
+	getDMFieldIcon
 };

--- a/canvas_modules/common-canvas/src/common-properties/util/property-utils.js
+++ b/canvas_modules/common-canvas/src/common-properties/util/property-utils.js
@@ -19,7 +19,7 @@
 import logger from "../../../utils/logger";
 import { ParamRole } from "../constants/form-constants";
 import { DATA_TYPE, CARBON_ICONS } from "../constants/constants";
-import { cloneDeep, isUndefined, isString } from "lodash";
+import { cloneDeep, isUndefined, isString, isEqual } from "lodash";
 import { v4 as uuid4 } from "uuid";
 import defaultMessages1 from "../../../locales/common-properties/locales/en.json";
 import defaultMessages2 from "../../../locales/command-actions/locales/en.json";
@@ -590,6 +590,19 @@ function convertValueDataTypes(currentParameters, controls) {
 	return convertedCurrentParameters;
 }
 
+// Returns an array of keys whose values are different in two objects
+function getObjectDifference(obj1, obj2) {
+	return Object.keys(obj1).reduce((result, key, val) => {
+		if (!(key in obj2)) {
+			result.push(key);
+		} else if (isEqual(obj1[key], obj2[key])) {
+			const resultKeyIndex = result.indexOf(key);
+			result.splice(resultKeyIndex, 1);
+		}
+		return result;
+	}, Object.keys(obj2));
+}
+
 export {
 	toType,
 	formatMessage,
@@ -607,5 +620,6 @@ export {
 	fieldStringToValue,
 	generateId,
 	getDMDefault,
-	getDMFieldIcon
+	getDMFieldIcon,
+	getObjectDifference
 };

--- a/canvas_modules/harness/src/client/App.js
+++ b/canvas_modules/harness/src/client/App.js
@@ -27,6 +27,7 @@ import { FormattedMessage, IntlProvider } from "react-intl";
 import { forIn, get, has, isEmpty, isEqual } from "lodash";
 import { hot } from "react-hot-loader/root";
 import classNames from "classnames";
+import { v4 as uuid4 } from "uuid";
 
 import { getMessages } from "../intl/intl-utils";
 import * as HarnessBundles from "../intl/locales";
@@ -1746,7 +1747,8 @@ class App extends React.Component {
 			parameterDef: properties,
 			additionalComponents: additionalComponents,
 			expressionInfo: expressionInfo,
-			initialEditorSize: this.state.initialEditorSize
+			initialEditorSize: this.state.initialEditorSize,
+			parameterDefId: uuid4()
 		};
 
 		this.setState({ showPropertiesDialog: true, propertiesInfo: propsInfo });

--- a/canvas_modules/harness/src/client/App.js
+++ b/canvas_modules/harness/src/client/App.js
@@ -1748,7 +1748,7 @@ class App extends React.Component {
 			additionalComponents: additionalComponents,
 			expressionInfo: expressionInfo,
 			initialEditorSize: this.state.initialEditorSize,
-			parameterDefId: uuid4()
+			id: uuid4()
 		};
 
 		this.setState({ showPropertiesDialog: true, propertiesInfo: propsInfo });


### PR DESCRIPTION
Fixes #1575 

Added a new optional config option `id` in [propertiesInfo object](https://github.com/elyra-ai/canvas/wiki/3.0-Common-Properties-documentation#step-2--set-the-data).

To test this PR, add following code in test harness App.js - https://github.com/elyra-ai/canvas/blob/main/canvas_modules/harness/src/client/App.js#L1940

```
setTimeout(() => {
			console.log("Updating paramDef after 30 seconds");
			const oldParamDef = this.state.propertiesInfo.parameterDef;
			const newParamDef = cloneDeep(oldParamDef);

			const uuid = uuid4();
			const parameterObj = {
				"id": `checkbox-${uuid}`,
				"type": "boolean",
				"default": true
			};

			const parameterInfoObj = {
				"parameter_ref": `checkbox-${uuid}`,
				"label": {
					"default": `checkbox-${uuid}`
				},
				"description": {
					"default": "new added checkbox with undefined value"
				}
			};
			newParamDef.parameters.push(parameterObj);
			newParamDef.uihints.parameter_info.push(parameterInfoObj);
			newParamDef.uihints.group_info[0].parameter_refs.push(`checkbox-${uuid}`);

			const newPropsInfo = cloneDeep(this.state.propertiesInfo);
			newPropsInfo.parameterDef = newParamDef;
			this.setState({ propertiesInfo: newPropsInfo });

		}, 30000);

```
Also add logs in propertyListener - https://github.com/elyra-ai/canvas/blob/main/canvas_modules/harness/src/client/App.js#L1795

```
propertyListener(data) {
		console.log(data);
}
```

After updating current parameterDef every 5 seconds by adding a new property, notice `INITIAL_LOAD` is added only on the latest property. Not on the pre-existing properties.

https://github.com/elyra-ai/canvas/assets/25124000/8f039fba-650f-4110-924e-7aaa79b5ab6f



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

