### PR TITLE
#3073 Focus is does not return to parent object after editing a node …

### DIFF
--- a/canvas_modules/common-canvas/src/common-canvas/svg-canvas-renderer.js
+++ b/canvas_modules/common-canvas/src/common-canvas/svg-canvas-renderer.js
@@ -4724,20 +4724,26 @@ export default class SVGCanvasRenderer {
 	}
 
 	displayLinksSubset(selection, linksArray) {
-		selection
-			.data(linksArray, (link) => link.id)
-			.join(
-				(enter) => this.createLinks(enter)
-			)
-			.attr("class", (d) => this.getLinkGroupClass(d))
-			.attr("tabindex", -1)
-			.attr("style", (d) => this.getLinkGrpStyle(d))
-			.attr("data-selected", (d) => (this.activePipeline.isSelected(d.id) ? true : null))
-			.attr("aria-label", (d) => CanvasUtils.getLinkAriaLabel(d, this.canvasController.labelUtil))
-			.attr("aria-roledescription", this.canvasController.labelUtil.getLabel("link.ariaRoleDescription"))
-			.call((joinedLinkGrps) => {
-				this.updateLinks(joinedLinkGrps, linksArray);
-			});
+		// The D3 join operation can sometimes cause focus to be lost from any
+		// currently focused object involved in the join (even if no new objects
+		// have been created or if no objects are removed) so we preserve and
+		// reinstate the focus after this operation is complete.
+		this.preserveFocus(() => {
+			selection
+				.data(linksArray, (link) => link.id)
+				.join(
+					(enter) => this.createLinks(enter)
+				)
+				.attr("class", (d) => this.getLinkGroupClass(d))
+				.attr("tabindex", -1)
+				.attr("style", (d) => this.getLinkGrpStyle(d))
+				.attr("data-selected", (d) => (this.activePipeline.isSelected(d.id) ? true : null))
+				.attr("aria-label", (d) => CanvasUtils.getLinkAriaLabel(d, this.canvasController.labelUtil))
+				.attr("aria-roledescription", this.canvasController.labelUtil.getLabel("link.ariaRoleDescription"))
+				.call((joinedLinkGrps) => {
+					this.updateLinks(joinedLinkGrps, linksArray);
+				});
+		});
 	}
 
 	// Creates all newly created links specified in the enter selection.

--- a/canvas_modules/common-canvas/src/common-canvas/svg-canvas-utils-textarea.js
+++ b/canvas_modules/common-canvas/src/common-canvas/svg-canvas-utils-textarea.js
@@ -88,7 +88,7 @@ export default class SvgCanvasTextArea {
 	displayCommentTextArea(d, parentDomObj) {
 		this.editingTextData = {
 			id: d.id,
-			comment: d,
+			focusReturn: d,
 			text: d.content,
 			singleLine: false,
 			maxCharacters: null,
@@ -465,6 +465,7 @@ export default class SvgCanvasTextArea {
 
 		this.editingTextData = {
 			id: node.id,
+			focusReturn: node,
 			text: node.label,
 			singleLine: node.layout.labelSingleLine,
 			maxCharacters: node.layout.labelMaxCharacters,
@@ -538,6 +539,7 @@ export default class SvgCanvasTextArea {
 
 		this.editingTextData = {
 			id: dec.id,
+			focusReturn: obj,
 			text: dec.label,
 			singleLine: dec.label_single_line || false,
 			maxCharacters: dec.label_max_characters || null,
@@ -707,10 +709,10 @@ export default class SvgCanvasTextArea {
 			// Tidy up
 			this.foreignObjectComment.remove();
 			this.foreignObjectComment = null;
-			this.canvasController.setFocusObject(data.comment, null, true);
 		}
 		this.editingText = false;
 		this.editingTextId = "";
+		this.canvasController.setFocusObject(data.focusReturn, null, true);
 	}
 
 	// Returns true if one of the keys that are allowed in the text area, when


### PR DESCRIPTION
…label or a label decoration on a node or link

Fixes: #3073 

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

