### PR TITLE
#1721 Replace codemirror-lang-r package with @codemirror/legacy-modes

### DIFF
--- a/canvas_modules/common-canvas/package.json
+++ b/canvas_modules/common-canvas/package.json
@@ -27,8 +27,8 @@
     "@codemirror/lang-javascript": "^6.2.1",
     "@codemirror/lang-python": "^6.1.4",
     "@codemirror/lang-sql": "^6.5.5",
-    "codemirror-lang-r": "^0.1.0-2",
     "@codemirror/language": "^6.10.1",
+    "@codemirror/legacy-modes": "^6.3.3",
     "@codemirror/state": "^6.4.0",
     "@codemirror/view": "^6.23.1",
     "@codemirror/autocomplete": "^6.12.0",
@@ -119,7 +119,7 @@
   },
   "jest": {
     "transformIgnorePatterns": [
-      "/node_modules/(?!(lezer-r|d3|d3-array|d3-axis|d3-brush|d3-chord|d3-color|d3-contour|d3-delaunay|d3-dispatch|d3-drag|d3-dsv|d3-ease|d3-fetch|d3-force|d3-format|d3-geo|d3-hierarchy|d3-interpolate|d3-path|d3-polygon|d3-quadtree|d3-random|d3-scale|d3-scale-chromatic|d3-selection|d3-shape|d3-time|d3-time-format|d3-timer|d3-transition|d3-zoom)/)"
+      "node_modules/(?!(@codemirror/legacy-modes|d3-*))"
     ],
     "moduleFileExtensions": [
       "js",

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.jsx
@@ -41,12 +41,11 @@ import { Compartment } from "@codemirror/state";
 import { tags } from "@lezer/highlight";
 import { HighlightStyle, syntaxHighlighting } from "@codemirror/language";
 import { python } from "@codemirror/lang-python";
-import { r } from "codemirror-lang-r";
 import { sql } from "@codemirror/lang-sql";
 import { javascript } from "@codemirror/lang-javascript";
 
 import { getPythonHints } from "./languages/python-hint";
-import { getRHints } from "./languages/r-hint";
+import { rLanguage } from "./languages/r-hint";
 import { clem } from "./languages/CLEM-hint";
 
 const pxPerChar = 8.5;
@@ -168,14 +167,13 @@ class ExpressionControl extends React.Component {
 			this.origHint = getPythonHints();
 			break;
 		case "text/x-rsrc":
-			language = r();
-			this.origHint = getRHints();
+			language = rLanguage(); // custom language
 			break;
 		case "javascript":
 			language = javascript();
 			break;
 		default:
-			language = clem();
+			language = clem(); // custom language
 		}
 
 		// Custom completions add to the language completions

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/languages/r-hint.js
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/languages/r-hint.js
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-// Ref: https://cran.r-project.org/doc/manuals/r-release/R-lang.html#Reserved-words
-// Search for "10.3.3 Reserved words"
-const keywords = "if|else|repeat|while|function|for|in|next|break" +
-	"|TRUE|FALSE|NULL|Inf|NaN|NA|NA_integer_|NA_real_|NA_complex_|NA_character_";
-
-const rKeywords = keywords.split("|");
+import { LanguageSupport, StreamLanguage } from "@codemirror/language";
+import { completeFromList } from "@codemirror/autocomplete";
+import { r } from "@codemirror/legacy-modes/mode/r";
 
 const builtIns = "zapsmall xzfile xtfrm xor writeLines writeChar writeBin write withVisible withRestarts within" +
 	" withCallingHandlers withAutoprint with while which weekdays warnings warning version Vectorize vector vapply" +
@@ -70,13 +67,23 @@ const rBuiltIns = builtIns.split(" ");
 function getRHints() {
 	const rHints = [];
 
-	rKeywords.forEach((keyword) => rHints.push({ label: keyword, type: "keyword" }));
-
 	rBuiltIns.forEach((builtIn) => rHints.push({ label: builtIn, type: "keyword" }));
 
 	return rHints;
 }
 
+// Define R language
+const rLan = StreamLanguage.define(r);
+
+// Autocompletions
+const rCompletion = rLan.data.of({
+	autocomplete: completeFromList(getRHints())
+});
+
+function rLanguage() {
+	return new LanguageSupport(rLan, [rCompletion]);
+}
+
 export {
-	getRHints
+	rLanguage
 };

--- a/canvas_modules/harness/cypress/e2e/properties/expression-control.cy.js
+++ b/canvas_modules/harness/cypress/e2e/properties/expression-control.cy.js
@@ -168,13 +168,14 @@ describe("Test of Python and R expression controls", function() {
 		// test R autocomplete and syntax highlighting
 		cy.verifyTypeOfWordInExpressionEditor("# syntax testing", "comment", "conditionExpr");
 		cy.verifyTypeOfWordInExpressionEditor("1", "number", "conditionExpr");
-		cy.verifyTypeOfWordInExpressionEditor("text", "string", "conditionExpr");
-		cy.verifyTypeOfWordInExpressionEditor("\n", "string", "conditionExpr");
+		cy.verifyTypeOfWordInExpressionEditor("text\"", "string", "conditionExpr");
+		cy.verifyTypeOfWordInExpressionEditor('\n', "string", "conditionExpr");
 		cy.verifyTypeOfWordInExpressionEditor("=", "operator", "conditionExpr");
 		cy.verifyTypeOfWordInExpressionEditor("function", "keyword", "conditionExpr");
-		cy.verifyTypeOfWordInExpressionEditor("Inf", "number", "conditionExpr");
-		cy.verifyTypeOfWordInExpressionEditor("return", "keyword", "conditionExpr");
+		cy.verifyTypeOfWordInExpressionEditor("Inf", "keyword", "conditionExpr");
+		cy.verifyTypeOfWordInExpressionEditor("return", "variable", "conditionExpr");
 		cy.verifyTypeOfWordInExpressionEditor("<-", "operator", "conditionExpr");
+		cy.verifyTypeOfWordInExpressionEditor(";", "punctuation", "conditionExpr");
 
 		cy.enterTextInExpressionEditor("br", "conditionExpr");
 		cy.verifyNumberOfHintsInExpressionEditor(9);


### PR DESCRIPTION
Fixes #1721 

Jest tests are failing with [@codemirror/legacy-modes](https://www.npmjs.com/package/@codemirror/legacy-modes) package as well. To fix jest tests, host applications should add this config in `package.json` file -
```
"jest": {
    "transformIgnorePatterns": [
      "node_modules/@elyra/canvas/node_modules/(?!@codemirror/legacy-modes)"
    ]
  }
```
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

