### PR TITLE
#1949 Code-mirror-replacement text and highlighting doesn't look correct in dark mode

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.scss
@@ -23,7 +23,7 @@
 		width: 100%;
 		background: $field-02;
 		color: $text-primary;
-	
+
 		.cm-gutters {
 			border-right: none;
 			background-color: inherit;
@@ -52,7 +52,8 @@
 			background-color: $background-active;
 		}
 		&.cm-focused .cm-selectionBackground, ::selection {
-			background: $support-info-inverse !important; //add !important to override the selected text style
+			/* stylelint-disable-next-line declaration-no-important */
+			background: $support-info-inverse !important; // add !important to override the selected text style
 		}
 		.cm-tooltip-autocomplete {
 			z-index: 1110;

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.scss
@@ -23,7 +23,7 @@
 		width: 100%;
 		background: $field-02;
 		color: $text-primary;
-
+	
 		.cm-gutters {
 			border-right: none;
 			background-color: inherit;
@@ -45,6 +45,15 @@
 			}
 		}
 
+		.cm-activeLine {
+			background-color: $background-selected; // works for both dark n light
+		}
+		.cm-activeLineGutter {
+			background-color: $background-active;
+		}
+		&.cm-focused .cm-selectionBackground, ::selection {
+			background: $support-info-inverse !important; //add !important to override the selected text style
+		}
 		.cm-tooltip-autocomplete {
 			z-index: 1110;
 			ul {
@@ -104,6 +113,9 @@
 .properties-light-disabled {
 	.elyra-CodeMirror .cm-editor {
 		background: $field-01;
+		.cm-activeLineGutter {
+			background-color: $background-inverse-hover;
+		}
 	}
 }
 

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.scss
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.scss
@@ -49,7 +49,8 @@
 			background-color: $background-selected; // works for both dark n light
 		}
 		.cm-activeLineGutter {
-			background-color: $background-active;
+			background-color: $text-placeholder;
+			color: $text-inverse;
 		}
 		&.cm-focused .cm-selectionBackground, ::selection {
 			/* stylelint-disable-next-line declaration-no-important */
@@ -114,9 +115,6 @@
 .properties-light-disabled {
 	.elyra-CodeMirror .cm-editor {
 		background: $field-01;
-		.cm-activeLineGutter {
-			background-color: $background-inverse-hover;
-		}
 	}
 }
 


### PR DESCRIPTION
Fixes: #1949 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

