### PR TITLE
fix: display close button below the toolbar when enableRightFlyoutUnderToolbar

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
+++ b/canvas_modules/common-canvas/src/common-properties/components/title-editor/title-editor.scss
@@ -175,6 +175,11 @@
 	padding: 0;
 }
 
+// When right flyout is under toolbar, position close button below the toolbar
+.right-flyout-panel.under-toolbar .properties-title-with-heading > .properties-close-button {
+	top: calc(carbon.$spacing-08 + carbon.$spacing-03); // toolbar height (32px) + original spacing (8px)
+}
+
 
 .properties-title-editor {
 	.tooltip-container {
@@ -182,4 +187,5 @@
 		cursor: pointer;
 	}
 }
+
 


### PR DESCRIPTION
fixes: https://github.com/elyra-ai/canvas/issues/2922

<img width="1810" height="922" alt="image" src="https://github.com/user-attachments/assets/bfdbaf4a-e29e-403b-b151-8bceb851a6e2" />

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

