### PR TITLE
#1621 In Cypress, open palette directly instead of simulating the act…

### DIFF
--- a/canvas_modules/harness/cypress/support/canvas/test-harness-cmds.js
+++ b/canvas_modules/harness/cypress/support/canvas/test-harness-cmds.js
@@ -60,22 +60,9 @@ Cypress.Commands.add("openCanvasDefinitionForExtraCanvas", (canvasFileName) => {
 	});
 });
 
-Cypress.Commands.add("openCanvasPalette", (paletteName) => {
-	cy.toggleCommonCanvasSidePanel();
-	cy.get("#harness-sidepanel-palette-dropdown").select(paletteName);
-	// Wait until we can get a palette flyout category from the canvas before proceeding. This
-	// allows the canvas to load and display before any more test case steps
-	// are executed. Note: this won't work if the testcase selects a second
-	// canvas while an existing canvas with nodes is displayed.
+Cypress.Commands.add("openCanvasPalette", (paletteFileName) => {
 	cy.document().then((doc) => {
-		if (doc.canvasController.getCanvasConfig().enablePaletteLayout === "Modal") {
-			// Palette Layout - Modal
-			cy.get(".palette-dialog-categories");
-		} else {
-			// Palette Layout - Flyout
-			cy.get(".palette-flyout-category");
-		}
-		cy.toggleCommonCanvasSidePanel();
+		doc.setPaletteDropdownSelect(paletteFileName);
 	});
 });
 


### PR DESCRIPTION
…ion through the right-side flyout.

Fixes: #1621 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

