### PR TITLE
#2207 Scrollbar for WYSIWYG annotation note can not be clicked to scroll

### DIFF
--- a/canvas_modules/common-canvas/src/common-canvas/svg-canvas-d3.scss
+++ b/canvas_modules/common-canvas/src/common-canvas/svg-canvas-d3.scss
@@ -118,12 +118,6 @@ $link-highlight-color: $support-info;
 	overflow: visible;
 }
 
-.d3-foreign-object-comment-text {
-	// Don't handle events - let objects inside foreign object handle them.
-	pointer-events: none;
-	overflow: hidden;
-}
-
 // Declare our own focus highlighting for text entry.
 @mixin d3-text-entry-focus-mixin {
 	// Supress the default focus highlighting with non-carbon color and round corners.
@@ -923,7 +917,6 @@ g.bkg-col-cyan-50 {
 	word-break: break-word;
 }
 
-/* Style for comment text entry when shown in an HTML textarea control. */
 .d3-comment-text-scroll,
 .d3-comment-text-entry-scroll {
 	pointer-events: unset;
@@ -934,29 +927,10 @@ g.bkg-col-cyan-50 {
 	border-style: solid;
 	height: 100%;
 	width: 100%;
+	scrollbar-color: $layer-active-02 $layer-02;
 }
 
-.d3-comment-text-outer {
-	display: table;
-	pointer-events: none;
-	overflow: hidden;
-	width: 100%;
-	height: 100%;
-}
-
-.d3-comment-text {
-	@include d3-comment-mixin;
-	background-color: $comment-fill-color;
-	padding: $comment-text-display-border;
-	user-select: none;
-	overflow: hidden;
-	display: table-cell;
-
-	&.markdown {
-		@include d3-comment-markdown;
-	}
-}
-
+.d3-comment-text-outer,
 .d3-comment-text-entry-outer {
 	display: table;
 	pointer-events: none;
@@ -966,15 +940,28 @@ g.bkg-col-cyan-50 {
 	outline: none;
 }
 
+.d3-comment-text,
 .d3-comment-text-entry {
 	@include d3-comment-mixin;
 	padding: $comment-text-display-border;
 	border-width: $comment-border-width;
-	background-color: $field-01;
+	background-color: $comment-fill-color;
 	outline: none;
 	user-select: none;
 	overflow: hidden;
 	display: table-cell;
+
+	// Only applicable to d3-comment-text
+	&.markdown {
+		@include d3-comment-markdown;
+	}
+}
+
+.d3-comment-text {
+	cursor: default;
+}
+
+.d3-comment-text-entry {
 	cursor: text;
 }
 

--- a/canvas_modules/common-canvas/src/common-canvas/svg-canvas-utils-textarea.js
+++ b/canvas_modules/common-canvas/src/common-canvas/svg-canvas-utils-textarea.js
@@ -727,6 +727,12 @@ export default class SvgCanvasTextArea {
 		this.foreignObjectComment
 			.append("xhtml:div") // Provide a namespace when div is inside foreignObject
 			.attr("class", "d3-comment-text-entry-scroll")
+			.on("mousedown", (d3Event) => {
+				// This is triggered when the user 'mousedown's on the scrollbar. In this
+				// case, prevent propogation otherwise it causes a 'blur' event and ends
+				// the edit mode.
+				CanvasUtils.stopPropagationAndPreventDefault(d3Event);
+			})
 			.each((d, i, commentTexts) => {
 				const commentElement = d3.select(commentTexts[i]);
 				CanvasUtils.applyOutlineStyle(commentElement, d.formats); // Only apply outlineStyle format here

--- a/canvas_modules/harness/cypress/support/canvas/comments-cmds.js
+++ b/canvas_modules/harness/cypress/support/canvas/comments-cmds.js
@@ -196,7 +196,7 @@ Cypress.Commands.add("moveCommentToPosition", (commentText, canvasX, canvasY) =>
 				.then((transform) => {
 					cy.window().then((win) => {
 						cy.get(srcSelector)
-							.trigger("mousedown", "topLeft", { which: 1, view: win });
+							.trigger("mousedown", "topLeft", { which: 1, view: win, force: true });
 						cy.get("#canvas-div-0")
 							.trigger("mousemove", canvasX + transform.x, canvasY + transform.y, { view: win });
 						cy.get("#canvas-div-0")


### PR DESCRIPTION
Fixes: #2207 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

