### PR TITLE
#4380 Clamp toolbar sub-menu height to prevent overflow of containing div

### DIFF
--- a/canvas_modules/common-canvas/src/toolbar/toolbar-sub-utils.js
+++ b/canvas_modules/common-canvas/src/toolbar/toolbar-sub-utils.js
@@ -49,6 +49,16 @@ export function adjustSubAreaPosition(subAreaRef, containingDivId, expandDirecti
 				: -(outsideBottom);
 
 			subAreaRef.style.top = newTop + "px";
+
+			// Clamp the menu height so it never overflows the containing div.
+			// This is needed when zoomed in far: neither above nor below the toolbar
+			// may have enough room to show the full menu.
+			const menuTop = actionItemRect.bottom + newTop;
+			const availableHeight = containingDivRect.bottom - Math.max(menuTop, containingDivRect.top);
+			if (availableHeight < subAreaRect.height) {
+				subAreaRef.style.maxHeight = availableHeight + "px";
+				subAreaRef.style.overflowY = "auto";
+			}
 		}
 
 		if (outsideRight > 0) {

--- a/canvas_modules/common-canvas/src/toolbar/toolbar-sub-utils.js
+++ b/canvas_modules/common-canvas/src/toolbar/toolbar-sub-utils.js
@@ -49,16 +49,6 @@ export function adjustSubAreaPosition(subAreaRef, containingDivId, expandDirecti
 				: -(outsideBottom);
 
 			subAreaRef.style.top = newTop + "px";
-
-			// Clamp the menu height so it never overflows the containing div.
-			// This is needed when zoomed in far: neither above nor below the toolbar
-			// may have enough room to show the full menu.
-			const menuTop = actionItemRect.bottom + newTop;
-			const availableHeight = containingDivRect.bottom - Math.max(menuTop, containingDivRect.top);
-			if (availableHeight < subAreaRect.height) {
-				subAreaRef.style.maxHeight = availableHeight + "px";
-				subAreaRef.style.overflowY = "auto";
-			}
 		}
 
 		if (outsideRight > 0) {

--- a/canvas_modules/harness/package-lock.json
+++ b/canvas_modules/harness/package-lock.json
@@ -3850,7 +3850,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },

--- a/canvas_modules/harness/package-lock.json
+++ b/canvas_modules/harness/package-lock.json
@@ -3850,6 +3850,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },


### PR DESCRIPTION
Clamp the sub-area menu height so it never overflows the containing div when zoomed in far, where neither above nor below the toolbar has enough room to show the full menu.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.