### PR TITLE
#2995 Carbon React icons occupy too much space in Elyra Canvas module

### DIFF
--- a/canvas_modules/common-canvas/package.json
+++ b/canvas_modules/common-canvas/package.json
@@ -89,6 +89,7 @@
     "autoprefixer": "9.8.8",
     "babel-jest": "26.3.0",
     "babel-plugin-lodash": "3.3.4",
+    "babel-plugin-transform-imports": "^2.0.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.24",
     "chai": "4.2.0",
     "classnames": "2.5.1",

--- a/canvas_modules/common-canvas/rollup.config.js
+++ b/canvas_modules/common-canvas/rollup.config.js
@@ -77,7 +77,14 @@ export default {
 				"@babel/plugin-proposal-class-properties",
 				"@babel/plugin-transform-runtime",
 				"@babel/plugin-proposal-export-default-from",
-				["transform-react-remove-prop-types", { removeImport: true }]
+				["transform-react-remove-prop-types", { removeImport: true }],
+				["transform-imports", {
+					"@carbon/react/icons": {
+						"transform": "@carbon/icons-react/lib/${member}",
+						"preventFullImport": true,
+						"skipDefaultConversion": true
+					}
+				}]
 			]
 		}),
 		terser(),


### PR DESCRIPTION
FIxes: #2995 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

