### PR TITLE
#1829 editActionHandler not called with multi-undo prototype

### DIFF
--- a/canvas_modules/common-canvas/src/common-canvas/canvas-controller.js
+++ b/canvas_modules/common-canvas/src/common-canvas/canvas-controller.js
@@ -1385,30 +1385,32 @@ export default class CanvasController {
 	}
 
 	// Calls the undo() method of the next available command on the command
-	// stack that can be undone, if one is available.
+	// stack that can be undone, if one is available. Uses the editActionHandler
+	// method which will cause the app's editActionHandler to be called.
 	undo() {
 		if (this.canUndo()) {
-			this.getCommandStack().undo();
-			this.objectModel.refreshToolbar();
+			this.editActionHandler({ editType: "undo", editSource: "controller" });
 		}
 	}
 
-	// Undoes a number of commands on the command stack as
-	// indicated by the 'count' parameter. If 'count' is bigger
-	// than the number of commands on the stack, all undoable
-	// commands currently on the command stack will be undone.
+	// Undoes a number of commands on the command stack as indicated by the
+	// 'count' parameter. If 'count' is bigger than the number of commands
+	// on the stack, all undoable commands currently on the command stack
+	// will be undone. Uses the editActionHandler method which will cause
+	// the app's editActionHandler to be called.
 	undoMulti(count) {
-		for (let i = 0; i < count; i++) {
-			this.undo();
+		for (let i = 0; i < count && this.canUndo(); i++) {
+			this.editActionHandler({ editType: "undo", editSource: "controller" });
 		}
 	}
+
 
 	// Calls the redo() method of the next available command on the command
-	// stack that can be redone, if one is available.
+	// stack that can be redone, if one is available. Uses the editActionHandler
+	// method which will cause the app's editActionHandler to be called.
 	redo() {
 		if (this.canRedo()) {
-			this.getCommandStack().redo();
-			this.objectModel.refreshToolbar();
+			this.editActionHandler({ editType: "redo", editSource: "controller" });
 		}
 	}
 


### PR DESCRIPTION
Fixes: #1829 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

