### PR TITLE
#1668 Fixed bug setDefaultValues not picking up defaults 2nd call onwards

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/properties-controller-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/properties-controller-test.js
@@ -29,6 +29,7 @@ import checkboxsetParamDef from "../test_resources/paramDefs/checkboxset_paramDe
 import checkboxParamDef from "../test_resources/paramDefs/checkbox_paramDef.json";
 import actionParamDef from "../test_resources/paramDefs/action_paramDef.json";
 import numberfieldParamDef from "../test_resources/paramDefs/numberfield_paramDef.json";
+import oneofselectParamDef from "../test_resources/paramDefs/oneofselect_paramDef.json";
 import structuretablePropertyValues from "../test_resources/json/structuretable_propertyValues.json";
 import ExpressionInfo from "../test_resources/json/expression-function-list.json";
 import readonlyTableParamDef from "../test_resources/paramDefs/readonlyTable_paramDef.json";
@@ -1221,10 +1222,71 @@ describe("Properties Controller handlers", () => {
 		const allProperties = merge({ "checkbox_hidden": true }, filteredValues);
 		expect(controller.getPropertyValues()).to.eql(allProperties);
 
+		// setDefaultValues is set to true - 2nd time
+		controller.setPropertyValues(filteredValues, { setDefaultValues: true });
+		// Verify a value is set for checkbox_hidden
+		expect(controller.getPropertyValues()).to.have.property("checkbox_hidden", true);
+		// Verify filteredValues and default values are set
+		expect(controller.getPropertyValues()).to.eql(allProperties);
+
+		// setDefaultValues is set to true - 3rd time
+		controller.setPropertyValues(filteredValues, { setDefaultValues: true });
+		// Verify a value is set for checkbox_hidden
+		expect(controller.getPropertyValues()).to.have.property("checkbox_hidden", true);
+		// Verify filteredValues and default values are set
+		expect(controller.getPropertyValues()).to.eql(allProperties);
+
 		// Verify there's a single call to the propertyListener()
 		expect(propertyListener.calledWith({
 			action: "SET_PROPERTIES"
 		})).to.be.true;
+	});
+	it("should set default values having 0 or ' ' when setPropertyValues() is called with option { setDefaultValues: true }", () => {
+		const renderedObject = testUtils.flyoutEditorForm(oneofselectParamDef);
+		controller = renderedObject.controller;
+		controller.setHandlers({
+			propertyListener: propertyListener
+		});
+
+		const filteredValues = controller.getPropertyValues({ filterHiddenDisabled: true });
+		// We filtered hidden and disabled properties, some hidden properties don't exist in filteredValues
+		expect(filteredValues).not.to.have.property("oneofselect_hidden");
+		expect(filteredValues).not.to.have.property("fill");
+		expect(filteredValues).not.to.have.property("viewonly");
+
+		// setDefaultValues is not set
+		controller.setPropertyValues(filteredValues);
+		// Verify value is not set for hidden properties
+		expect(controller.getPropertyValues()).not.to.have.property("oneofselect_hidden");
+		expect(controller.getPropertyValues()).not.to.have.property("fill");
+		expect(controller.getPropertyValues()).not.to.have.property("viewonly");
+		// Verify filteredValues are set
+		expect(controller.getPropertyValues()).to.eql(filteredValues);
+
+		// setDefaultValues is set to true - 1st time
+		controller.setPropertyValues(filteredValues, { setDefaultValues: true });
+		// Verify a default value is set for hidden properties
+		expect(controller.getPropertyValues()).to.have.property("fill", 0);
+		expect(controller.getPropertyValues()).to.have.property("viewonly", " ");
+		// Verify filteredValues and default values are set
+		const allProperties = merge({ "fill": 0, "viewonly": " " }, filteredValues);
+		expect(controller.getPropertyValues()).to.eql(allProperties);
+
+		// setDefaultValues is set to true - 2nd time
+		controller.setPropertyValues(filteredValues, { setDefaultValues: true });
+		// Verify a default value is set for hidden properties
+		expect(controller.getPropertyValues()).to.have.property("fill", 0);
+		expect(controller.getPropertyValues()).to.have.property("viewonly", " ");
+		// Verify filteredValues and default values are set
+		expect(controller.getPropertyValues()).to.eql(allProperties);
+
+		// setDefaultValues is set to true - 3rd time
+		controller.setPropertyValues(filteredValues, { setDefaultValues: true });
+		// Verify a default value is set for hidden properties
+		expect(controller.getPropertyValues()).to.have.property("fill", 0);
+		expect(controller.getPropertyValues()).to.have.property("viewonly", " ");
+		// Verify filteredValues and default values are set
+		expect(controller.getPropertyValues()).to.eql(allProperties);
 	});
 	it("should fire event on updatePropertyValue", () => {
 		controller.updatePropertyValue({ name: "param_int" }, 10);

--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/oneofselect_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/oneofselect_paramDef.json
@@ -5,6 +5,7 @@
   "current_parameters": {
     "oneofselect": "blue",
     "oneofselect_custom_value": "custom",
+    "oneofselect_custom_value_null": null,
     "oneofselect_null": null,
     "oneofselect_empty_string": "",
     "oneofselect_placeholder": "",
@@ -48,6 +49,30 @@
     },
     {
       "id": "oneofselect_custom_value",
+      "enum": [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "purple"
+      ],
+      "required": true
+    },
+    {
+      "id": "oneofselect_custom_value_null",
+      "enum": [
+        "red",
+        "orange",
+        "yellow",
+        "green",
+        "blue",
+        "purple"
+      ],
+      "required": true
+    },
+    {
+      "id": "oneofselect_custom_value_undefined",
       "enum": [
         "red",
         "orange",
@@ -172,6 +197,24 @@
         "purple"
       ],
       "required": true
+    },
+    {
+      "id": "fill",
+      "enum": [
+        -1,
+        0,
+        32
+      ],
+      "default": 0,
+      "required": false
+    },
+    {
+      "id": "viewonly",
+      "enum": [
+        " ",
+        "admin viewonly"
+      ],
+      "default": " "
     },
     {
       "id": "disable",
@@ -358,6 +401,26 @@
         "custom_value_allowed": true
       },
       {
+        "parameter_ref": "oneofselect_custom_value_null",
+        "label": {
+          "default": "oneofselect custom value allowed with parameter value set to 'null'"
+        },
+        "description": {
+          "default": "oneofselect with option to enter a custom value"
+        },
+        "custom_value_allowed": true
+      },
+      {
+        "parameter_ref": "oneofselect_custom_value_undefined",
+        "label": {
+          "default": "oneofselect custom value allowed with parameter value not set"
+        },
+        "description": {
+          "default": "oneofselect with option to enter a custom value"
+        },
+        "custom_value_allowed": true
+      },
+      {
         "parameter_ref": "oneofselect_null",
         "label": {
           "default": "oneofselect null"
@@ -446,6 +509,28 @@
         "parameter_ref": "oneofselect_hidden",
         "label": {
           "default": "oneofselect Hidden"
+        }
+      },
+      {
+        "parameter_ref": "fill",
+        "resource_key": "fillRKey",
+        "control": "oneofselect",
+        "label": {
+          "resource_key": "fillRKey.label"
+        },
+        "description": {
+          "resource_key": "fillRKey.description"
+        }
+      },
+      {
+        "parameter_ref": "viewonly",
+        "resource_key": "viewonlyRKey",
+        "control": "oneofselect",
+        "label": {
+          "resource_key": "viewonlyRkey.label"
+        },
+        "description": {
+          "resource_key": "viewonly.description"
         }
       },
       {
@@ -618,6 +703,8 @@
         "parameter_refs": [
           "oneofselect",
           "oneofselect_custom_value",
+          "oneofselect_custom_value_null",
+          "oneofselect_custom_value_undefined",
           "oneofselect_null",
           "oneofselect_empty_string",
           "oneofselect_undefined",
@@ -637,6 +724,8 @@
           "oneofselect_warning",
           "hide",
           "oneofselect_hidden",
+          "fill",
+          "viewonly",
           "disable",
           "oneofselect_disabled"
         ]
@@ -726,6 +815,34 @@
       "visible": {
         "parameter_refs": [
           "oneofselect_hidden"
+        ],
+        "evaluate": {
+          "condition": {
+            "parameter_ref": "hide",
+            "op": "equals",
+            "value": false
+          }
+        }
+      }
+    },
+    {
+      "visible": {
+        "parameter_refs": [
+          "fill"
+        ],
+        "evaluate": {
+          "condition": {
+            "parameter_ref": "hide",
+            "op": "equals",
+            "value": false
+          }
+        }
+      }
+    },
+    {
+      "visible": {
+        "parameter_refs": [
+          "viewonly"
         ],
         "evaluate": {
           "condition": {
@@ -957,6 +1074,15 @@
     "oneofselect_filtered.blue.label": "Blue",
     "animal.cat.label": "Cat",
     "animal.dog.label": "Dog",
-    "animal.pig.label": "Pig"
+    "animal.pig.label": "Pig",
+    "fillRKey.label": "Fill char",
+    "fillRKey.description": "Byte value to fill in any gaps in an exported record caused by field positioning properties. Valid only for export. By default, the fill value is the null byte (0); it may be an integer between 0 and 255, or a single-character value.",
+    "fillRKey.-1.label": "Custom fill char character",
+    "fillRKey.0.label": "null",
+    "fillRKey.32.label": "space",
+    "viewonlyRkey.label": "View state file",
+    "viewonly.description": "Select whether or not to view details of the state file.",
+    "viewonlyRKey.admin viewonly.label": "Yes",
+    "viewonlyRKey. .label": "No"
   }
 }

--- a/canvas_modules/common-canvas/src/common-properties/properties-controller.js
+++ b/canvas_modules/common-canvas/src/common-properties/properties-controller.js
@@ -395,7 +395,7 @@ export default class PropertiesController {
 		parseUiContent(this.panelTree, this.form, PANEL_TREE_ROOT);
 	}
 
-	_addToControlValues(sameParameterDefRendered, resolveParameterRefs, setDefaultValues) {
+	_addToControlValues(sameParameterDefRendered, resolveParameterRefs, setDefaults) {
 		const defaultControlValues = {};
 		for (const keyName in this.controls) {
 			if (!has(this.controls, keyName)) {
@@ -403,7 +403,12 @@ export default class PropertiesController {
 			}
 			const control = this.controls[keyName];
 			const propertyId = { name: control.name };
-			let controlValue = this.getPropertyValue(propertyId);
+			let controlValue;
+			if (setDefaults?.values) {
+				controlValue = setDefaults.values[control.name];
+			} else {
+				controlValue = this.getPropertyValue(propertyId);
+			}
 
 			if (resolveParameterRefs) {
 				if (typeof controlValue !== "undefined" && controlValue !== null && typeof controlValue.parameterRef !== "undefined") {
@@ -422,7 +427,7 @@ export default class PropertiesController {
 					controlValue = PropertyUtils.convertObjectStructureToArray(control.valueDef.isList, control.subControls, controlValue);
 				}
 
-				if (setDefaultValues) {
+				if (setDefaults?.setDefaultValues) {
 					// When setDefaultValues is set, update all default values in a single call
 					defaultControlValues[control.name] = controlValue;
 				} else if (sameParameterDefRendered && !this.differentProperties.includes(control.name)) {
@@ -440,7 +445,7 @@ export default class PropertiesController {
 			}
 		}
 
-		if (setDefaultValues) {
+		if (setDefaults?.setDefaultValues) {
 			return defaultControlValues;
 		}
 
@@ -1243,7 +1248,8 @@ export default class PropertiesController {
 		}
 
 		if (options && options.setDefaultValues) {
-			const defaultValues = this._addToControlValues(false, false, true);
+			const setDefaults = { values: inValues, setDefaultValues: true };
+			const defaultValues = this._addToControlValues(false, false, setDefaults);
 			inValues = merge(defaultValues, inValues);
 		}
 

--- a/canvas_modules/harness/test_resources/parameterDefs/oneofselect_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/oneofselect_paramDef.json
@@ -199,6 +199,24 @@
       "required": true
     },
     {
+      "id": "fill",
+      "enum": [
+        -1,
+        0,
+        32
+      ],
+      "default": 0,
+      "required": false
+    },
+    {
+      "id": "viewonly",
+      "enum": [
+        " ",
+        "admin viewonly"
+      ],
+      "default": " "
+    },
+    {
       "id": "disable",
       "type": "boolean"
     },
@@ -494,6 +512,28 @@
         }
       },
       {
+        "parameter_ref": "fill",
+        "resource_key": "fillRKey",
+        "control": "oneofselect",
+        "label": {
+          "resource_key": "fillRKey.label"
+        },
+        "description": {
+          "resource_key": "fillRKey.description"
+        }
+      },
+      {
+        "parameter_ref": "viewonly",
+        "resource_key": "viewonlyRKey",
+        "control": "oneofselect",
+        "label": {
+          "resource_key": "viewonlyRkey.label"
+        },
+        "description": {
+          "resource_key": "viewonly.description"
+        }
+      },
+      {
         "parameter_ref": "disable",
         "label": {
           "default": "Disable 'oneofselect Disabled'"
@@ -684,6 +724,8 @@
           "oneofselect_warning",
           "hide",
           "oneofselect_hidden",
+          "fill",
+          "viewonly",
           "disable",
           "oneofselect_disabled"
         ]
@@ -773,6 +815,34 @@
       "visible": {
         "parameter_refs": [
           "oneofselect_hidden"
+        ],
+        "evaluate": {
+          "condition": {
+            "parameter_ref": "hide",
+            "op": "equals",
+            "value": false
+          }
+        }
+      }
+    },
+    {
+      "visible": {
+        "parameter_refs": [
+          "fill"
+        ],
+        "evaluate": {
+          "condition": {
+            "parameter_ref": "hide",
+            "op": "equals",
+            "value": false
+          }
+        }
+      }
+    },
+    {
+      "visible": {
+        "parameter_refs": [
+          "viewonly"
         ],
         "evaluate": {
           "condition": {
@@ -1004,6 +1074,15 @@
     "oneofselect_filtered.blue.label": "Blue",
     "animal.cat.label": "Cat",
     "animal.dog.label": "Dog",
-    "animal.pig.label": "Pig"
+    "animal.pig.label": "Pig",
+    "fillRKey.label": "Fill char",
+    "fillRKey.description": "Byte value to fill in any gaps in an exported record caused by field positioning properties. Valid only for export. By default, the fill value is the null byte (0); it may be an integer between 0 and 255, or a single-character value.",
+    "fillRKey.-1.label": "Custom fill char character",
+    "fillRKey.0.label": "null",
+    "fillRKey.32.label": "space",
+    "viewonlyRkey.label": "View state file",
+    "viewonly.description": "Select whether or not to view details of the state file.",
+    "viewonlyRKey.admin viewonly.label": "Yes",
+    "viewonlyRKey. .label": "No"
   }
 }


### PR DESCRIPTION
Fixes #1668 

Added 2 new properties having default values `0` and `" "`. These will be hidden if the `hide` checkbox is selected.
I don't see any issues with setting `0` and `" "` as default values. 
<img width="318" alt="Screenshot 2024-01-18 at 2 59 39 PM" src="https://github.com/elyra-ai/canvas/assets/25124000/4db3fdee-5b9c-4360-a5af-fab90cde08ad">




 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

