### PR TITLE
#2827 Always show Action button on the next line

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.jsx
@@ -102,7 +102,7 @@ class ControlItem extends React.Component {
 		const className = classNames(
 			"properties-control-item",
 			{ "hide": hidden },
-			{ "properties-ci-action-item": action && this.props.control.action.actionType === ActionType.IMAGE }
+			{ "properties-ci-action-item image": action && this.props.control.action.actionType === ActionType.IMAGE }
 		);
 
 		/*

--- a/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/control-item/control-item.scss
@@ -38,8 +38,10 @@
 }
 
 .properties-ci-action-item {
-	display: flex;
-	justify-content: space-between;
+	&.image {
+		display: flex;
+		justify-content: space-between;
+	}
 
 	.properties-ci-content-container {
 		flex-grow: 1;


### PR DESCRIPTION
Fixes #2827 

**Before -** 
Action button used to show next to inaccessible controls. This is inconsistent as the action button shows up on next line for accessible controls.
<img width="486" height="92" alt="Screenshot 2025-12-05 at 12 30 16 PM" src="https://github.com/user-attachments/assets/8af77036-dad1-4045-9d5c-466ebcfcf581" />

<img width="322" height="153" alt="Screenshot 2025-12-05 at 12 43 45 PM" src="https://github.com/user-attachments/assets/15182909-461b-43e0-b8ea-96d6721eba71" />


**Now -** 
Action button shows up on next line for both accessible and inaccessible controls.

<img width="486" height="133" alt="Screenshot 2025-12-05 at 12 30 21 PM" src="https://github.com/user-attachments/assets/07114d2d-34ce-489e-ade8-971620192bc8" />

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

