### PR TITLE
#2072 fix: added explicit check for react version

### DIFF
--- a/canvas_modules/common-canvas/src/common-canvas/svg-canvas-utils-external.js
+++ b/canvas_modules/common-canvas/src/common-canvas/svg-canvas-utils-external.js
@@ -30,8 +30,8 @@ export default class SvgCanvasExternal {
 		return React.isValidElement(el);
 	}
 
-	isReact18() {
-		return React.version.split(".")[0] === "18";
+	isReact18OrHigher() {
+		return Number(React.version.split(".")[0]) >= 18;
 	}
 
 	addNodeExternalObject(node, i, foreignObjects) {
@@ -55,7 +55,7 @@ export default class SvgCanvasExternal {
 
 	renderExternalObject(jsx, container) {
 		// createRoot only available in React v18
-		if (this.isReact18()) {
+		if (this.isReact18OrHigher()) {
 			if (!container.ccExtRoot) {
 				container.ccExtRoot = createRoot(container);
 			}
@@ -69,7 +69,7 @@ export default class SvgCanvasExternal {
 
 	removeExternalObject(obj, i, foreignObjects) {
 		// createRoot only available in React v18
-		if (this.isReact18()) {
+		if (this.isReact18OrHigher()) {
 			const container = foreignObjects[i];
 			if (!container.ccExtRoot) {
 				container.ccExtRoot = createRoot(container);

--- a/canvas_modules/common-canvas/src/common-canvas/svg-canvas-utils-external.js
+++ b/canvas_modules/common-canvas/src/common-canvas/svg-canvas-utils-external.js
@@ -30,6 +30,10 @@ export default class SvgCanvasExternal {
 		return React.isValidElement(el);
 	}
 
+	isReact18() {
+		return React.version.split(".")[0] === "18";
+	}
+
 	addNodeExternalObject(node, i, foreignObjects) {
 		const jsx = (
 			<node.layout.nodeExternalObject
@@ -51,7 +55,7 @@ export default class SvgCanvasExternal {
 
 	renderExternalObject(jsx, container) {
 		// createRoot only available in React v18
-		if (createRoot) {
+		if (this.isReact18()) {
 			if (!container.ccExtRoot) {
 				container.ccExtRoot = createRoot(container);
 			}
@@ -65,7 +69,7 @@ export default class SvgCanvasExternal {
 
 	removeExternalObject(obj, i, foreignObjects) {
 		// createRoot only available in React v18
-		if (createRoot) {
+		if (this.isReact18()) {
 			const container = foreignObjects[i];
 			if (!container.ccExtRoot) {
 				container.ccExtRoot = createRoot(container);


### PR DESCRIPTION
closes #2072 

The current check for `createRoot` was causing builds to fail with `ba.createRoot is not a function` when attempting to use a jsx element as an image for a node, as `createRoot` still returned a value on prior versions. This change explicitly checks the react version to make sure `createRoot` is only use if React 18 is being used, otherwise it will use `ReactDOM.render`
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

