### PR TITLE
#3236 Prepare for unsafe-inline - color-picker

### DIFF
--- a/canvas_modules/common-canvas/src/color-picker/color-picker.jsx
+++ b/canvas_modules/common-canvas/src/color-picker/color-picker.jsx
@@ -124,21 +124,20 @@ class ColorPicker extends React.Component {
 
 				return (<div key={"key" + i} ref={this.refss[i]} tabIndex={"-1"}
 					data-color={c}
-					style={{ backgroundColor: c }}
+					style={{ "--color-picker-swatch-color": c }}
 					className={className}
 				/>);
 			});
 
 			const rowCount = Math.ceil(this.totalColors / this.colorsPerRow);
 
-			const style = {
-				width: (this.colorsPerRow * COLOR_DIM_PLUS_PAD) + COLOR_PADDING,
-				height: (rowCount * COLOR_DIM_PLUS_PAD) + COLOR_PADDING,
-				paddingBottom: "4px"
+			const containerStyle = {
+				"--color-picker-width": (this.colorsPerRow * COLOR_DIM_PLUS_PAD) + COLOR_PADDING + "px",
+				"--color-picker-height": (rowCount * COLOR_DIM_PLUS_PAD) + COLOR_PADDING + "px"
 			};
 
 			return (
-				<div className="color-picker" style={style} tabIndex={"-1"} onClick={this.onClick} onKeyDown={this.onKeyDown}>
+				<div className="color-picker" style={containerStyle} tabIndex={"-1"} onClick={this.onClick} onKeyDown={this.onKeyDown}>
 					{colorDivs}
 				</div>
 			);

--- a/canvas_modules/common-canvas/src/color-picker/color-picker.scss
+++ b/canvas_modules/common-canvas/src/color-picker/color-picker.scss
@@ -17,14 +17,18 @@
 @use "../carbon.scss";
 
 .color-picker {
-	width: 156px;
-	height: 55px;
+	// width and height are set via CSS custom properties from color-picker.jsx.
+	width: var(--color-picker-width, 156px);
+	height: var(--color-picker-height, 55px);
 	display: flex;
 	flex-wrap: wrap;
+	padding-bottom: 4px;
 
 	.color-picker-item {
 		width: 20px;
 		height: 20px;
+		// background-color is set via CSS custom property from color-picker.jsx.
+		background-color: var(--color-picker-swatch-color);
 		margin: 5px 0 0 5px;
 		cursor: pointer;
 		border: carbon.$border-subtle-02 1px solid;


### PR DESCRIPTION
Fixes: #3236 

color-picker.jsx used style={{ backgroundColor: c }} on each swatch and style={{ width, height, paddingBottom }} on the container, producing inline style attributes blocked by style-src CSP without unsafe-inline.

Replace swatch backgroundColor with --color-picker-swatch-color and container dimensions with --color-picker-width/height, all consumed in color-picker.scss. Move the constant paddingBottom value to SCSS.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

