### PR TITLE
#2088 Render actions in title outside of groups

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/components/title-editor-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/components/title-editor-test.js
@@ -420,7 +420,7 @@ describe("Title editor actions", () => {
 		expect(buttons.length).to.equal(2);
 
 		expect(buttons[0].textContent).to.equal("Increment");
-		expect(buttons[1].textContent).to.equal("Decrement");
+		expect(buttons[1].textContent).to.equal("Run");
 
 		fireEvent.click(buttons[0]);
 

--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/action_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/action_paramDef.json
@@ -158,7 +158,7 @@
     "title_info": {
       "action_refs": [
         "increment",
-        "decrement"
+        "run_action"
       ]
     },
     "parameter_info": [
@@ -716,6 +716,14 @@
             "width": 25
           }
         }
+      },
+      {
+        "id": "run_action",
+        "label": {
+          "resource_key": "run_action"
+        },
+        "control": "button",
+        "data": {}
       }
     ],
     "group_info": [
@@ -918,7 +926,6 @@
               "disable_image_text"
             ]
           }
-
         ]
       },
       {
@@ -1010,8 +1017,6 @@
         }
       }
     }
-
-
   ],
   "dataset_metadata": [
     {
@@ -1085,13 +1090,14 @@
   "resources": {
     "increment": "Increment",
     "decrement": "Decrement",
+    "run_action": "Run",
     "dm-update": "Add Field",
-    "winter":    "Winter",
-    "summer":    "Summer",
-    "fall":      "Fall",
-    "spring":    "Spring",
-    "moon":      "Moon",
-    "meteor":    "Meteor",
+    "winter": "Winter",
+    "summer": "Summer",
+    "fall": "Fall",
+    "spring": "Spring",
+    "moon": "Moon",
+    "meteor": "Meteor",
     "weather.action.panel.label": "Weather action panel label",
     "weather.action.panel.desc": "Weather action panel description"
   }

--- a/canvas_modules/common-canvas/src/common-properties/form/EditorForm.js
+++ b/canvas_modules/common-canvas/src/common-properties/form/EditorForm.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Elyra Authors
+ * Copyright 2017-2024 Elyra Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -856,5 +856,5 @@ function _parameterValueDescription(parameter, l10nProvider) {
 
 
 export {
-	makePrimaryTab, _makeControl as makeControl
+	makePrimaryTab, _makeControl as makeControl, _makeActions as makeActions
 };

--- a/canvas_modules/common-canvas/src/common-properties/form/Form.js
+++ b/canvas_modules/common-canvas/src/common-properties/form/Form.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 Elyra Authors
+ * Copyright 2017-2024 Elyra Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 import { PropertyDef } from "./PropertyDef";
 import { propertyOf } from "lodash";
-import { makePrimaryTab } from "./EditorForm";
+import { makePrimaryTab, makeActions } from "./EditorForm";
 import { UIItem } from "./UIItem";
 import { L10nProvider } from "../util/L10nProvider";
 import { translateMessages } from "./Conditions";
@@ -61,6 +61,10 @@ export default class Form {
 					tabs.push(makePrimaryTab(propDef, group, l10nProvider, containerType));
 				}
 			}
+			let titleActions = [];
+			if (propDef.titleMetadata && propDef.actionMetadata) {
+				titleActions = makeActions(null, propDef.actionMetadata, propDef.titleMetadata.Title, null, l10nProvider);
+			}
 
 			const currentParameters = propertyOf(paramDef)("current_parameters");
 			const data = {
@@ -76,7 +80,7 @@ export default class Form {
 				propDef.help,
 				propDef.editorSizeHint(editorSizeDefault),
 				propDef.pixelWidth,
-				[UIItem.makePrimaryTabs(tabs)],
+				[UIItem.makePrimaryTabs(tabs)].concat(titleActions),
 				_defaultButtons(),
 				data,
 				translateMessages(conditions, l10nProvider),

--- a/canvas_modules/harness/test_resources/parameterDefs/action_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/action_paramDef.json
@@ -158,7 +158,7 @@
     "title_info": {
       "action_refs": [
         "increment",
-        "decrement"
+        "run_action"
       ]
     },
     "parameter_info": [
@@ -716,6 +716,14 @@
             "width": 25
           }
         }
+      },
+      {
+        "id": "run_action",
+        "label": {
+          "resource_key": "run_action"
+        },
+        "control": "button",
+        "data": {}
       }
     ],
     "group_info": [
@@ -918,7 +926,6 @@
               "disable_image_text"
             ]
           }
-
         ]
       },
       {
@@ -1010,8 +1017,6 @@
         }
       }
     }
-
-
   ],
   "dataset_metadata": [
     {
@@ -1085,13 +1090,14 @@
   "resources": {
     "increment": "Increment",
     "decrement": "Decrement",
+    "run_action": "Run",
     "dm-update": "Add Field",
-    "winter":    "Winter",
-    "summer":    "Summer",
-    "fall":      "Fall",
-    "spring":    "Spring",
-    "moon":      "Moon",
-    "meteor":    "Meteor",
+    "winter": "Winter",
+    "summer": "Summer",
+    "fall": "Fall",
+    "spring": "Spring",
+    "moon": "Moon",
+    "meteor": "Meteor",
     "weather.action.panel.label": "Weather action panel label",
     "weather.action.panel.desc": "Weather action panel description"
   }


### PR DESCRIPTION
closes #2088

Additional changes to render actions in the title editor that are not defined in group_info
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

