### PR TITLE
#3248 Prepare for unsafe-inline - expression builder nonce support

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/common-properties.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/common-properties.jsx
@@ -255,7 +255,8 @@ CommonProperties.propTypes = {
 		showRequiredIndicator: PropTypes.bool,
 		showAlertsTab: PropTypes.bool,
 		locale: PropTypes.string,
-		enableTanstackTable: PropTypes.bool
+		enableTanstackTable: PropTypes.bool,
+		cspNonce: PropTypes.string
 	}),
 	callbacks: PropTypes.shape({
 		controllerHandler: PropTypes.func,

--- a/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/expression/expression.jsx
@@ -295,6 +295,7 @@ class ExpressionControl extends React.Component {
 		});
 
 		const linterExtension = this.props.control.language === "json" ? linter(jsonParseLinter()) : [];
+		const cspNonce = this.props.controller.getPropertiesConfig().cspNonce;
 
 		this.editor = new EditorView({
 			doc: this.props.value,
@@ -303,6 +304,7 @@ class ExpressionControl extends React.Component {
 				customCompletions,
 				...expressionEditorTheme,
 				this.themeCompartment.of(EditorView.theme({}, { dark: this.state.theme === themeG90 })),
+				...(cspNonce ? [EditorView.cspNonce.of(cspNonce)] : []),
 				lineNumbers(), // basicSetup start
 				highlightActiveLineGutter(),
 				highlightSpecialChars(),

--- a/docs/pages/04.08-properties-config.md
+++ b/docs/pages/04.08-properties-config.md
@@ -45,3 +45,28 @@ The Properties Config is an object passed as an optional prop to the `<CommonPro
 * categoryView `string` - View categories in right-flyout. Can be `"accordions"` or `"tabs"`. default: `"accordions"`.
 
 * enableTanstackTable `boolean`: Feature flag to enable using Tanstack tables instead of React-virtualized tables. default: `true`
+
+* cspNonce `string` - Default undefined. A [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) nonce value to pass to the expression editor. When your application enforces a `style-src` CSP directive without `'unsafe-inline'`, the expression editor (powered by CodeMirror 6) will be blocked from injecting its required stylesheets. Providing a nonce allows those stylesheets to be permitted under a nonce-based policy.
+
+    **How to use:**
+
+    1. On your server, generate a cryptographically random nonce for each HTTP response:
+        ```js
+        const crypto = require("crypto");
+        const nonce = crypto.randomBytes(16).toString("base64");
+        ```
+
+    2. Include the nonce in your `Content-Security-Policy` header:
+        ```
+        style-src 'self' 'nonce-<your-nonce-value>'
+        ```
+
+    3. Pass the nonce to `<CommonProperties>`:
+        ```jsx
+        <CommonProperties
+            propertiesConfig={{ cspNonce: nonce }}
+            ...
+        />
+        ```
+
+    **Note:** If your application does not use the expression editor, this field is not required and `'unsafe-inline'` is not needed in `style-src` for common-properties. If you do use the expression editor and do not provide a nonce, you must include `'unsafe-inline'` in your `style-src` policy for the editor to function correctly.


### PR DESCRIPTION
Fixes: #3248 

Add cspNonce support to expression editor via propertiesConfig
Applications running a strict style-src 'self' CSP can now eliminate the 'unsafe-inline' requirement for CodeMirror by passing a per-request nonce through propertiesConfig:

  <CommonProperties propertiesConfig={{ cspNonce: nonce }} ... />

The nonce is threaded from propertiesConfig through PropertiesController to EditorView.cspNonce.of() in the extensions array. StyleModule.mount() (style-mod) then sets the nonce attribute on the injected <style> element, allowing the browser to permit the style injection under a nonce-based style-src policy.

Add cspNonce: PropTypes.string to the propertiesConfig PropTypes shape.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

