### PR TITLE
#2676 Fixed Bug: Visible condition is not working properly inside subpanel for custom controls

### DIFF
--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/structurelisteditor_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/structurelisteditor_paramDef.json
@@ -826,6 +826,10 @@
 					"id": "fieldScale",
 					"type": "number",
 					"default": 2
+				},
+				{
+					"id": "custom_toggle",
+					"type": "boolean"
 				}
 			]
 		}
@@ -1005,7 +1009,7 @@
 					"default": "Test visible cell condition in subpanel"
 				},
 				"description": {
-					"default": "Set Field Type: DECIMAL to see Precision and Scale fields",
+					"default": "Set Field Type: DECIMAL to see Precision, Scale, Custom Toggle fields",
 					"placement": "on_panel"
 				}
 			}
@@ -1882,6 +1886,16 @@
 						"label": {
 							"default": "Scale"
 						}
+					},
+					{
+						"parameter_ref": "custom_toggle",
+						"label": {
+							"default": "Custom Toggle"
+						},
+						"width": 20,
+						"edit_style": "subpanel",
+						"control": "custom",
+						"custom_control_id": "harness-custom-toggle-control"
 					}
 				]
 			}
@@ -2359,6 +2373,7 @@
     {
 			"visible": {
 				"parameter_refs": [
+					"subpanelEditingTable[3]",
 					"subpanelEditingTable[2]",
 					"subpanelEditingTable[1]"
 				],

--- a/canvas_modules/common-canvas/src/common-properties/controls/control-factory.js
+++ b/canvas_modules/common-canvas/src/common-properties/controls/control-factory.js
@@ -61,31 +61,31 @@ import { has, get, isUndefined } from "lodash";
 */
 const accessibleControls = [
 	ControlType.CHECKBOXSET,
-	ControlType.HIDDEN,
+	ControlType.CODE,
 	ControlType.DATEFIELD,
 	ControlType.DATEPICKER,
 	ControlType.DATEPICKERRANGE,
+	ControlType.EXPRESSION,
+	ControlType.HIDDEN,
+	ControlType.LIST,
+	ControlType.MULTISELECT,
 	ControlType.NUMBERFIELD,
-	ControlType.SPINNER,
+	ControlType.ONEOFSELECT,
 	ControlType.PASSWORDFIELD,
+	ControlType.READONLY,
+	ControlType.READONLYTABLE,
+	ControlType.SELECTCOLUMN,
+	ControlType.SELECTCOLUMNS,
+	ControlType.SELECTSCHEMA,
+	ControlType.SLIDER,
+	ControlType.SOMEOFSELECT,
+	ControlType.SPINNER,
 	ControlType.TEXTAREA,
 	ControlType.TEXTFIELD,
 	ControlType.TIMEFIELD,
-	ControlType.TOGGLETEXT,
-	ControlType.LIST,
-	ControlType.TOGGLE,
-	ControlType.SOMEOFSELECT,
-	ControlType.SELECTCOLUMNS,
-	ControlType.READONLY,
-	ControlType.READONLYTABLE,
 	ControlType.TIMESTAMP,
-	ControlType.EXPRESSION,
-	ControlType.CODE,
-	ControlType.ONEOFSELECT,
-	ControlType.MULTISELECT,
-	ControlType.SELECTSCHEMA,
-	ControlType.SELECTCOLUMN,
-	ControlType.SLIDER
+	ControlType.TOGGLE,
+	ControlType.TOGGLETEXT
 ];
 
 const tableControls = [
@@ -131,14 +131,12 @@ export default class ControlFactory {
 		if (accessibleControls.includes(control.controlType)) {
 			return controlObj;
 		}
-		const hidden = this.controller.getControlState(propertyId) === STATES.HIDDEN;
-		if (hidden) {
-			return null; // Do not render hidden controls
-		}
 		// When control-item displays other controls, add padding on control-item
+		// Don't add "hide" class for subpanel properties because "hide" class isn't removed after a property becomes visible in the already opened subpanel
+		const hidden = this.controller.getControlState(propertyId) === STATES.HIDDEN && control.editStyle !== EditStyle.SUBPANEL;
 		return (
 			<div key={"properties-ctrl-" + control.name} data-id={"properties-ctrl-" + control.name}
-				className={classNames("properties-ctrl-wrapper", className)}
+				className={classNames("properties-ctrl-wrapper", { "hide": hidden }, className)}
 			>
 				<ControlItem
 					key={"ctrl-item-" + control.name}

--- a/canvas_modules/harness/test_resources/parameterDefs/structurelisteditor_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/structurelisteditor_paramDef.json
@@ -893,6 +893,10 @@
 					"id": "fieldScale",
 					"type": "number",
 					"default": 2
+				},
+				{
+					"id": "custom_toggle",
+					"type": "boolean"
 				}
 			]
 		}
@@ -1084,7 +1088,7 @@
 					"default": "Test visible cell condition in subpanel"
 				},
 				"description": {
-					"default": "Set Field Type: DECIMAL to see Precision and Scale fields",
+					"default": "Set Field Type: DECIMAL to see Precision, Scale, Custom Toggle fields",
 					"placement": "on_panel"
 				}
 			}
@@ -2031,6 +2035,16 @@
 						"label": {
 							"default": "Scale"
 						}
+					},
+					{
+						"parameter_ref": "custom_toggle",
+						"label": {
+							"default": "Custom Toggle"
+						},
+						"width": 20,
+						"edit_style": "subpanel",
+						"control": "custom",
+						"custom_control_id": "harness-custom-toggle-control"
 					}
 				]
 			}
@@ -2629,6 +2643,7 @@
     {
 			"visible": {
 				"parameter_refs": [
+					"subpanelEditingTable[3]",
 					"subpanelEditingTable[2]",
 					"subpanelEditingTable[1]"
 				],


### PR DESCRIPTION
Fixes: #2676 

Added custom control column in this table in `structurelisteditor_paramDef.json -> Conditions -> Test visible cell condition in subpanel` -

<img width="682" height="292" alt="Screenshot 2025-07-28 at 2 38 50 PM" src="https://github.com/user-attachments/assets/01070917-204b-47fe-93dd-8b113faed300" />

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

