### PR TITLE
#3270 Fix Many messages displayed when running Jest tests

### DIFF
--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/action_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/action_paramDef.json
@@ -293,7 +293,9 @@
         "label": {
           "default": "Currency type"
         },
-        "description": "Try pressing the currency image",
+        "description": {
+          "default": "Try pressing the currency image"
+        },
         "control": "readonly",
         "action_ref": "currency"
       },
@@ -750,6 +752,9 @@
         "label": {
           "resource_key": "moon"
         },
+        "description": {
+          "default": "This is a tooltip for moon1 action image."
+        },
         "control": "image",
         "data": {
           "parameter_ref": "oneofselect_null"
@@ -768,6 +773,9 @@
         "label": {
           "resource_key": "moon"
         },
+        "description": {
+          "default": "This is a tooltip for moon2 action image."
+        },
         "control": "image",
         "data": {
           "parameter_ref": "oneofselect_empty_string"
@@ -784,6 +792,9 @@
         "id": "moon3",
         "label": {
           "resource_key": "moon"
+        },
+        "description": {
+          "default": "This is a tooltip for moon3 action image."
         },
         "control": "image",
         "data": {
@@ -803,6 +814,9 @@
         "label": {
           "resource_key": "moon"
         },
+        "description": {
+          "default": "This is a tooltip for moon4 action image."
+        },
         "control": "image",
         "data": {
           "parameter_ref": "radioString"
@@ -821,6 +835,9 @@
         "label": {
           "resource_key": "moon"
         },
+        "description": {
+          "default": "This is a tooltip for moon5 action image."
+        },
         "control": "image",
         "data": {
           "parameter_ref": "radioString"
@@ -837,6 +854,9 @@
         "id": "meteor",
         "label": {
           "resource_key": "meteor"
+        },
+        "description": {
+          "default": "This is a tooltip for meteor action image."
         },
         "control": "image",
         "data": {


### PR DESCRIPTION

 Fix: #3270 

**Why the messages were occurring:**
- renderIcon without iconDescription - descriptions were accidentally removed from `moon1`–`moon5` and `meteor` image actions; Carbon's Button requires `iconDescription` when `renderIcon` is set.
- Invalid prop 'link' of type 'function' - `currency_svg` description was changed from `{"default": "..."}` to a plain string; in JavaScript, `"string".link` resolves to `String.prototype.link`, a function, which ToolTip's `link` prop does not accept.

Screenshot of `npm run test:jest title-editor-test.js` passing without many messages:
<img width="895" height="551" alt="Screenshot 2026-07-29 at 1 42 50 PM" src="https://github.com/user-attachments/assets/867483ec-ec7d-47a9-a190-a529bd41ec1e" />

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

