### PR TITLE
#3238 Prepare for unsafe-inline - floating toolbar & context menu

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-canvas/common-canvas-text-toolbar-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-canvas/common-canvas-text-toolbar-test.js
@@ -64,15 +64,15 @@ describe("Common Canvas Text Toolbar renders correctly", () => {
 		canvasController.openTextToolbar(100, 200, [], MARKDOWN, () => { /**/ });
 
 		await waitFor(() => {
-			expect(container.querySelectorAll(".text-toolbar")[0].style.left).to.equal("100px");
-			expect(container.querySelectorAll(".text-toolbar")[0].style.top).to.equal("200px");
+			expect(container.querySelectorAll(".text-toolbar")[0].style.getPropertyValue("--cc-text-toolbar-left")).to.equal("100px");
+			expect(container.querySelectorAll(".text-toolbar")[0].style.getPropertyValue("--cc-text-toolbar-top")).to.equal("200px");
 		});
 
 		canvasController.moveTextToolbar(150, 250);
 
 		await waitFor(() => {
-			expect(container.querySelectorAll(".text-toolbar")[0].style.left).to.equal("150px");
-			expect(container.querySelectorAll(".text-toolbar")[0].style.top).to.equal("250px");
+			expect(container.querySelectorAll(".text-toolbar")[0].style.getPropertyValue("--cc-text-toolbar-left")).to.equal("150px");
+			expect(container.querySelectorAll(".text-toolbar")[0].style.getPropertyValue("--cc-text-toolbar-top")).to.equal("250px");
 		});
 	});
 

--- a/canvas_modules/common-canvas/__tests__/context-menu/common-context-menu-test.js
+++ b/canvas_modules/common-canvas/__tests__/context-menu/common-context-menu-test.js
@@ -143,7 +143,7 @@ describe("CommonContextMenu renders correctly", () => {
 		const style = subMenuItem.style;
 
 		// If left property is negative, the submenu is on the left of the main menu.
-		expect(style.left).to.equal("-160px");
+		expect(style.getPropertyValue("--context-submenu-left")).to.equal("-160px");
 	});
 });
 

