### PR TITLE
#1970 Replace light prop with Layer component in Carbon components

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/editor-form/editor-form.jsx
@@ -270,7 +270,6 @@ class EditorForm extends React.Component {
 		return (
 			<Tabs key={"tab." + key}
 				selectedIndex={modalSelected}
-				light={this.props.controller.getLight()}
 			>
 				<TabList className="properties-primaryTabs" aria-label={tabListAriaLabel}>
 					{tabLists}

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.jsx
@@ -20,7 +20,7 @@ import { connect } from "react-redux";
 import { setTitle } from "./../../actions";
 import Isvg from "react-inlinesvg";
 import { get } from "lodash";
-import { TextInput, Button } from "@carbon/react";
+import { TextInput, Button, Layer } from "@carbon/react";
 import { MESSAGE_KEYS, CONDITION_MESSAGE_TYPE } from "./../../constants/constants";
 import * as PropertyUtils from "./../../util/property-utils";
 import classNames from "classnames";
@@ -181,25 +181,26 @@ class TitleEditor extends Component {
 					}
 				)}
 				>
-					<TextInput
-						id={this.id}
-						ref={this.textInputRef}
-						value={this.props.title}
-						onChange={this.handleTitleChange}
-						onKeyDown={(e) => this._handleKeyPress(e)}
-						readOnly={this.props.labelEditable === false} // shows a non editable icon
-						labelText={this.labelText}
-						hideLabel
-						size="sm"
-						onFocus={this.textInputOnFocus}
-						onBlur={this.textInputOnBlur}
-						light={this.props.controller.getLight()}
-						invalid={titleWithErrror}
-						invalidText={get(this.state.titleValidation, "message")}
-						warn={titleWithWarning}
-						warnText={get(this.state.titleValidation, "message")}
-						{... this.state.focused && { className: "properties-title-editor-focused" }}
-					/>
+					<Layer level={this.props.controller.getLight() ? 1 : 0} className="properties-title-editor-layer">
+						<TextInput
+							id={this.id}
+							ref={this.textInputRef}
+							value={this.props.title}
+							onChange={this.handleTitleChange}
+							onKeyDown={(e) => this._handleKeyPress(e)}
+							readOnly={this.props.labelEditable === false} // shows a non editable icon
+							labelText={this.labelText}
+							hideLabel
+							size="sm"
+							onFocus={this.textInputOnFocus}
+							onBlur={this.textInputOnBlur}
+							invalid={titleWithErrror}
+							invalidText={get(this.state.titleValidation, "message")}
+							warn={titleWithWarning}
+							warnText={get(this.state.titleValidation, "message")}
+							{... this.state.focused && { className: "properties-title-editor-focused" }}
+						/>
+					</Layer>
 					{titleValidationTypes.includes(get(this.state.titleValidation, "type")) ? null : propertiesTitleEdit}
 				</div>
 				{!this.headingEnabled && !titleValidationTypes.includes(get(this.state.titleValidation, "type")) ? helpButton : null}

--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
@@ -53,10 +53,11 @@
 	&.properties-title-editor-with-help {
 		width: calc(100% - #{$spacing-07} - #{$spacing-03}); // subtract the size of the help button and 8px to align with Close icon when applyOnBlur is set
 	}
-	.cds--form-item.cds--text-input-wrapper {
+	.properties-title-editor-layer {
 		// allow edit icon to be at the end of text input
 		width: 100%;
-
+	}
+	.cds--form-item.cds--text-input-wrapper {
 		input { //override styling from carbon
 			@include type-style("productive-heading-02");
 			color: $text-primary;

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression-builder/expression-select-field-function.jsx
@@ -18,7 +18,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Add } from "@carbon/react/icons";
 import { Button } from "@carbon/react";
-import { Switch, ContentSwitcher, Dropdown } from "@carbon/react";
+import { Switch, ContentSwitcher, Dropdown, Layer } from "@carbon/react";
 import FlexibleTable from "./../../../components/flexible-table/flexible-table";
 import TruncatedContentTooltip from "./../../../components/truncated-content-tooltip";
 import { MESSAGE_KEYS, EXPRESSION_TABLE_ROWS, SORT_DIRECTION, ROW_SELECTION } from "./../../../constants/constants";
@@ -605,15 +605,16 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 		};
 		return (
 			<div className="properties-expression-function-select">
-				<Dropdown
-					id={"properties-expression-function-select-dropdown-" + this.uuid}
-					light={this.props.controller.getLight()}
-					label={label}
-					items={items}
-					onChange={this.onFunctionCatChange}
-					translateWithId={(id) => listBoxMenuIconTranslationIds[id]}
-					titleText={header}
-				/>
+				<Layer level={this.props.controller.getLight() ? 1 : 0}>
+					<Dropdown
+						id={"properties-expression-function-select-dropdown-" + this.uuid}
+						label={label}
+						items={items}
+						onChange={this.onFunctionCatChange}
+						translateWithId={(id) => listBoxMenuIconTranslationIds[id]}
+						titleText={header}
+					/>
+				</Layer>
 			</div>);
 	}
 
@@ -634,15 +635,16 @@ export default class ExpressionSelectFieldOrFunction extends React.Component {
 		};
 		return (
 			<div className="properties-expression-field-select">
-				<Dropdown
-					id={"properties-expression-field-select-dropdown-" + this.uuid}
-					light={this.props.controller.getLight()}
-					label={label}
-					items={newItems}
-					onChange={this.onFieldCatChange}
-					translateWithId={(id) => listBoxMenuIconTranslationIds[id]}
-					titleText={header}
-				/>
+				<Layer level={this.props.controller.getLight() ? 1 : 0}>
+					<Dropdown
+						id={"properties-expression-field-select-dropdown-" + this.uuid}
+						label={label}
+						items={newItems}
+						onChange={this.onFieldCatChange}
+						translateWithId={(id) => listBoxMenuIconTranslationIds[id]}
+						titleText={header}
+					/>
+				</Layer>
 			</div>);
 	}
 

--- a/canvas_modules/common-canvas/src/common-properties/panels/subtabs/subtabs.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/subtabs/subtabs.jsx
@@ -86,7 +86,6 @@ class Subtabs extends React.Component {
 			>
 				<Tabs
 					selectedIndex={activeTab}
-					light={this.props.controller.getLight()}
 				>
 					<TabList className={classNames("properties-subtabs", { "properties-leftnav-subtabs": this.props.leftnav })} aria-label={tabListAriaLabel}>
 						{subTabLists}


### PR DESCRIPTION
Fixes #1970 

These components were missed during Carbon 11 Migration. Replacing `light` prop with Layer component in **Carbon 11 components only**. 
We will continue using `light` prop in common-properties components like `FlexibleTable, WideFlyout, VirtualizedTable` etc.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

