### PR TITLE
#2541 Improve error message when customControls are forgotten

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/custom-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/custom-test.js
@@ -19,6 +19,11 @@ import tableUtilsRTL from "./../../_utils_/table-utilsRTL";
 import customControlParamDef from "../../test_resources/paramDefs/custom-ctrl-op_paramDef.json";
 import { expect } from "chai";
 import { fireEvent } from "@testing-library/react";
+import { render } from "../../_utils_/mount-utils.js";
+import { IntlProvider } from "react-intl";
+import React from "react";
+import { CommonProperties } from "../../../src/common-properties";
+import sinon from "sinon";
 
 describe("custom control renders correctly", () => {
 	let wrapper;
@@ -100,6 +105,34 @@ describe("custom control renders correctly", () => {
 		dropdownWrapper = container.querySelector("div[data-id='properties-colors']");
 		dropdownList = dropdownWrapper.querySelectorAll("li.cds--list-box__menu-item");
 		expect(dropdownList).to.be.length(2); // should have 2 items. Custom toggle control updates the values
+	});
+
+	it("When customControls is not defined, proper error message should be displayed", () => {
+		const propertiesInfo = {
+			parameterDef: customControlParamDef
+		};
+		const applyPropertyChanges = sinon.spy();
+		const closePropertiesDialog = sinon.spy();
+		const propertyIconHandler = sinon.spy();
+		const callbacks = {
+			applyPropertyChanges: applyPropertyChanges,
+			closePropertiesDialog: closePropertiesDialog,
+			propertyIconHandler: propertyIconHandler
+		};
+
+		// Common-properties is called without customControls
+		wrapper = render(
+			<IntlProvider key="IntlProvider2" locale="en">
+				<CommonProperties
+					propertiesInfo={propertiesInfo}
+					callbacks={callbacks}
+				/>
+			</IntlProvider>
+		);
+		const { container } = wrapper;
+		const customToggleControl = container.querySelector("div[data-id='properties-ctrl-custom_toggle']").querySelector(".properties-custom-ctrl");
+		// Verify the error message
+		expect(customToggleControl.textContent).to.equal("Custom control not found: harness-custom-toggle-control");
 	});
 });
 

--- a/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/properties-main/properties-main.jsx
@@ -54,7 +54,9 @@ class PropertiesMain extends React.Component {
 		if (this.props.propertiesInfo.initialEditorSize) {
 			this.propertiesController.setEditorSize(this.props.propertiesInfo.initialEditorSize);
 		}
-		this.propertiesController.setCustomControls(props.customControls);
+		if (typeof props.customControls !== "undefined") {
+			this.propertiesController.setCustomControls(props.customControls);
+		}
 		this.propertiesController.setCustomActions(props.customActions);
 		this.propertiesController.setConditionOps(props.customConditionOps);
 		this.propertiesController.setLight(props.light);
@@ -119,7 +121,9 @@ class PropertiesMain extends React.Component {
 					this.currentParameters = this.propertiesController.getPropertyValues();
 				}
 				this.propertiesController.setAppData(newProps.propertiesInfo.appData);
-				this.propertiesController.setCustomControls(newProps.customControls);
+				if (typeof newProps.customControls !== "undefined") {
+					this.propertiesController.setCustomControls(newProps.customControls);
+				}
 				this.propertiesController.setCustomActions(newProps.customActions);
 				this.propertiesController.setConditionOps(newProps.customConditionOps);
 				this.previousErrorMessages = {};


### PR DESCRIPTION
Fixes: #2541 

When `customControls` are undefined, following error will be shown -
![Screenshot 2025-05-13 at 2 49 10 PM](https://github.com/user-attachments/assets/82ce4fc6-b12b-4984-ad13-85ac0bc26921)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

