### PR TITLE
#2300 Readonly table row should not have delete icon

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/abstract-table.jsx
@@ -744,7 +744,7 @@ export default class AbstractTable extends React.Component {
 					const cell = this.buildChildItem(propertyName, rowIndex, tableState);
 					columns.push(cell);
 				}
-				if (this.props.control.rowSelection === ROW_SELECTION.SINGLE) {
+				if (this.props.control.rowSelection === ROW_SELECTION.SINGLE && !this.isReadonlyTable()) {
 					const toolTip = PropertyUtils.formatMessage(this.reactIntl, MESSAGE_KEYS.TABLE_DELETEICON_TOOLTIP);
 					const tooltipId = "tooltip-delete-row";
 					const deleteOption = (


### PR DESCRIPTION
Fixes: #2300 

![Screenshot 2025-01-14 at 2 47 12 PM](https://github.com/user-attachments/assets/722574c9-639a-4a6c-ba0a-2883a005c1e1)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

