### PR TITLE
#1761 Add Elyra documentation link in readme and npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ The Common Canvas tooling consists of two Node JS modules:
 2) `Test harness`  
 See [here](https://github.com/elyra-ai/canvas/tree/main/canvas_modules/harness) for setting up local environment
 
+## Documentation
+* Elyra canvas documentation - https://elyra-ai.github.io/canvas/
+* Elyra canvas playground (Test harness) - https://ibm.biz/elyra-canvas-test-harness
+
 ## Using local version of common-canvas and/or common-properties
 Clone elyra/canvas
 ```sh

--- a/canvas_modules/common-canvas/package.json
+++ b/canvas_modules/common-canvas/package.json
@@ -4,7 +4,7 @@
   "description": "Elyra common-canvas",
   "main": "dist/common-canvas.js",
   "module": "dist/common-canvas.es.js",
-  "homepage": "https://github.com/elyra-ai/canvas",
+  "homepage": "https://elyra-ai.github.io/canvas/",
   "repository": {
     "type": "git",
     "url": "https://github.com/elyra-ai/canvas/tree/main/canvas_modules/common-canvas"


### PR DESCRIPTION
Fixes #1761 
 
To add documentation link under `Homepage` - https://www.npmjs.com/package/@elyra/canvas
![Screenshot 2024-03-21 at 3 12 35 PM](https://github.com/elyra-ai/canvas/assets/25124000/389e5a19-f1a3-4dc1-affc-649812eaa082)

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

