### PR TITLE
#3262 add opacity to disabled text panels for visual cue

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/panels/text-panel/text-panel.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/text-panel/text-panel.jsx
@@ -29,7 +29,7 @@ class TextPanel extends Component {
 		const className = this.props.panel.className ? this.props.panel.className : "";
 		const hidden = this.props.panelState === STATES.HIDDEN;
 		const disabled = this.props.panelState === STATES.DISABLED;
-		let label = this.props.panel.label ? (<div className="panel-label">{this.props.panel.label}</div>) : null;
+		let label = this.props.panel.label ? (<div className="panel-label" aria-disabled={disabled}>{this.props.panel.label}</div>) : null;
 		let description;
 		if (this.props.panel.description && !isEmpty(this.props.panel.description.text)) {
 			const dynamicDescriptionText = evaluateText(this.props.panel.description.text, this.props.controller);

--- a/canvas_modules/common-canvas/src/common-properties/panels/text-panel/text-panel.scss
+++ b/canvas_modules/common-canvas/src/common-properties/panels/text-panel/text-panel.scss
@@ -31,6 +31,7 @@
 		margin-bottom: carbon.$spacing-03;
 	}
 	&[disabled] {
+		opacity: 0.5;
 		pointer-events: none;
 	}
 	&.hide {

--- a/canvas_modules/common-canvas/src/common-properties/panels/text-panel/text-panel.scss
+++ b/canvas_modules/common-canvas/src/common-properties/panels/text-panel/text-panel.scss
@@ -31,8 +31,11 @@
 		margin-bottom: carbon.$spacing-03;
 	}
 	&[disabled] {
-		opacity: 0.5;
 		pointer-events: none;
+		.panel-label,
+		.panel-description {
+			color: carbon.$text-disabled;
+		}
 	}
 	&.hide {
 		display: none;


### PR DESCRIPTION
Fixes #3262

Disabled text panels had no visual indication of their disabled state. The pointer-events: none rule was already blocking interaction, but there was no styling change to signal "disabled" to the user.
Added opacity: 0.5 to the .properties-text-panel[disabled] rule.

File used to recreate original issue: panelConditions_paramDef.json

How it works now:

<img width="384" height="252" alt="Screen Recording 2026-07-27 at 17 59 59" src="https://github.com/user-attachments/assets/1aae16bc-cb75-4c75-8b9e-c1e69838109f" />


 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

