### PR TITLE
#1649 Added a new parameter in setPropertyValues() to set default properties

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/properties-controller-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/properties-controller-test.js
@@ -1194,7 +1194,7 @@ describe("Properties Controller handlers", () => {
 		const actual = controller.getPropertyValues();
 		expect(actual).to.eql(values);
 	});
-	it("should set default values when setPropertyValues() is called with setDefaultValues = true", () => {
+	it("should set default values when setPropertyValues() is called with option { setDefaultValues: true }", () => {
 		const renderedObject = testUtils.flyoutEditorForm(checkboxParamDef);
 		controller = renderedObject.controller;
 
@@ -1208,7 +1208,7 @@ describe("Properties Controller handlers", () => {
 		expect(controller.getPropertyValues()).not.to.have.property("checkbox_hidden");
 
 		// setDefaultValues is set to true
-		controller.setPropertyValues(filteredValues, true);
+		controller.setPropertyValues(filteredValues, { setDefaultValues: true });
 		// Verify a value is set for checkbox_hidden
 		expect(controller.getPropertyValues()).to.have.property("checkbox_hidden", true);
 	});

--- a/canvas_modules/common-canvas/__tests__/common-properties/properties-controller-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/properties-controller-test.js
@@ -25,6 +25,7 @@ import datasetMetadata from "../test_resources/json/datasetMetadata.json";
 import structureListEditorParamDef from "../test_resources/paramDefs/structurelisteditor_paramDef.json";
 import structureTableParamDef from "../test_resources/paramDefs/structuretable_paramDef.json";
 import checkboxsetParamDef from "../test_resources/paramDefs/checkboxset_paramDef.json";
+import checkboxParamDef from "../test_resources/paramDefs/checkbox_paramDef.json";
 import actionParamDef from "../test_resources/paramDefs/action_paramDef.json";
 import numberfieldParamDef from "../test_resources/paramDefs/numberfield_paramDef.json";
 import structuretablePropertyValues from "../test_resources/json/structuretable_propertyValues.json";
@@ -1192,6 +1193,24 @@ describe("Properties Controller handlers", () => {
 		expect(propertyListener).to.have.property("callCount", 4);
 		const actual = controller.getPropertyValues();
 		expect(actual).to.eql(values);
+	});
+	it("should set default values when setPropertyValues() is called with setDefaultValues = true", () => {
+		const renderedObject = testUtils.flyoutEditorForm(checkboxParamDef);
+		controller = renderedObject.controller;
+
+		const filteredValues = controller.getPropertyValues({ filterHiddenDisabled: true });
+		// We filtered hidden and disabled properties, so "checkbox_hidden" property doesn't exist in filteredValues
+		expect(filteredValues).not.to.have.property("checkbox_hidden");
+
+		// setDefaultValues is not set
+		controller.setPropertyValues(filteredValues);
+		// Verify value is not set for checkbox_hidden
+		expect(controller.getPropertyValues()).not.to.have.property("checkbox_hidden");
+
+		// setDefaultValues is set to true
+		controller.setPropertyValues(filteredValues, true);
+		// Verify a value is set for checkbox_hidden
+		expect(controller.getPropertyValues()).to.have.property("checkbox_hidden", true);
 	});
 	it("should fire event on updatePropertyValue", () => {
 		controller.updatePropertyValue({ name: "param_int" }, 10);

--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/checkbox_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/checkbox_paramDef.json
@@ -16,8 +16,7 @@
     "checkbox_error": false,
     "checkbox_warning": false,
     "disable": true,
-    "hide": true,
-    "checkbox_hidden": false
+    "hide": true
   },
   "parameters": [
     {
@@ -69,7 +68,8 @@
     {
       "id": "checkbox_hidden",
       "type": "boolean",
-      "required": true
+      "required": true,
+      "default": true
     }
   ],
   "complex_types": [

--- a/canvas_modules/common-canvas/src/common-properties/properties-controller.js
+++ b/canvas_modules/common-canvas/src/common-properties/properties-controller.js
@@ -179,7 +179,7 @@ export default class PropertiesController {
 			}
 			// Set the opening dataset(s), during which multiples are flattened and compound names generated if necessary
 			this.setDatasetMetadata(datasetMetadata);
-			this.setPropertyValues(propertyValues, false, true); // needs to be after setDatasetMetadata to run conditions
+			this.setPropertyValues(propertyValues, { isInitProps: true }); // needs to be after setDatasetMetadata to run conditions
 			this.differentProperties = [];
 			if (sameParameterDefRendered) {
 				// When a parameterDef is dynamically updated, set difference between old and new controls
@@ -1207,7 +1207,12 @@ export default class PropertiesController {
 		return returnValues;
 	}
 
-	setPropertyValues(values, setDefaultValues, isInitProps) {
+	/*
+	* options - optional object of config options where
+	*   setDefaultValues: true - set default values from parameter definition
+	*   isInitProps: true - Function is called during initial load. This is only used internally in setForm().
+	*/
+	setPropertyValues(values, options) {
 		let inValues = cloneDeep(values);
 
 		// convert currentParameters of type:object to array values
@@ -1229,7 +1234,7 @@ export default class PropertiesController {
 
 		this.propertiesStore.setPropertyValues(inValues);
 
-		if (isInitProps) {
+		if (options && options.isInitProps) {
 			// Evaluate conditional defaults based on current_parameters upon loading of view
 			// For a given parameter_ref, if multiple conditions evaluate to true only the first one is used.
 			const conditionalDefaultValues = {};
@@ -1265,7 +1270,7 @@ export default class PropertiesController {
 			);
 		}
 
-		if (setDefaultValues) {
+		if (options && options.setDefaultValues) {
 			this._addToControlValues(true);
 		}
 	}

--- a/canvas_modules/common-canvas/src/common-properties/properties-controller.js
+++ b/canvas_modules/common-canvas/src/common-properties/properties-controller.js
@@ -179,7 +179,7 @@ export default class PropertiesController {
 			}
 			// Set the opening dataset(s), during which multiples are flattened and compound names generated if necessary
 			this.setDatasetMetadata(datasetMetadata);
-			this.setPropertyValues(propertyValues, true); // needs to be after setDatasetMetadata to run conditions
+			this.setPropertyValues(propertyValues, false, true); // needs to be after setDatasetMetadata to run conditions
 			this.differentProperties = [];
 			if (sameParameterDefRendered) {
 				// When a parameterDef is dynamically updated, set difference between old and new controls
@@ -1207,7 +1207,7 @@ export default class PropertiesController {
 		return returnValues;
 	}
 
-	setPropertyValues(values, isInitProps) {
+	setPropertyValues(values, setDefaultValues, isInitProps) {
 		let inValues = cloneDeep(values);
 
 		// convert currentParameters of type:object to array values
@@ -1263,6 +1263,10 @@ export default class PropertiesController {
 					action: ACTIONS.SET_PROPERTIES // Setting the properties in current_parameters
 				}
 			);
+		}
+
+		if (setDefaultValues) {
+			this._addToControlValues(true);
 		}
 	}
 

--- a/canvas_modules/harness/test_resources/parameterDefs/checkbox_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/checkbox_paramDef.json
@@ -16,8 +16,7 @@
     "checkbox_error": false,
     "checkbox_warning": false,
     "disable": true,
-    "hide": true,
-    "checkbox_hidden": false
+    "hide": true
   },
   "parameters": [
     {
@@ -69,7 +68,8 @@
     {
       "id": "checkbox_hidden",
       "type": "boolean",
-      "required": true
+      "required": true,
+      "default": true
     }
   ],
   "complex_types": [


### PR DESCRIPTION
Fixes #1649 

Added a new parameter to set config options in `setPropertyValues()` method - 
```
/*
* options - optional object of config options where
*   setDefaultValues (boolean): when set to true, set default values from parameter definition
*/
setPropertyValues(values, options)
```


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

