### PR TITLE
#1635 Highlighting of radio buttons cut off when radio button is clicked

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/controls/radioset/radioset.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/radioset/radioset.scss
@@ -44,6 +44,7 @@
 		align-items: center;
 		flex-wrap: wrap;
 		overflow: hidden;
+		padding-left: 0.1rem;
 		.bx--radio-button-wrapper{
 			margin-right: 0; // We removed the space between radio & tooltip to position it correctly
 		}


### PR DESCRIPTION
Fixes: #1635
When radio buttons are selected they appear with part of the circle cut off

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

