### PR TITLE
#3228 Add CSP header to harness and remove empty style prop

### DIFF
--- a/canvas_modules/harness/lib/application.js
+++ b/canvas_modules/harness/lib/application.js
@@ -52,6 +52,27 @@ function create(callback) {
 	app.set("trust proxy", 1);
 	app.use(compression());
 
+	// Content Security Policy — 'unsafe-inline' is included in style-src and
+	// script-src because the canvas relies on React inline styles and the HMR
+	// dev toolchain injects inline scripts. Remove 'unsafe-inline' from these
+	// directives to surface violations during hardening work.
+	app.use((_req, res, next) => {
+		res.setHeader(
+			"Content-Security-Policy",
+			[
+				"default-src 'self'",
+				"script-src 'self' 'unsafe-inline'",
+				"style-src 'self' 'unsafe-inline'",
+				// "style-src 'self'",
+				"font-src 'self' data:",
+				"img-src 'self' data:",
+				"connect-src 'self'",
+				"worker-src blob:"
+			].join("; ")
+		);
+		next();
+	});
+
 	app.use(session({
 		secret: APP_SESSION_KEY,
 		resave: false,


### PR DESCRIPTION
Fixes: #3228

Add a Content-Security-Policy header to the harness Express server that omits 'unsafe-inline' from style-src and script-src by default. This makes CSP violations visible as browser console errors during development, making it easy to identify inline-style usage that would be blocked in a strict CSP environment.

Also remove the empty style={{}} prop from the virtualized-table row wrapper div. React renders style={{}} as style="" in the DOM, which produces a CSP violation for the SHA-256 hash of an empty string. The prop was a stale react-virtualized requirement; the wrapper div only needs to exist for the onDoubleClick handler.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

