### PR TITLE
#2483 Cannot use CanvasController when it is exported only as a type

### DIFF
--- a/canvas_modules/common-canvas/types/common-canvas.ts
+++ b/canvas_modules/common-canvas/types/common-canvas.ts
@@ -113,6 +113,8 @@ export type {
   CanvasAssociationLink
 } from  "@elyra/pipeline-schemas/types";
 
+export { CanvasController } from "./canvas-controller";
+
 export type {
   InternalAction,
   PipelineId,
@@ -149,7 +151,6 @@ export type {
   ContextMenuDivider,
   ContextMenuItem,
   CommentFormat,
-  CanvasController,
 } from "./canvas-controller";
 
 // These positions enumerations can be used to position elements relative to


### PR DESCRIPTION
Fixes: #2483 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