--- a/canvas_modules/common-canvas/src/common-canvas/cc-context-toolbar.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/cc-context-toolbar.jsx
@@ -42,6 +42,16 @@ class CommonCanvasContextToolbar extends React.Component {
 		this.toolbarActionHandler = this.toolbarActionHandler.bind(this);
 		this.colorClicked = this.colorClicked.bind(this);
 		this.closeContextToolbar = this.closeContextToolbar.bind(this);
+
+		this.toolbarDivRef = React.createRef();
+	}
+
+	componentDidMount() {
+		this.applyToolbarPosition();
+	}
+
+	componentDidUpdate() {
+		this.applyToolbarPosition();
 	}
 
 	onMouseLeave(evt) {
@@ -125,6 +135,34 @@ class CommonCanvasContextToolbar extends React.Component {
 		// work correctly with different browser magnifications.
 		const reduction = overflowMenuItems.length > 0 ? 5 : 0;
 		return buttonsWidth + dividersWidth - reduction;
+	}
+
+	/** Sets CSS custom properties for toolbar position and width on the DOM node. */
+	applyToolbarPosition() {
+		if (!this.toolbarDivRef.current) {
+			return;
+		}
+		const el = this.toolbarDivRef.current;
+		const pos = this.props.contextSource ? this.props.contextSource.cmPos || { x: 0, y: 0 } : { x: 0, y: 0 };
+		const toolbarItems = this.props.contextMenuDef
+			? this.props.contextMenuDef.filter((cmItem) => cmItem.toolbarItem)
+			: [];
+		let overflowMenuItems = this.props.contextMenuDef
+			? this.props.contextMenuDef.filter((cmItem) => !cmItem.toolbarItem)
+			: [];
+		overflowMenuItems = this.removeUnnecessaryDividers(overflowMenuItems);
+		const toolbarWidth = this.getContextToolbarWidth(toolbarItems, overflowMenuItems);
+
+		let x = this.shouldCenterJustifyToolbar()
+			? pos.x - (toolbarWidth / 2)
+			: pos.x - toolbarWidth;
+		let y = pos.y - ICON_SIZE_PLUS_GAP;
+
+		({ x, y } = this.adjustPosToFit(x, y, toolbarWidth, ICON_SIZE_PLUS_GAP));
+
+		el.style.setProperty("--cc-ctx-toolbar-left", x + "px");
+		el.style.setProperty("--cc-ctx-toolbar-top", y + "px");
+		el.style.setProperty("--cc-ctx-toolbar-width", toolbarWidth + "px");
 	}
 
 	// Removes leading and trailing dividers from the items array and any
@@ -231,26 +269,14 @@ class CommonCanvasContextToolbar extends React.Component {
 			let overflowMenuItems = this.props.contextMenuDef.filter((cmItem) => !cmItem.toolbarItem);
 			overflowMenuItems = this.removeUnnecessaryDividers(overflowMenuItems);
 			const toolbarConfig = this.getToolbarConfig({ toolbarItems, overflowMenuItems });
-			const toolbarWidth = this.getContextToolbarWidth(toolbarItems, overflowMenuItems);
-
-			// Note: cmPos is already adjusted as a starting point for the context
-			// toolbar position by a calculation in svg-canvas-renderer.js.
-			const pos = this.props.contextSource.cmPos || { x: 0, y: 0 };
-			let x = this.shouldCenterJustifyToolbar()
-				? pos.x - (toolbarWidth / 2)
-				: pos.x - toolbarWidth;
-			let y = pos.y - ICON_SIZE_PLUS_GAP;
-
-			// Make sure the context toolbar is fully inside the viewport.
-			({ x, y } = this.adjustPosToFit(x, y, toolbarWidth, ICON_SIZE_PLUS_GAP));
 
 			// Only set initial focus if context toolbar was opened via keyboard
 			const setInitialFocus = this.props.contextSource.cause === CAUSE_KEYBOARD;
 
 			contextToolbar = (
 				<div
+					ref={this.toolbarDivRef}
 					className={"context-toolbar floating-toolbar"}
-					style={{ left: x, top: y, width: toolbarWidth }}
 					onMouseEnter={this.onMouseEnter}
 					onMouseLeave={this.onMouseLeave}
 				>

--- a/canvas_modules/common-canvas/src/common-canvas/cc-context-toolbar.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/cc-context-toolbar.jsx
@@ -142,7 +142,11 @@ class CommonCanvasContextToolbar extends React.Component {
 		if (!this.toolbarDivRef.current) {
 			return;
 		}
+
 		const el = this.toolbarDivRef.current;
+
+		// Note: cmPos is already adjusted as a starting point for the context
+		// toolbar position by a calculation in svg-canvas-renderer.js.
 		const pos = this.props.contextSource ? this.props.contextSource.cmPos || { x: 0, y: 0 } : { x: 0, y: 0 };
 		const toolbarItems = this.props.contextMenuDef
 			? this.props.contextMenuDef.filter((cmItem) => cmItem.toolbarItem)
@@ -158,6 +162,7 @@ class CommonCanvasContextToolbar extends React.Component {
 			: pos.x - toolbarWidth;
 		let y = pos.y - ICON_SIZE_PLUS_GAP;
 
+		// Make sure the context toolbar is fully inside the viewport.
 		({ x, y } = this.adjustPosToFit(x, y, toolbarWidth, ICON_SIZE_PLUS_GAP));
 
 		el.style.setProperty("--cc-ctx-toolbar-left", x + "px");

--- a/canvas_modules/common-canvas/src/common-canvas/cc-text-toolbar.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/cc-text-toolbar.jsx
@@ -58,6 +58,15 @@ class CommonCanvasTextToolbar extends React.Component {
 		this.onKeyDown = this.onKeyDown.bind(this);
 
 		this.logger = new Logger("CC-Text-Toolbar");
+		this.toolbarDivRef = React.createRef();
+	}
+
+	componentDidMount() {
+		this.applyToolbarPosition();
+	}
+
+	componentDidUpdate() {
+		this.applyToolbarPosition();
 	}
 
 	onKeyDown(evt) {
@@ -304,6 +313,16 @@ class CommonCanvasTextToolbar extends React.Component {
 		return { leftBar: [] };
 	}
 
+	/** Sets CSS custom properties for toolbar position on the DOM node. */
+	applyToolbarPosition() {
+		if (!this.toolbarDivRef.current) {
+			return;
+		}
+		const el = this.toolbarDivRef.current;
+		el.style.setProperty("--cc-text-toolbar-left", this.props.pos_x + "px");
+		el.style.setProperty("--cc-text-toolbar-top", this.props.pos_y + "px");
+	}
+
 	render() {
 		this.logger.log("render");
 
@@ -312,8 +331,8 @@ class CommonCanvasTextToolbar extends React.Component {
 		if (this.props.isOpen) {
 			textToolbar = (
 				<div
+					ref={this.toolbarDivRef}
 					className={"text-toolbar floating-toolbar"}
-					style={{ left: this.props.pos_x, top: this.props.pos_y }}
 					onBlur={this.props.blurHandler}
 					onKeyDown={this.onKeyDown}
 				>

--- a/canvas_modules/common-canvas/src/common-canvas/common-canvas.scss
+++ b/canvas_modules/common-canvas/src/common-canvas/common-canvas.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 Elyra Authors
+ * Copyright 2017-2026 Elyra Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,6 +147,10 @@ $panel-border-color: carbon.$border-subtle-01;
 // necessary because the width allocated to the context toolbar is reduced by
 // five pixels to force the overflow icon to be displayed.
 .context-toolbar  {
+	// width is set via CSS custom property applied by CSSOM (see cc-context-toolbar.jsx).
+	// It forces the overflow button to appear by constraining the available width.
+	width: var(--cc-ctx-toolbar-width, fit-content);
+
 	.toolbar-overflow-item {
 		button:focus {
 			border-color: transparent;
@@ -158,13 +162,9 @@ $panel-border-color: carbon.$border-subtle-01;
 .text-toolbar,
 .context-toolbar  {
 	position: absolute;
-	// For text toolbar - top and left will be calculated and set programmatically
-	// For context toolbar - top, left and width will be calculated and set programmatically.
-	// 'width' is set for the context toolbar because the overflow button must be forced to
-	// appear by setting the width appropriately (see cc-context-toolbar.jsx).
-	top: 0;
-	left: 0;
-	width: fit-content;
+	// top and left are set via CSS custom properties applied by CSSOM (see component files).
+	top: var(--cc-text-toolbar-top, var(--cc-ctx-toolbar-top, 0));
+	left: var(--cc-text-toolbar-left, var(--cc-ctx-toolbar-left, 0));
 	// This bottom border allows the canvas context toolbar to disappear, if the mouse
 	// cursor is immediately moved away from the toolbar, after it opens. That's because,
 	// when the toolbar opens, the border will be underneath the mouse cursor and so the
@@ -186,6 +186,8 @@ $panel-border-color: carbon.$border-subtle-01;
 
 // Text toolbar specific attributes.
 .text-toolbar  {
+	width: fit-content;
+
 	.toolbar-div {
 		animation: raise-toolbar 0.3s linear;
 		border: 1px solid carbon.$border-strong-01;

--- a/canvas_modules/common-canvas/src/context-menu/common-context-menu.jsx
+++ b/canvas_modules/common-canvas/src/context-menu/common-context-menu.jsx
@@ -38,6 +38,8 @@ class CommonContextMenu extends React.Component {
 		};
 		this.menuRefs = [];
 		this.subMenuRefs = [];
+		this.subMenuDivRefs = {};
+		this.subMenuPosData = {};
 
 		this.focusIndex = null; // Set to null so we know when it is not initialized.
 		this.subMenuFocusIndex = 0;
@@ -45,14 +47,21 @@ class CommonContextMenu extends React.Component {
 		this.onKeyDown = this.onKeyDown.bind(this);
 		this.itemSelected = this.itemSelected.bind(this);
 		this.colorClicked = this.colorClicked.bind(this);
+
+		this.menuPopoverRef = React.createRef();
 	}
 
 	componentDidMount() {
+		this.applyMenuPosition();
+		this.applySubMenuPositions();
 		this.focusIndex = this.focusIndex === null ? 0 : this.focusIndex;
 		this.menuRefs[this.focusIndex].current.focus();
 	}
 
 	componentDidUpdate() {
+		this.applyMenuPosition();
+		this.applySubMenuPositions();
+
 		if (this.state.displaySubMenuAction) {
 			this.subMenuFocusIndex = 0;
 			if (this.state.displaySubMenuAction !== ACTION_COLOR_BACKGROUND) {
@@ -120,6 +129,34 @@ class CommonContextMenu extends React.Component {
 				this.itemSelected(action);
 			}
 		}
+	}
+
+	/** Sets CSS custom properties for the root menu position on its DOM node. */
+	applyMenuPosition() {
+		if (!this.menuPopoverRef.current) {
+			return;
+		}
+		const menuSize = this.calculateMenuSize(this.props.menuDefinition);
+		const menuPos = this.calculateMenuPos(this.props.mousePos, menuSize, this.props.canvasRect);
+		const el = this.menuPopoverRef.current;
+		el.style.setProperty("--context-menu-left", menuPos.x + "px");
+		el.style.setProperty("--context-menu-top", menuPos.y + "px");
+	}
+
+	/** Sets CSS custom properties for each sub-menu position collected during render. */
+	applySubMenuPositions() {
+		Object.keys(this.subMenuDivRefs).forEach((action) => {
+			const ref = this.subMenuDivRefs[action];
+			const posData = this.subMenuPosData[action];
+			if (ref && ref.current && posData) {
+				ref.current.style.setProperty("--context-submenu-top", posData.top);
+				if ("left" in posData) {
+					ref.current.style.setProperty("--context-submenu-left", posData.left);
+				} else {
+					ref.current.style.removeProperty("--context-submenu-left");
+				}
+			}
+		});
 	}
 
 	itemSelected(data) {
@@ -342,6 +379,10 @@ class CommonContextMenu extends React.Component {
 			menuRefs.push(ref);
 		}
 
+		const subMenuDivRef = React.createRef();
+		this.subMenuDivRefs[menuItem.action] = subMenuDivRef;
+		this.subMenuPosData[menuItem.action] = subMenuPosStyle;
+
 		return (
 			<div key={index} ref={ref} className={menuItemClass} aria-haspopup tabIndex={-1} data-action={menuItem.action} role="menuitem"
 				onMouseEnter={onMouseEnter}
@@ -349,7 +390,7 @@ class CommonContextMenu extends React.Component {
 				onKeyDown={this.onKeyDown}
 			>
 				{menuItemContent}
-				<div style={subMenuPosStyle} className={subMenuClass}>
+				<div ref={subMenuDivRef} className={subMenuClass}>
 					{subMenuContent}
 				</div>
 			</div>
@@ -404,21 +445,17 @@ class CommonContextMenu extends React.Component {
 	}
 
 	render() {
-		// Reposition contextMenu so that it does not show off the screen
+		this.menuRefs = [];
+		this.subMenuDivRefs = {};
+		this.subMenuPosData = {};
 		const menuSize = this.calculateMenuSize(this.props.menuDefinition);
 		const menuPos = this.calculateMenuPos(this.props.mousePos, menuSize, this.props.canvasRect);
-		const posStyle = {
-			left: menuPos.x + "px",
-			top: menuPos.y + "px"
-		};
-
-		this.menuRefs = [];
 		const menuDefinition = this.ensureAllSubMenuItemsHaveAction(this.props.menuDefinition);
 		const menuInfo = this.buildMenu(menuDefinition, menuSize, menuPos, this.props.canvasRect);
 		this.menuRefs = menuInfo.menuRefs;
 
 		return (
-			<div id="context-menu-popover" role="menu" className="context-menu-popover" style={posStyle} onContextMenu={this.onContextMenu}>
+			<div ref={this.menuPopoverRef} id="context-menu-popover" role="menu" className="context-menu-popover" onContextMenu={this.onContextMenu}>
 				{menuInfo.menuItems}
 			</div>
 		);

--- a/canvas_modules/common-canvas/src/context-menu/context-menu.scss
+++ b/canvas_modules/common-canvas/src/context-menu/context-menu.scss
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2025 Elyra Authors
+ * Copyright 2017-2026 Elyra Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,11 +30,15 @@
 	-webkit-box-shadow: carbon.$spacing-01 carbon.$spacing-01 carbon.$spacing-01 rgba(0, 0, 0, 0.2);
 	box-shadow: carbon.$spacing-01 carbon.$spacing-01 carbon.$spacing-01 rgba(0, 0, 0, 0.2);
 	position: absolute;
+	// left and top are set via CSS custom properties applied by CSSOM (see common-context-menu.jsx).
+	left: var(--context-menu-left, 0);
+	top: var(--context-menu-top, 0);
 
 	// For cascaded sub-menu
 	&.context-menu-submenu {
-		top: 0;
-		left: 100%;
+		// top and left are set via CSS custom properties applied by CSSOM (see common-context-menu.jsx).
+		top: var(--context-submenu-top, 0);
+		left: var(--context-submenu-left, 100%);
 		display: none;
 
 		// Makes the cascaded sub-menu visible.


### PR DESCRIPTION
…lbars and context menu

Fixes: #3238 

Context toolbar, text toolbar, and context menu previously used React style={{}} props to set position (left/top) and width, producing inline style attributes blocked by style-src CSP without unsafe-inline.

Replace with CSSOM setProperty() calls on refs in componentDidMount/ componentDidUpdate, consuming CSS custom properties defined in SCSS:
  --cc-ctx-toolbar-left/top/width  (cc-context-toolbar.jsx)
  --cc-text-toolbar-left/top       (cc-text-toolbar.jsx)
  --context-menu-left/top          (common-context-menu.jsx)
  --context-submenu-left/top       (common-context-menu.jsx)

element.style.setProperty() is a CSSOM write and is not blocked by CSP.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

