### PR TITLE
#3979 Improve TypeScript definitions of EditActionData

### DIFF
--- a/canvas_modules/common-canvas/types/common-canvas.ts
+++ b/canvas_modules/common-canvas/types/common-canvas.ts
@@ -2812,8 +2812,8 @@ export type CtxMenuHandlerSource =
     };
  
 export type EditActionTargetObject = CanvasNode | (CanvasNodeLink & {
-  srcObj?: unknown;
-  trgNode?: unknown;
+  srcObj?: Record<string, unknown>;
+  trgNode?: Record<string, unknown>;
 });   
 export interface EditActionNode {
   id?: string;

--- a/canvas_modules/common-canvas/types/common-canvas.ts
+++ b/canvas_modules/common-canvas/types/common-canvas.ts
@@ -2810,24 +2810,29 @@ export type CtxMenuHandlerSource =
       selectedObjectIds: string[];
       mousePos: { x: string; y: string };
     };
-
+ 
+export type EditActionTargetObject = CanvasNode | (CanvasNodeLink & {
+  srcObj?: unknown;
+  trgNode?: unknown;
+});   
+export interface EditActionNode {
+  id?: string;
+  portId?: string;
+}    
 export interface EditActionData {
-  editType:
-    | "createComment"
-    | "createNode"
-    | "moveObjects"
-    | "linkNodes"
-    | "linkComment"
-    | "resizeObjects"
-    | "editComment"
-    | "expandSuperNodeInPlace"
-    | "displaySubPipeline"
-    | "displayPreviousPipeline"
-    | string;
+  editType: "createComment" | "createNode" | "moveObjects" | "linkNodes" | "deleteSelectedObjects" | "deleteLink" | "createAutoNode" | "setNodeLabelEditingMode" | "setZoom" | "linkComment" | "resizeObjects" | "editComment" | "expandSuperNodeInPlace" | "displaySubPipeline" | "displayPreviousPipeline" | string;
   editSource: "contextmenu" | "toolbar" | "keyboard" | "canvas" | "api" | "controller";
   selectedObjects: Record<string, unknown>[];
-  /** @deprecated */
   selectedObjectIds: string[];
+  type?: "nodeLink" | "node" | string;
+  linkIds?: string[];
+  linkType?: string;
+  nodes?: EditActionNode[];
+  targetNodes?: EditActionNode[];
+  newNode?: CanvasNode;
+  targetObject?: EditActionTargetObject;
+  newLink?: CanvasNodeLink;
+  sourceNode?: CanvasNode;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
#3979 Improve TypeScript definitions of EditActionData 
Fix for [#3979](https://github.ibm.com/NGP-TWC/wdp-abstract-canvas/issues/3979)
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

