### PR TITLE
#2189 Fixed actions image cypress test

### DIFF
--- a/canvas_modules/harness/cypress/e2e/properties/actions.cy.js
+++ b/canvas_modules/harness/cypress/e2e/properties/actions.cy.js
@@ -29,6 +29,7 @@ describe("Test of action image tooltip direction", function() {
 		cy.hoverOverActionImage("fall");
 		cy.verifyTip(null, "visible",
 			"This is a long tooltip for action image. Adding this line makes it a multi-line tooltip.", "left");
+		cy.hoverOverControl("weather-action-panel");
 
 		// Test: action image tooltip direction right
 		// ------------------------------------------
@@ -36,6 +37,7 @@ describe("Test of action image tooltip direction", function() {
 		// For "spring" image, tooltip_direction is set to "right" in paramDef
 		cy.hoverOverActionImage("spring");
 		cy.verifyTip(null, "visible", "Spring", "right");
+		cy.hoverOverControl("weather-action-panel");
 
 
 		// Test: action image tooltip direction top
@@ -44,6 +46,7 @@ describe("Test of action image tooltip direction", function() {
 		// For "summer" image, tooltip_direction is set to "top" in paramDef
 		cy.hoverOverActionImage("summer");
 		cy.verifyTip(null, "visible", "Summer", "top");
+		cy.hoverOverControl("weather-action-panel");
 
 		// Test: action image tooltip direction bottom
 		// -------------------------------------------
@@ -51,6 +54,7 @@ describe("Test of action image tooltip direction", function() {
 		// For "winter" image, tooltip_direction is set to "bottom" in paramDef
 		cy.hoverOverActionImage("winter");
 		cy.verifyTip(null, "visible", "Winter", "bottom");
+		cy.hoverOverControl("weather-action-panel");
 
 		// Test: "When tooltip_direction is not specified, default direction is bottom
 		// ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #2189 

Cypress test was failing because first `cy.hoverOverActionImage("fall");` works fine. But next `cy.hoverOverActionImage("spring");` fails. Mouse never goes over spring action image.

To fix the test, moved mouse elsewhere before calling `cy.hoverOverActionImage("spring");` .
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

