### PR TITLE
#2666 Tabbing to a new group of nodes does not call zoomToReveal when…

### DIFF
--- a/canvas_modules/common-canvas/src/common-canvas/common-canvas-utils.js
+++ b/canvas_modules/common-canvas/src/common-canvas/common-canvas-utils.js
@@ -264,6 +264,14 @@ export default class CanvasUtils {
 		evnt.preventDefault();
 	}
 
+	// Returns true if evt passed in is a KeyboardEvent. If evt originates from
+	// React it will be a SyntheticBaseEvent which will have a nativeEvent field.
+	static isKeyboardEvent(evt) {
+		return evt &&
+			(evt instanceof KeyboardEvent ||
+				(evt.nativeEvent && evt.nativeEvent instanceof KeyboardEvent));
+	}
+
 	// Returns a snap-to-grid value for the value passed in based on a grid
 	// size defined by the gridSize passed in.
 	static snapToGrid(value, gridSize) {

--- a/canvas_modules/common-canvas/src/common-canvas/svg-canvas-renderer.js
+++ b/canvas_modules/common-canvas/src/common-canvas/svg-canvas-renderer.js
@@ -6434,8 +6434,9 @@ export default class SVGCanvasRenderer {
 			// appears in the viewport. If the event was a MouseEvent we don't zoom to reveal
 			// because it interferes with double-click events (also it's not necessary becasue
 			// the object will be at least partially visible in the view port for it to be clicked).
-			if (evt instanceof KeyboardEvent) {
+			if (CanvasUtils.isKeyboardEvent(evt)) {
 				const zoom = this.canvasController.getZoomToReveal([obj.id]);
+
 				if (zoom) {
 					this.zoomTo(zoom);
 				}


### PR DESCRIPTION
… the group is outside of the viewport

Fixes: #2666 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

