### PR TITLE
#2814 Fixed - All Expression controls show red caret with error message

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.jsx
@@ -224,7 +224,7 @@ class ExpressionControl extends React.Component {
 			{ tag: tags.meta, class: "cm-meta" }
 		]);
 
-		const linterExtension = linter(jsonParseLinter());
+		const linterExtension = this.props.control.language === "json" ? linter(jsonParseLinter()) : [];
 
 		this.editor = new EditorView({
 			doc: this.props.value,


### PR DESCRIPTION
Fixes #2814 

`linterExtension` was only parsing JSON syntax. And this linter throws error for other supported languages like "CLEM", "text/x-hive". So we don't see red caret for JSON code but we saw it in every other language.



Bug fixed  - 
<img width="327" height="756" alt="Screenshot 2025-11-19 at 2 53 42 PM" src="https://github.com/user-attachments/assets/c628deb0-c2f1-49ec-a6cb-efdbd0b67902" />

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

