### PR TITLE
#3259 Elyra-Canvas Studio POC

### DIFF
--- a/canvas_modules/harness/assets/images/carbon/folder--open.svg
+++ b/canvas_modules/harness/assets/images/carbon/folder--open.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: none;
+      }
+      .cls-1, .cls-2 {
+        stroke-width: 0px;
+      }
+    </style>
+  </defs>
+  <path class="cls-2" d="M28,8H20.8284L17.4143,4.5859A2,2,0,0,0,16,4H4A2,2,0,0,0,2,6V26a2,2,0,0,0,2,2H28a2,2,0,0,0,2-2V10A2,2,0,0,0,28,8ZM8,26V14h8v6.17l-2.59-2.58L12,19l5,5,5-5-1.41-1.41L18,20.17V14a2.0025,2.0025,0,0,0-2-2H8a2.0025,2.0025,0,0,0-2,2V26H4V6H16l4,4h8v2H22v2h6V26Z"/>
+  <rect id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" class="cls-1" width="32" height="32"/>
+</svg>

--- a/canvas_modules/harness/assets/images/carbon/folder.svg
+++ b/canvas_modules/harness/assets/images/carbon/folder.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="icon" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: none;
+      }
+      .cls-1, .cls-2 {
+        stroke-width: 0px;
+      }
+    </style>
+  </defs>
+  <path class="cls-2" d="M11.17,6l3.42,3.41.58.59H28V26H4V6h7.17m0-2H4A2,2,0,0,0,2,6V26a2,2,0,0,0,2,2H28a2,2,0,0,0,2-2V10a2,2,0,0,0-2-2H16L12.59,4.59A2,2,0,0,0,11.17,4Z"/>
+  <rect id="_Transparent_Rectangle_" data-name="&lt;Transparent Rectangle&gt;" class="cls-1" width="32" height="32"/>
+</svg>

--- a/canvas_modules/harness/assets/styles/harness.scss
+++ b/canvas_modules/harness/assets/styles/harness.scss
@@ -29,6 +29,7 @@
 @forward "../../src/styles/custom-actions.scss";
 @forward "../../src/styles/glmm.scss";
 @forward "../../src/styles/notifications-panel-wrapper.scss";
+@forward "../../src/styles/studio.scss";
 
 :root {
 	@include carbon.theme(themes.$g10);

--- a/canvas_modules/harness/src/client/App.js
+++ b/canvas_modules/harness/src/client/App.js
@@ -2970,6 +2970,14 @@ class App extends React.Component {
 			],
 			rightBar: [
 				{
+					action: "studio",
+					label: "Canvas Studio",
+					enable: true,
+					iconEnabled: (<SelectWindow size={16} />),
+					tooltip: "Open Canvas Studio (no-code builder)"
+				},
+				{ divider: true },
+				{
 					action: "help",
 					label: "Elyra Canvas Documentation",
 					enable: true,
@@ -3025,6 +3033,9 @@ class App extends React.Component {
 
 	toolbarActionHandler(action) {
 		switch (action) {
+		case "studio":
+			window.location.href = "/#/studio";
+			break;
 		case "console":
 			this.openConsole();
 			break;

--- a/canvas_modules/harness/src/client/App.js
+++ b/canvas_modules/harness/src/client/App.js
@@ -97,7 +97,7 @@ import AppSettingsPanel from "./app-x-settings-panel.jsx";
 // Uncomment these and associated code to automatically display a flow and palette.
 // import allTypesCanvas from "../../../harness/test_resources/diagrams/allTypesCanvas.json";
 
-import { Add, AddAlt, SubtractAlt, Api_1 as Api, Chat, ChatOff, ColorPalette, Download, Edit, FlowData, GuiManagement,
+import { Add, AddAlt, SubtractAlt, Api_1 as Api, Chat, ChatOff, ColorPalette, DocumentImport, Download, Edit, FlowData, GuiManagement,
 	Help, OpenPanelFilledBottom, Play, Scale, Settings, SelectWindow,
 	StopFilledAlt, Subtract, TextScale, TouchInteraction, Notification as NotificationIcon, Save, Launch, Restart } from "@carbon/react/icons";
 
@@ -1429,6 +1429,43 @@ class App extends React.Component {
 
 	openConsole() {
 		this.setState({ consoleOpened: !this.state.consoleOpened });
+	}
+
+	goToStudio() {
+		try {
+			const saved = localStorage.getItem("elyra-studio-state");
+			const studioState = saved ? JSON.parse(saved) : {};
+			studioState.pipelineFlow = this.canvasController.getPipelineFlow();
+			localStorage.setItem("elyra-studio-state", JSON.stringify(studioState));
+		} catch {
+			// ignore
+		}
+		window.location.assign("/#/studio");
+	}
+
+	loadFromStudio() {
+		try {
+			const saved = localStorage.getItem("elyra-studio-harness-config");
+			if (!saved) {
+				this.log("Load from Studio: no Studio configuration found — use Save to Harness in Canvas Studio first");
+				return;
+			}
+			const config = JSON.parse(saved);
+			if (config.palette) {
+				this.canvasController.setPipelineFlowPalette(config.palette);
+				this.log("Palette loaded from Studio");
+			}
+			if (config.pipelineFlow) {
+				this.canvasController.getCommandStack().clearCommandStack();
+				this.canvasController.setPipelineFlow(config.pipelineFlow);
+				this.setFlowNotificationMessages();
+				this.setBreadcrumbsDefinition();
+				this.canvasController.zoomToFit();
+				this.log("Pipeline flow loaded from Studio");
+			}
+		} catch (err) {
+			this.log("Load from Studio: failed to parse Studio configuration — " + err);
+		}
 	}
 
 	downloadPipelineFlow() {
@@ -2936,6 +2973,14 @@ class App extends React.Component {
 				},
 				{ divider: true },
 				{
+					action: "loadFromStudio",
+					label: "Load from Studio",
+					enable: true,
+					iconEnabled: (<DocumentImport size={16} />),
+					tooltip: "Load palette and flow from Canvas Studio"
+				},
+				{ divider: true },
+				{
 					action: "theme-toggle",
 					label: "Switch Theme",
 					enable: true,
@@ -3034,7 +3079,10 @@ class App extends React.Component {
 	toolbarActionHandler(action) {
 		switch (action) {
 		case "studio":
-			window.location.href = "/#/studio";
+			this.goToStudio();
+			break;
+		case "loadFromStudio":
+			this.loadFromStudio();
 			break;
 		case "console":
 			this.openConsole();

--- a/canvas_modules/harness/src/client/components/studio/StudioPage.jsx
+++ b/canvas_modules/harness/src/client/components/studio/StudioPage.jsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import { Button } from "@carbon/react";
-import { Download, Upload } from "@carbon/react/icons";
+import { Download, Save, Upload } from "@carbon/react/icons";
 import JavascriptFileDownload from "js-file-download";
 
 import PaletteBuilder from "./palette-builder/PaletteBuilder";
@@ -37,6 +37,7 @@ const DEFAULT_CANVAS_CONFIG = {
 export default class StudioPage extends React.Component {
 	constructor(props) {
 		super(props);
+		this.studioCanvasRef = React.createRef();
 		this.state = {
 			categories: [],
 			paramDefs: {},
@@ -54,6 +55,8 @@ export default class StudioPage extends React.Component {
 		this.handleFlowImported = this.handleFlowImported.bind(this);
 		this.handleExport = this.handleExport.bind(this);
 		this.handleImport = this.handleImport.bind(this);
+		this.handleSaveToHarness = this.handleSaveToHarness.bind(this);
+		this.handleDiscardAndExit = this.handleDiscardAndExit.bind(this);
 	}
 
 	componentDidMount() {
@@ -65,6 +68,7 @@ export default class StudioPage extends React.Component {
 					categories: categories || [],
 					paramDefs: paramDefs || {},
 					canvasConfig: canvasConfig || { ...DEFAULT_CANVAS_CONFIG },
+					pipelineFlow: pipelineFlow || null,
 					importedFlow: pipelineFlow || null
 				});
 			}
@@ -87,6 +91,13 @@ export default class StudioPage extends React.Component {
 				// ignore quota errors
 			}
 		}
+	}
+
+	getCurrentFlow() {
+		if (this.studioCanvasRef.current) {
+			return this.studioCanvasRef.current.getFlow();
+		}
+		return this.state.pipelineFlow;
 	}
 
 	handleCategoriesChange(categories) {
@@ -137,8 +148,35 @@ export default class StudioPage extends React.Component {
 		this.setState({ importedFlow: null });
 	}
 
+	handleSaveToHarness() {
+		const { categories, paramDefs, canvasConfig } = this.state;
+		const pipelineFlow = this.getCurrentFlow();
+		try {
+			localStorage.setItem("elyra-studio-harness-config", JSON.stringify({
+				palette: paletteGenerator(categories),
+				paramDefs,
+				canvasConfig,
+				pipelineFlow
+			}));
+			localStorage.setItem("elyra-studio-state", JSON.stringify({ categories, paramDefs, canvasConfig, pipelineFlow }));
+		} catch {
+			// ignore quota errors
+		}
+		window.location.assign("/#/");
+	}
+
+	handleDiscardAndExit() {
+		try {
+			localStorage.removeItem("elyra-studio-state");
+		} catch {
+			// ignore
+		}
+		window.location.assign("/#/");
+	}
+
 	handleExport() {
-		const { categories, paramDefs, canvasConfig, pipelineFlow } = this.state;
+		const { categories, paramDefs, canvasConfig } = this.state;
+		const pipelineFlow = this.getCurrentFlow();
 		const bundle = {
 			version: "1.0",
 			studio: { categories, paramDefs, canvasConfig, pipelineFlow },
@@ -182,7 +220,6 @@ export default class StudioPage extends React.Component {
 			<div className="studio-page">
 				<div className="studio-header">
 					<div className="studio-header-left">
-						<a href="/#/" className="studio-back-link">← Back to Harness</a>
 						<span className="studio-title">Canvas Studio</span>
 					</div>
 					<div className="studio-header-actions">
@@ -196,8 +233,15 @@ export default class StudioPage extends React.Component {
 							style={{ display: "none" }}
 							onChange={this.handleImport}
 						/>
-						<Button kind="secondary" size="sm" renderIcon={Download} onClick={this.handleExport}>
+						<Button kind="ghost" size="sm" renderIcon={Download} onClick={this.handleExport}>
 							Export JSON
+						</Button>
+						<div className="studio-header-divider" />
+						<Button kind="ghost" size="sm" onClick={this.handleDiscardAndExit}>
+							Exit without saving
+						</Button>
+						<Button kind="primary" size="sm" renderIcon={Save} onClick={this.handleSaveToHarness}>
+							Save to Harness
 						</Button>
 					</div>
 				</div>
@@ -230,6 +274,7 @@ export default class StudioPage extends React.Component {
 					</div>
 
 					<StudioCanvas
+						ref={this.studioCanvasRef}
 						paletteJSON={paletteJSON}
 						paramDefs={paramDefs}
 						categories={categories}

--- a/canvas_modules/harness/src/client/components/studio/StudioPage.jsx
+++ b/canvas_modules/harness/src/client/components/studio/StudioPage.jsx
@@ -68,7 +68,7 @@ export default class StudioPage extends React.Component {
 			this.setState((prev) => ({
 				paramDefs: {
 					...prev.paramDefs,
-					[updatedNode.studioId]: { titleDefinition: { title: "", editable: true }, parameters: [], conditions: [], actions: [] }
+					[updatedNode.studioId]: { titleDefinition: { title: "", editable: true }, parameters: [], conditions: [], actions: [], groups: [], groupLayout: "flat", resources: {} }
 				}
 			}));
 		}
@@ -127,7 +127,7 @@ export default class StudioPage extends React.Component {
 	render() {
 		const { categories, paramDefs, selectedNodeStudioId, canvasConfig } = this.state;
 		const paletteJSON = paletteGenerator(categories);
-		const emptyParamDef = { titleDefinition: { title: "", editable: true }, parameters: [], conditions: [], actions: [] };
+		const emptyParamDef = { titleDefinition: { title: "", editable: true }, parameters: [], conditions: [], actions: [], groups: [], groupLayout: "flat", resources: {} };
 		const selectedParamDef = selectedNodeStudioId ? (paramDefs[selectedNodeStudioId] || emptyParamDef) : null;
 
 		return (

--- a/canvas_modules/harness/src/client/components/studio/StudioPage.jsx
+++ b/canvas_modules/harness/src/client/components/studio/StudioPage.jsx
@@ -41,15 +41,52 @@ export default class StudioPage extends React.Component {
 			categories: [],
 			paramDefs: {},
 			selectedNodeStudioId: null,
-			canvasConfig: { ...DEFAULT_CANVAS_CONFIG }
+			canvasConfig: { ...DEFAULT_CANVAS_CONFIG },
+			pipelineFlow: null,
+			importedFlow: null
 		};
 		this.handleCategoriesChange = this.handleCategoriesChange.bind(this);
 		this.handleSelectNode = this.handleSelectNode.bind(this);
 		this.handleNodeTypeUpdate = this.handleNodeTypeUpdate.bind(this);
 		this.handleParamDefChange = this.handleParamDefChange.bind(this);
 		this.handleCanvasConfigChange = this.handleCanvasConfigChange.bind(this);
+		this.handleFlowChange = this.handleFlowChange.bind(this);
+		this.handleFlowImported = this.handleFlowImported.bind(this);
 		this.handleExport = this.handleExport.bind(this);
 		this.handleImport = this.handleImport.bind(this);
+	}
+
+	componentDidMount() {
+		try {
+			const saved = localStorage.getItem("elyra-studio-state");
+			if (saved) {
+				const { categories, paramDefs, canvasConfig, pipelineFlow } = JSON.parse(saved);
+				this.setState({
+					categories: categories || [],
+					paramDefs: paramDefs || {},
+					canvasConfig: canvasConfig || { ...DEFAULT_CANVAS_CONFIG },
+					importedFlow: pipelineFlow || null
+				});
+			}
+		} catch {
+			// ignore corrupt localStorage
+		}
+	}
+
+	componentDidUpdate(_prevProps, prevState) {
+		const { categories, paramDefs, canvasConfig, pipelineFlow } = this.state;
+		if (
+			prevState.categories !== categories ||
+			prevState.paramDefs !== paramDefs ||
+			prevState.canvasConfig !== canvasConfig ||
+			prevState.pipelineFlow !== pipelineFlow
+		) {
+			try {
+				localStorage.setItem("elyra-studio-state", JSON.stringify({ categories, paramDefs, canvasConfig, pipelineFlow }));
+			} catch {
+				// ignore quota errors
+			}
+		}
 	}
 
 	handleCategoriesChange(categories) {
@@ -65,11 +102,13 @@ export default class StudioPage extends React.Component {
 		// so properties are not lost when renaming a node
 		const existing = this.state.paramDefs[updatedNode.studioId];
 		if (!existing) {
+			const blank = {
+				titleDefinition: { title: "", editable: true },
+				parameters: [], conditions: [], actions: [],
+				groups: [], groupLayout: "flat", resources: {}
+			};
 			this.setState((prev) => ({
-				paramDefs: {
-					...prev.paramDefs,
-					[updatedNode.studioId]: { titleDefinition: { title: "", editable: true }, parameters: [], conditions: [], actions: [], groups: [], groupLayout: "flat", resources: {} }
-				}
+				paramDefs: { ...prev.paramDefs, [updatedNode.studioId]: blank }
 			}));
 		}
 	}
@@ -90,11 +129,19 @@ export default class StudioPage extends React.Component {
 		}));
 	}
 
+	handleFlowChange(flow) {
+		this.setState({ pipelineFlow: flow });
+	}
+
+	handleFlowImported() {
+		this.setState({ importedFlow: null });
+	}
+
 	handleExport() {
-		const { categories, paramDefs, canvasConfig } = this.state;
+		const { categories, paramDefs, canvasConfig, pipelineFlow } = this.state;
 		const bundle = {
 			version: "1.0",
-			studio: { categories, paramDefs, canvasConfig },
+			studio: { categories, paramDefs, canvasConfig, pipelineFlow },
 			palette: paletteGenerator(categories)
 		};
 		JavascriptFileDownload(JSON.stringify(bundle, null, 2), "studio-config.json", "application/json");
@@ -114,6 +161,7 @@ export default class StudioPage extends React.Component {
 						categories: bundle.studio.categories || [],
 						paramDefs: bundle.studio.paramDefs || {},
 						canvasConfig: bundle.studio.canvasConfig || { ...DEFAULT_CANVAS_CONFIG },
+						importedFlow: bundle.studio.pipelineFlow || null,
 						selectedNodeStudioId: null
 					});
 				}
@@ -187,6 +235,9 @@ export default class StudioPage extends React.Component {
 						categories={categories}
 						canvasConfig={canvasConfig}
 						onCanvasConfigChange={this.handleCanvasConfigChange}
+						importedFlow={this.state.importedFlow}
+						onFlowChange={this.handleFlowChange}
+						onFlowImported={this.handleFlowImported}
 					/>
 				</div>
 			</div>

--- a/canvas_modules/harness/src/client/components/studio/StudioPage.jsx
+++ b/canvas_modules/harness/src/client/components/studio/StudioPage.jsx
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint complexity: ["error", 20] */
+
+import React from "react";
+import { Button } from "@carbon/react";
+import { Download, Upload } from "@carbon/react/icons";
+import JavascriptFileDownload from "js-file-download";
+
+import PaletteBuilder from "./palette-builder/PaletteBuilder";
+import PropertiesBuilder from "./properties-builder/PropertiesBuilder";
+import StudioCanvas from "./preview/StudioCanvas";
+import paletteGenerator from "./utils/palette-generator";
+
+const DEFAULT_CANVAS_CONFIG = {
+	enableSnapToGridType: "None",
+	enableLinkType: "Curve",
+	enableLinkDirection: "LeftRight",
+	enableLinkMethod: "Ports",
+	enablePaletteLayout: "Flyout",
+	enableNarrowPalette: true
+};
+
+export default class StudioPage extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			categories: [],
+			paramDefs: {},
+			selectedNodeStudioId: null,
+			canvasConfig: { ...DEFAULT_CANVAS_CONFIG }
+		};
+		this.handleCategoriesChange = this.handleCategoriesChange.bind(this);
+		this.handleSelectNode = this.handleSelectNode.bind(this);
+		this.handleNodeTypeUpdate = this.handleNodeTypeUpdate.bind(this);
+		this.handleParamDefChange = this.handleParamDefChange.bind(this);
+		this.handleCanvasConfigChange = this.handleCanvasConfigChange.bind(this);
+		this.handleExport = this.handleExport.bind(this);
+		this.handleImport = this.handleImport.bind(this);
+	}
+
+	handleCategoriesChange(categories) {
+		this.setState({ categories });
+	}
+
+	handleSelectNode(nodeStudioId) {
+		this.setState({ selectedNodeStudioId: nodeStudioId });
+	}
+
+	handleNodeTypeUpdate(updatedNode) {
+		// Keep paramDefs keyed by studioId; if op/label changes, the key stays stable
+		// so properties are not lost when renaming a node
+		const existing = this.state.paramDefs[updatedNode.studioId];
+		if (!existing) {
+			this.setState((prev) => ({
+				paramDefs: {
+					...prev.paramDefs,
+					[updatedNode.studioId]: { titleDefinition: { title: "", editable: true }, parameters: [], conditions: [], actions: [] }
+				}
+			}));
+		}
+	}
+
+	handleParamDefChange(updatedParamDef) {
+		const { selectedNodeStudioId } = this.state;
+		if (!selectedNodeStudioId) {
+			return;
+		}
+		this.setState((prev) => ({
+			paramDefs: { ...prev.paramDefs, [selectedNodeStudioId]: updatedParamDef }
+		}));
+	}
+
+	handleCanvasConfigChange(key, value) {
+		this.setState((prev) => ({
+			canvasConfig: { ...prev.canvasConfig, [key]: value }
+		}));
+	}
+
+	handleExport() {
+		const { categories, paramDefs, canvasConfig } = this.state;
+		const bundle = {
+			version: "1.0",
+			studio: { categories, paramDefs, canvasConfig },
+			palette: paletteGenerator(categories)
+		};
+		JavascriptFileDownload(JSON.stringify(bundle, null, 2), "studio-config.json", "application/json");
+	}
+
+	handleImport(e) {
+		const file = e.target.files && e.target.files[0];
+		if (!file) {
+			return;
+		}
+		const reader = new FileReader();
+		reader.onload = (evt) => {
+			try {
+				const bundle = JSON.parse(evt.target.result);
+				if (bundle.studio) {
+					this.setState({
+						categories: bundle.studio.categories || [],
+						paramDefs: bundle.studio.paramDefs || {},
+						canvasConfig: bundle.studio.canvasConfig || { ...DEFAULT_CANVAS_CONFIG },
+						selectedNodeStudioId: null
+					});
+				}
+			} catch (err) {
+				console.error("Studio: failed to parse imported file", err);
+			}
+		};
+		reader.readAsText(file);
+	}
+
+	render() {
+		const { categories, paramDefs, selectedNodeStudioId, canvasConfig } = this.state;
+		const paletteJSON = paletteGenerator(categories);
+		const emptyParamDef = { titleDefinition: { title: "", editable: true }, parameters: [], conditions: [], actions: [] };
+		const selectedParamDef = selectedNodeStudioId ? (paramDefs[selectedNodeStudioId] || emptyParamDef) : null;
+
+		return (
+			<div className="studio-page">
+				<div className="studio-header">
+					<div className="studio-header-left">
+						<a href="/#/" className="studio-back-link">← Back to Harness</a>
+						<span className="studio-title">Canvas Studio</span>
+					</div>
+					<div className="studio-header-actions">
+						<label htmlFor="studio-import-file" style={{ cursor: "pointer" }}>
+							<Button kind="ghost" size="sm" renderIcon={Upload} as="span">Import</Button>
+						</label>
+						<input
+							id="studio-import-file"
+							type="file"
+							accept=".json"
+							style={{ display: "none" }}
+							onChange={this.handleImport}
+						/>
+						<Button kind="secondary" size="sm" renderIcon={Download} onClick={this.handleExport}>
+							Export JSON
+						</Button>
+					</div>
+				</div>
+
+				<div className="studio-body">
+					<div className="studio-column">
+						<div className="studio-column-header">Palette Builder</div>
+						<div className="studio-column-content">
+							<PaletteBuilder
+								categories={categories}
+								selectedNodeStudioId={selectedNodeStudioId}
+								onCategoriesChange={this.handleCategoriesChange}
+								onSelectNode={this.handleSelectNode}
+								onNodeTypeUpdate={this.handleNodeTypeUpdate}
+							/>
+						</div>
+					</div>
+
+					<div className="studio-column">
+						<div className="studio-column-header">Node Properties</div>
+						<div className="studio-column-content">
+							<PropertiesBuilder
+								categories={categories}
+								selectedNodeStudioId={selectedNodeStudioId}
+								paramDef={selectedParamDef}
+								onSelectNode={this.handleSelectNode}
+								onParamDefChange={this.handleParamDefChange}
+							/>
+						</div>
+					</div>
+
+					<StudioCanvas
+						paletteJSON={paletteJSON}
+						paramDefs={paramDefs}
+						categories={categories}
+						canvasConfig={canvasConfig}
+						onCanvasConfigChange={this.handleCanvasConfigChange}
+					/>
+				</div>
+			</div>
+		);
+	}
+}

--- a/canvas_modules/harness/src/client/components/studio/StudioPage.jsx
+++ b/canvas_modules/harness/src/client/components/studio/StudioPage.jsx
@@ -17,7 +17,7 @@
 
 import React from "react";
 import { Button } from "@carbon/react";
-import { Download, Save, Upload } from "@carbon/react/icons";
+import { Close, Download, Save, Upload } from "@carbon/react/icons";
 import JavascriptFileDownload from "js-file-download";
 
 import PaletteBuilder from "./palette-builder/PaletteBuilder";
@@ -44,7 +44,9 @@ export default class StudioPage extends React.Component {
 			selectedNodeStudioId: null,
 			canvasConfig: { ...DEFAULT_CANVAS_CONFIG },
 			pipelineFlow: null,
-			importedFlow: null
+			importedFlow: null,
+			paletteCollapsed: false,
+			propertiesCollapsed: false
 		};
 		this.handleCategoriesChange = this.handleCategoriesChange.bind(this);
 		this.handleSelectNode = this.handleSelectNode.bind(this);
@@ -210,11 +212,93 @@ export default class StudioPage extends React.Component {
 		reader.readAsText(file);
 	}
 
-	render() {
-		const { categories, paramDefs, selectedNodeStudioId, canvasConfig } = this.state;
-		const paletteJSON = paletteGenerator(categories);
-		const emptyParamDef = { titleDefinition: { title: "", editable: true }, parameters: [], conditions: [], actions: [], groups: [], groupLayout: "flat", resources: {} };
+	renderPaletteColumn() {
+		const { categories, selectedNodeStudioId, paletteCollapsed } = this.state;
+		if (paletteCollapsed) {
+			return (
+				<div
+					className="studio-column studio-column--collapsed"
+					role="button"
+					tabIndex={0}
+					onClick={() => this.setState({ paletteCollapsed: false })}
+					onKeyDown={(e) => e.key === "Enter" && this.setState({ paletteCollapsed: false })}
+				>
+					<span className="studio-column-collapsed-label">Palette Builder</span>
+				</div>
+			);
+		}
+		return (
+			<div className="studio-column">
+				<div className="studio-column-header">
+					Palette Builder
+					<Button kind="ghost" size="sm" hasIconOnly
+						renderIcon={Close} iconDescription="Collapse panel"
+						onClick={() => this.setState({ paletteCollapsed: true })}
+					/>
+				</div>
+				<div className="studio-column-content">
+					<PaletteBuilder
+						categories={categories}
+						selectedNodeStudioId={selectedNodeStudioId}
+						onCategoriesChange={this.handleCategoriesChange}
+						onSelectNode={this.handleSelectNode}
+						onNodeTypeUpdate={this.handleNodeTypeUpdate}
+					/>
+				</div>
+			</div>
+		);
+	}
+
+	renderPropertiesColumn() {
+		const { categories, paramDefs, selectedNodeStudioId, propertiesCollapsed } = this.state;
+		const emptyParamDef = {
+			titleDefinition: { title: "", editable: true },
+			parameters: [], conditions: [], actions: [],
+			groups: [], groupLayout: "flat", resources: {}
+		};
 		const selectedParamDef = selectedNodeStudioId ? (paramDefs[selectedNodeStudioId] || emptyParamDef) : null;
+
+		if (propertiesCollapsed) {
+			return (
+				<div
+					className="studio-column studio-column--collapsed"
+					role="button"
+					tabIndex={0}
+					onClick={() => this.setState({ propertiesCollapsed: false })}
+					onKeyDown={(e) => e.key === "Enter" && this.setState({ propertiesCollapsed: false })}
+				>
+					<span className="studio-column-collapsed-label">Node Properties</span>
+				</div>
+			);
+		}
+		return (
+			<div className="studio-column">
+				<div className="studio-column-header">
+					Node Properties
+					<Button kind="ghost" size="sm" hasIconOnly
+						renderIcon={Close} iconDescription="Collapse panel"
+						onClick={() => this.setState({ propertiesCollapsed: true })}
+					/>
+				</div>
+				<div className="studio-column-content">
+					<PropertiesBuilder
+						categories={categories}
+						selectedNodeStudioId={selectedNodeStudioId}
+						paramDef={selectedParamDef}
+						onSelectNode={this.handleSelectNode}
+						onParamDefChange={this.handleParamDefChange}
+					/>
+				</div>
+			</div>
+		);
+	}
+
+	render() {
+		const { categories, paramDefs, canvasConfig, paletteCollapsed, propertiesCollapsed } = this.state;
+		const paletteJSON = paletteGenerator(categories);
+		const bodyStyle = {
+			gridTemplateColumns: `${paletteCollapsed ? "40px" : "320px"} ${propertiesCollapsed ? "40px" : "320px"} 1fr`
+		};
 
 		return (
 			<div className="studio-page">
@@ -246,33 +330,9 @@ export default class StudioPage extends React.Component {
 					</div>
 				</div>
 
-				<div className="studio-body">
-					<div className="studio-column">
-						<div className="studio-column-header">Palette Builder</div>
-						<div className="studio-column-content">
-							<PaletteBuilder
-								categories={categories}
-								selectedNodeStudioId={selectedNodeStudioId}
-								onCategoriesChange={this.handleCategoriesChange}
-								onSelectNode={this.handleSelectNode}
-								onNodeTypeUpdate={this.handleNodeTypeUpdate}
-							/>
-						</div>
-					</div>
-
-					<div className="studio-column">
-						<div className="studio-column-header">Node Properties</div>
-						<div className="studio-column-content">
-							<PropertiesBuilder
-								categories={categories}
-								selectedNodeStudioId={selectedNodeStudioId}
-								paramDef={selectedParamDef}
-								onSelectNode={this.handleSelectNode}
-								onParamDefChange={this.handleParamDefChange}
-							/>
-						</div>
-					</div>
-
+				<div className="studio-body" style={bodyStyle}>
+					{this.renderPaletteColumn()}
+					{this.renderPropertiesColumn()}
 					<StudioCanvas
 						ref={this.studioCanvasRef}
 						paletteJSON={paletteJSON}

--- a/canvas_modules/harness/src/client/components/studio/palette-builder/CategoryForm.jsx
+++ b/canvas_modules/harness/src/client/components/studio/palette-builder/CategoryForm.jsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { TextInput, Toggle } from "@carbon/react";
+import IconPicker from "./IconPicker";
+
+export default class CategoryForm extends React.Component {
+	constructor(props) {
+		super(props);
+		this.handleChange = this.handleChange.bind(this);
+	}
+
+	handleChange(field, value) {
+		this.props.onChange({ ...this.props.category, [field]: value });
+	}
+
+	render() {
+		const { category } = this.props;
+
+		return (
+			<div>
+				<div className="studio-form-field">
+					<TextInput
+						id={`cat-label-${category.studioId}`}
+						labelText="Category Label"
+						value={category.label || ""}
+						size="sm"
+						onChange={(e) => this.handleChange("label", e.target.value)}
+					/>
+				</div>
+
+				<div className="studio-form-field">
+					<TextInput
+						id={`cat-desc-${category.studioId}`}
+						labelText="Description"
+						value={category.description || ""}
+						size="sm"
+						onChange={(e) => this.handleChange("description", e.target.value)}
+					/>
+				</div>
+
+				<div className="studio-form-field">
+					<div style={{ fontSize: "0.75rem", fontWeight: 400, color: "var(--cds-text-secondary)", marginBottom: "0.375rem" }}>Icon</div>
+					<IconPicker
+						value={category.image}
+						onChange={(val) => this.handleChange("image", val)}
+					/>
+				</div>
+
+				<div className="studio-form-field">
+					<Toggle
+						id={`cat-open-${category.studioId}`}
+						labelText="Open by default"
+						toggled={Boolean(category.is_open)}
+						size="sm"
+						onToggle={(checked) => this.handleChange("is_open", checked)}
+					/>
+				</div>
+			</div>
+		);
+	}
+}
+
+CategoryForm.propTypes = {
+	category: PropTypes.object.isRequired,
+	onChange: PropTypes.func.isRequired
+};

--- a/canvas_modules/harness/src/client/components/studio/palette-builder/IconPicker.jsx
+++ b/canvas_modules/harness/src/client/components/studio/palette-builder/IconPicker.jsx
@@ -22,6 +22,7 @@ const ICON_TABS = [
 	{
 		label: "General",
 		icons: [
+			"folder", "folder--open",
 			"analytics", "chart--column", "chart--line", "chart--scatter",
 			"data-collection", "data-table", "db2--database", "document--export",
 			"document--import", "document", "filter", "gears", "join--inner",

--- a/canvas_modules/harness/src/client/components/studio/palette-builder/IconPicker.jsx
+++ b/canvas_modules/harness/src/client/components/studio/palette-builder/IconPicker.jsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { TextInput } from "@carbon/react";
+
+const ICON_TABS = [
+	{
+		label: "General",
+		icons: [
+			"analytics", "chart--column", "chart--line", "chart--scatter",
+			"data-collection", "data-table", "db2--database", "document--export",
+			"document--import", "document", "filter", "gears", "join--inner",
+			"merge", "object-storage", "partition--specific", "scales",
+			"sort--ascending"
+		].map((n) => ({ name: n, path: `/images/carbon/${n}.svg` }))
+	},
+	{
+		label: "Sources",
+		icons: [
+			{ name: "user_input", path: "/images/common_node_icons/sources/source_user_input.svg" },
+			{ name: "var_import", path: "/images/common_node_icons/sources/source_var_import.svg" }
+		]
+	},
+	{
+		label: "Models",
+		icons: [
+			"model_c50", "model_cart_build", "model_feature_selection",
+			"model_linear_regression", "model_logistic_regression",
+			"model_neural_network", "model_random_forest"
+		].map((n) => ({ name: n, path: `/images/common_node_icons/models/${n}.svg` }))
+	},
+	{
+		label: "Operations",
+		icons: [
+			"operation_aggregate", "operation_append", "operation_balance",
+			"operation_binning", "operation_derive", "operation_distinct",
+			"operation_ensemble", "operation_field_reorganize", "operation_filler",
+			"operation_filter"
+		].map((n) => ({ name: n, path: `/images/common_node_icons/operations/${n}.svg` }))
+	},
+	{
+		label: "Output",
+		icons: [
+			"output_data_audit", "output_evaluate", "output_histogram",
+			"output_table", "output_var_export"
+		].map((n) => ({ name: n, path: `/images/common_node_icons/output/${n}.svg` }))
+	},
+	{
+		label: "URL",
+		icons: []
+	}
+];
+
+export default class IconPicker extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = { activeTab: 0 };
+		this.handleTabClick = this.handleTabClick.bind(this);
+	}
+
+	handleTabClick(index) {
+		this.setState({ activeTab: index });
+	}
+
+	render() {
+		const { value, onChange } = this.props;
+		const { activeTab } = this.state;
+		const tab = ICON_TABS[activeTab];
+		const isUrlTab = tab.label === "URL";
+
+		return (
+			<div className="studio-icon-picker">
+				<div className="studio-icon-picker-tabs">
+					{ICON_TABS.map((t, i) => (
+						<div
+							key={t.label}
+							className={`studio-icon-tab${activeTab === i ? " studio-icon-tab--active" : ""}`}
+							onClick={() => this.handleTabClick(i)}
+							role="tab"
+							tabIndex={0}
+							onKeyDown={(e) => e.key === "Enter" && this.handleTabClick(i)}
+						>
+							{t.label}
+						</div>
+					))}
+				</div>
+				{isUrlTab ? (
+					<div className="studio-icon-custom-url">
+						<TextInput
+							id="studio-icon-custom-url-input"
+							labelText="Image URL"
+							placeholder="https://example.com/icon.svg"
+							value={value || ""}
+							size="sm"
+							onChange={(e) => onChange(e.target.value)}
+						/>
+					</div>
+				) : (
+					<div className="studio-icon-grid">
+						{tab.icons.map((icon) => (
+							<div
+								key={icon.path}
+								className={`studio-icon-cell${value === icon.path ? " studio-icon-cell--selected" : ""}`}
+								onClick={() => onChange(icon.path)}
+								role="button"
+								tabIndex={0}
+								title={icon.name}
+								onKeyDown={(e) => e.key === "Enter" && onChange(icon.path)}
+							>
+								<img src={icon.path} alt={icon.name} />
+							</div>
+						))}
+					</div>
+				)}
+			</div>
+		);
+	}
+}
+
+IconPicker.propTypes = {
+	value: PropTypes.string,
+	onChange: PropTypes.func.isRequired
+};

--- a/canvas_modules/harness/src/client/components/studio/palette-builder/NodeTypeForm.jsx
+++ b/canvas_modules/harness/src/client/components/studio/palette-builder/NodeTypeForm.jsx
@@ -25,20 +25,26 @@ export default class NodeTypeForm extends React.Component {
 	constructor(props) {
 		super(props);
 		this.handleChange = this.handleChange.bind(this);
+		this.handleClose = this.handleClose.bind(this);
 	}
 
 	handleChange(field, value) {
 		this.props.onChange({ ...this.props.nodeType, [field]: value });
 	}
 
+	handleClose(e) {
+		e.stopPropagation();
+		this.props.onClose();
+	}
+
 	render() {
-		const { nodeType, onClose } = this.props;
+		const { nodeType } = this.props;
 
 		return (
 			<div className="studio-node-type-form">
 				<div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
 					<div className="studio-node-type-form-title">Edit Node Type</div>
-					<Button kind="ghost" size="sm" hasIconOnly renderIcon={Close} iconDescription="Close" onClick={onClose} />
+					<Button kind="ghost" size="sm" hasIconOnly renderIcon={Close} iconDescription="Close" onClick={this.handleClose} />
 				</div>
 
 				<div className="studio-form-field">

--- a/canvas_modules/harness/src/client/components/studio/palette-builder/NodeTypeForm.jsx
+++ b/canvas_modules/harness/src/client/components/studio/palette-builder/NodeTypeForm.jsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { TextInput, Button } from "@carbon/react";
+import { Close } from "@carbon/react/icons";
+import PortsEditor from "./PortsEditor";
+import IconPicker from "./IconPicker";
+
+export default class NodeTypeForm extends React.Component {
+	constructor(props) {
+		super(props);
+		this.handleChange = this.handleChange.bind(this);
+	}
+
+	handleChange(field, value) {
+		this.props.onChange({ ...this.props.nodeType, [field]: value });
+	}
+
+	render() {
+		const { nodeType, onClose } = this.props;
+
+		return (
+			<div className="studio-node-type-form">
+				<div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+					<div className="studio-node-type-form-title">Edit Node Type</div>
+					<Button kind="ghost" size="sm" hasIconOnly renderIcon={Close} iconDescription="Close" onClick={onClose} />
+				</div>
+
+				<div className="studio-form-field">
+					<TextInput
+						id={`node-label-${nodeType.studioId}`}
+						labelText="Label"
+						value={nodeType.label || ""}
+						size="sm"
+						onChange={(e) => this.handleChange("label", e.target.value)}
+					/>
+				</div>
+
+				<div className="studio-form-field">
+					<TextInput
+						id={`node-op-${nodeType.studioId}`}
+						labelText="Operation ID (op)"
+						placeholder="com.example.mynode"
+						value={nodeType.op || ""}
+						size="sm"
+						onChange={(e) => this.handleChange("op", e.target.value)}
+					/>
+				</div>
+
+				<div className="studio-form-field">
+					<TextInput
+						id={`node-desc-${nodeType.studioId}`}
+						labelText="Description"
+						value={nodeType.description || ""}
+						size="sm"
+						onChange={(e) => this.handleChange("description", e.target.value)}
+					/>
+				</div>
+
+				<div className="studio-form-field">
+					<div style={{ fontSize: "0.75rem", fontWeight: 400, color: "var(--cds-text-secondary)", marginBottom: "0.375rem" }}>Icon</div>
+					<IconPicker
+						value={nodeType.image}
+						onChange={(val) => this.handleChange("image", val)}
+					/>
+				</div>
+
+				<PortsEditor
+					ports={nodeType.inputs || []}
+					portType="input"
+					onChange={(ports) => this.handleChange("inputs", ports)}
+				/>
+
+				<PortsEditor
+					ports={nodeType.outputs || []}
+					portType="output"
+					onChange={(ports) => this.handleChange("outputs", ports)}
+				/>
+			</div>
+		);
+	}
+}
+
+NodeTypeForm.propTypes = {
+	nodeType: PropTypes.object.isRequired,
+	onChange: PropTypes.func.isRequired,
+	onClose: PropTypes.func.isRequired
+};

--- a/canvas_modules/harness/src/client/components/studio/palette-builder/PaletteBuilder.jsx
+++ b/canvas_modules/harness/src/client/components/studio/palette-builder/PaletteBuilder.jsx
@@ -37,6 +37,7 @@ export default class PaletteBuilder extends React.Component {
 		this.removeNodeType = this.removeNodeType.bind(this);
 		this.updateNodeType = this.updateNodeType.bind(this);
 		this.selectNode = this.selectNode.bind(this);
+		this.closeNodeForm = this.closeNodeForm.bind(this);
 	}
 
 	addCategory() {
@@ -128,6 +129,10 @@ export default class PaletteBuilder extends React.Component {
 		this.props.onSelectNode(editing);
 	}
 
+	closeNodeForm() {
+		this.setState({ editingNodeId: null });
+	}
+
 	renderNodeTypeItem(category, nodeType) {
 		const isEditing = this.state.editingNodeId === nodeType.studioId;
 		return (
@@ -166,7 +171,7 @@ export default class PaletteBuilder extends React.Component {
 					<NodeTypeForm
 						nodeType={nodeType}
 						onChange={(updated) => this.updateNodeType(category.studioId, updated)}
-						onClose={() => this.setState({ editingNodeId: null })}
+						onClose={this.closeNodeForm}
 					/>
 				)}
 			</div>

--- a/canvas_modules/harness/src/client/components/studio/palette-builder/PaletteBuilder.jsx
+++ b/canvas_modules/harness/src/client/components/studio/palette-builder/PaletteBuilder.jsx
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { Button } from "@carbon/react";
+import { Add, ChevronDown, ChevronUp, Edit, TrashCan } from "@carbon/react/icons";
+import { v4 as uuid4 } from "uuid";
+import CategoryForm from "./CategoryForm";
+import NodeTypeForm from "./NodeTypeForm";
+
+export default class PaletteBuilder extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			expandedCategories: {},
+			editingNodeId: null
+		};
+		this.addCategory = this.addCategory.bind(this);
+		this.removeCategory = this.removeCategory.bind(this);
+		this.toggleCategory = this.toggleCategory.bind(this);
+		this.updateCategory = this.updateCategory.bind(this);
+		this.addNodeType = this.addNodeType.bind(this);
+		this.removeNodeType = this.removeNodeType.bind(this);
+		this.updateNodeType = this.updateNodeType.bind(this);
+		this.selectNode = this.selectNode.bind(this);
+	}
+
+	addCategory() {
+		const newCategory = {
+			studioId: uuid4(),
+			label: "New Category",
+			description: "",
+			image: "/images/carbon/gears.svg",
+			is_open: true,
+			nodeTypes: []
+		};
+		const expanded = { ...this.state.expandedCategories, [newCategory.studioId]: true };
+		this.setState({ expandedCategories: expanded });
+		this.props.onCategoriesChange([...this.props.categories, newCategory]);
+	}
+
+	removeCategory(studioId) {
+		this.props.onCategoriesChange(this.props.categories.filter((c) => c.studioId !== studioId));
+		const expanded = { ...this.state.expandedCategories };
+		delete expanded[studioId];
+		this.setState({ expandedCategories: expanded });
+	}
+
+	toggleCategory(studioId) {
+		const expanded = { ...this.state.expandedCategories };
+		expanded[studioId] = !expanded[studioId];
+		this.setState({ expandedCategories: expanded });
+	}
+
+	updateCategory(updatedCategory) {
+		const categories = this.props.categories.map((c) =>
+			(c.studioId === updatedCategory.studioId ? updatedCategory : c)
+		);
+		this.props.onCategoriesChange(categories);
+	}
+
+	addNodeType(categoryStudioId) {
+		const newNode = {
+			studioId: uuid4(),
+			label: "New Node",
+			op: "",
+			description: "",
+			image: "/images/carbon/gears.svg",
+			type: "execution_node",
+			inputs: [{ portId: uuid4(), label: "Input", cardinalityMin: 0, cardinalityMax: 1 }],
+			outputs: [{ portId: uuid4(), label: "Output", cardinalityMin: 0, cardinalityMax: -1 }]
+		};
+		const categories = this.props.categories.map((c) => {
+			if (c.studioId === categoryStudioId) {
+				return { ...c, nodeTypes: [...(c.nodeTypes || []), newNode] };
+			}
+			return c;
+		});
+		this.props.onCategoriesChange(categories);
+		this.setState({ editingNodeId: newNode.studioId });
+		this.props.onSelectNode(newNode.studioId);
+	}
+
+	removeNodeType(categoryStudioId, nodeStudioId) {
+		const categories = this.props.categories.map((c) => {
+			if (c.studioId === categoryStudioId) {
+				return { ...c, nodeTypes: c.nodeTypes.filter((n) => n.studioId !== nodeStudioId) };
+			}
+			return c;
+		});
+		this.props.onCategoriesChange(categories);
+		if (this.state.editingNodeId === nodeStudioId) {
+			this.setState({ editingNodeId: null });
+		}
+		if (this.props.selectedNodeStudioId === nodeStudioId) {
+			this.props.onSelectNode(null);
+		}
+	}
+
+	updateNodeType(categoryStudioId, updatedNode) {
+		const categories = this.props.categories.map((c) => {
+			if (c.studioId === categoryStudioId) {
+				return { ...c, nodeTypes: c.nodeTypes.map((n) => (n.studioId === updatedNode.studioId ? updatedNode : n)) };
+			}
+			return c;
+		});
+		this.props.onCategoriesChange(categories);
+		this.props.onNodeTypeUpdate(updatedNode);
+	}
+
+	selectNode(nodeStudioId) {
+		const editing = this.state.editingNodeId === nodeStudioId ? null : nodeStudioId;
+		this.setState({ editingNodeId: editing });
+		this.props.onSelectNode(editing);
+	}
+
+	renderNodeTypeItem(category, nodeType) {
+		const isEditing = this.state.editingNodeId === nodeType.studioId;
+		return (
+			<div key={nodeType.studioId}>
+				<div
+					className={`studio-node-type-item${nodeType.studioId === this.props.selectedNodeStudioId ? " studio-node-type-item--selected" : ""}`}
+					onClick={() => this.selectNode(nodeType.studioId)}
+					role="button"
+					tabIndex={0}
+					onKeyDown={(e) => e.key === "Enter" && this.selectNode(nodeType.studioId)}
+				>
+					<div className="studio-node-type-label">
+						{nodeType.image && <img src={nodeType.image} alt="" className="studio-node-icon-preview" />}
+						<span>{nodeType.label || "Unnamed Node"}</span>
+					</div>
+					<div className="studio-node-type-actions" onClick={(e) => e.stopPropagation()}>
+						<Button
+							kind="ghost"
+							size="sm"
+							hasIconOnly
+							renderIcon={Edit}
+							iconDescription="Edit node"
+							onClick={() => this.selectNode(nodeType.studioId)}
+						/>
+						<Button
+							kind="ghost"
+							size="sm"
+							hasIconOnly
+							renderIcon={TrashCan}
+							iconDescription="Delete node"
+							onClick={() => this.removeNodeType(category.studioId, nodeType.studioId)}
+						/>
+					</div>
+				</div>
+				{isEditing && (
+					<NodeTypeForm
+						nodeType={nodeType}
+						onChange={(updated) => this.updateNodeType(category.studioId, updated)}
+						onClose={() => this.setState({ editingNodeId: null })}
+					/>
+				)}
+			</div>
+		);
+	}
+
+	renderCategory(category) {
+		const isExpanded = Boolean(this.state.expandedCategories[category.studioId]);
+		return (
+			<div key={category.studioId} className="studio-category-item">
+				<div className="studio-category-header">
+					<div
+						className="studio-category-label"
+						onClick={() => this.toggleCategory(category.studioId)}
+						role="button"
+						tabIndex={0}
+						onKeyDown={(e) => e.key === "Enter" && this.toggleCategory(category.studioId)}
+					>
+						{isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+						{category.image && <img src={category.image} alt="" className="studio-category-icon-preview" />}
+						<span>{category.label || "Unnamed Category"}</span>
+					</div>
+					<div className="studio-category-actions">
+						<Button
+							kind="ghost"
+							size="sm"
+							hasIconOnly
+							renderIcon={TrashCan}
+							iconDescription="Delete category"
+							onClick={(e) => {
+								e.stopPropagation();
+								this.removeCategory(category.studioId);
+							}}
+						/>
+					</div>
+				</div>
+
+				{isExpanded && (
+					<div className="studio-category-body">
+						<CategoryForm
+							category={category}
+							onChange={this.updateCategory}
+						/>
+						<div className="studio-node-type-list">
+							<div className="studio-node-type-list-header">
+								<span>Node Types ({(category.nodeTypes || []).length})</span>
+								<Button
+									kind="ghost"
+									size="sm"
+									renderIcon={Add}
+									onClick={() => this.addNodeType(category.studioId)}
+								>
+									Add Node
+								</Button>
+							</div>
+							{(category.nodeTypes || []).map((nodeType) =>
+								this.renderNodeTypeItem(category, nodeType)
+							)}
+						</div>
+					</div>
+				)}
+			</div>
+		);
+	}
+
+	render() {
+		return (
+			<div className="studio-palette-builder">
+				<div className="studio-section-actions">
+					<Button kind="primary" size="sm" renderIcon={Add} onClick={this.addCategory}>
+						Add Category
+					</Button>
+				</div>
+				{this.props.categories.length === 0 && (
+					<div className="studio-no-node-placeholder">
+						<p>No categories yet.</p>
+						<p>Click &quot;Add Category&quot; to get started.</p>
+					</div>
+				)}
+				{this.props.categories.map((cat) => this.renderCategory(cat))}
+			</div>
+		);
+	}
+}
+
+PaletteBuilder.propTypes = {
+	categories: PropTypes.array.isRequired,
+	selectedNodeStudioId: PropTypes.string,
+	onCategoriesChange: PropTypes.func.isRequired,
+	onSelectNode: PropTypes.func.isRequired,
+	onNodeTypeUpdate: PropTypes.func.isRequired
+};

--- a/canvas_modules/harness/src/client/components/studio/palette-builder/PortsEditor.jsx
+++ b/canvas_modules/harness/src/client/components/studio/palette-builder/PortsEditor.jsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { Button, TextInput } from "@carbon/react";
+import { Add, TrashCan } from "@carbon/react/icons";
+import { v4 as uuid4 } from "uuid";
+
+export default class PortsEditor extends React.Component {
+	constructor(props) {
+		super(props);
+		this.handleLabelChange = this.handleLabelChange.bind(this);
+		this.handleCardinalityChange = this.handleCardinalityChange.bind(this);
+		this.addPort = this.addPort.bind(this);
+		this.removePort = this.removePort.bind(this);
+	}
+
+	handleLabelChange(portId, label) {
+		const ports = this.props.ports.map((p) =>
+			(p.portId === portId ? { ...p, label } : p)
+		);
+		this.props.onChange(ports);
+	}
+
+	handleCardinalityChange(portId, field, value) {
+		const numVal = parseInt(value, 10);
+		const ports = this.props.ports.map((p) =>
+			(p.portId === portId ? { ...p, [field]: isNaN(numVal) ? 0 : numVal } : p)
+		);
+		this.props.onChange(ports);
+	}
+
+	addPort() {
+		const portIndex = this.props.ports.length;
+		const newPort = {
+			portId: uuid4(),
+			label: `${this.props.portType === "input" ? "Input" : "Output"} ${portIndex}`,
+			cardinalityMin: 0,
+			cardinalityMax: 1
+		};
+		this.props.onChange([...this.props.ports, newPort]);
+	}
+
+	removePort(portId) {
+		this.props.onChange(this.props.ports.filter((p) => p.portId !== portId));
+	}
+
+	render() {
+		const { ports, portType } = this.props;
+		const label = portType === "input" ? "Inputs" : "Outputs";
+
+		return (
+			<div className="studio-ports-editor">
+				<div className="studio-ports-section-label">{label}</div>
+				{ports.map((port) => (
+					<div key={port.portId} className="studio-port-row">
+						<TextInput
+							id={`port-label-${port.portId}`}
+							labelText="Label"
+							value={port.label}
+							size="sm"
+							onChange={(e) => this.handleLabelChange(port.portId, e.target.value)}
+						/>
+						<div className="studio-port-num">
+							<label className="studio-port-num-label" htmlFor={`port-min-${port.portId}`}>Min</label>
+							<input
+								id={`port-min-${port.portId}`}
+								type="number"
+								className="studio-port-num-input"
+								value={port.cardinalityMin}
+								min={0}
+								onChange={(e) => this.handleCardinalityChange(port.portId, "cardinalityMin", e.target.value)}
+							/>
+						</div>
+						<div className="studio-port-num">
+							<label className="studio-port-num-label" htmlFor={`port-max-${port.portId}`}>Max (-1=∞)</label>
+							<input
+								id={`port-max-${port.portId}`}
+								type="number"
+								className="studio-port-num-input"
+								value={port.cardinalityMax}
+								min={-1}
+								onChange={(e) => this.handleCardinalityChange(port.portId, "cardinalityMax", e.target.value)}
+							/>
+						</div>
+						<Button
+							kind="ghost"
+							size="sm"
+							iconDescription="Remove port"
+							hasIconOnly
+							renderIcon={TrashCan}
+							onClick={() => this.removePort(port.portId)}
+						/>
+					</div>
+				))}
+				<Button
+					kind="ghost"
+					size="sm"
+					renderIcon={Add}
+					className="studio-add-port-btn"
+					onClick={this.addPort}
+				>
+					Add {portType}
+				</Button>
+			</div>
+		);
+	}
+}
+
+PortsEditor.propTypes = {
+	ports: PropTypes.array.isRequired,
+	portType: PropTypes.string.isRequired,
+	onChange: PropTypes.func.isRequired
+};

--- a/canvas_modules/harness/src/client/components/studio/palette-builder/PortsEditor.jsx
+++ b/canvas_modules/harness/src/client/components/studio/palette-builder/PortsEditor.jsx
@@ -38,8 +38,12 @@ export default class PortsEditor extends React.Component {
 
 	handleCardinalityChange(portId, field, value) {
 		const numVal = parseInt(value, 10);
+		let stored = null;
+		if (value !== "") {
+			stored = isNaN(numVal) ? 0 : numVal;
+		}
 		const ports = this.props.ports.map((p) =>
-			(p.portId === portId ? { ...p, [field]: isNaN(numVal) ? 0 : numVal } : p)
+			(p.portId === portId ? { ...p, [field]: stored } : p)
 		);
 		this.props.onChange(ports);
 	}
@@ -81,7 +85,7 @@ export default class PortsEditor extends React.Component {
 								id={`port-min-${port.portId}`}
 								type="number"
 								className="studio-port-num-input"
-								value={port.cardinalityMin}
+								value={port.cardinalityMin ?? ""}
 								min={0}
 								onChange={(e) => this.handleCardinalityChange(port.portId, "cardinalityMin", e.target.value)}
 							/>
@@ -92,7 +96,7 @@ export default class PortsEditor extends React.Component {
 								id={`port-max-${port.portId}`}
 								type="number"
 								className="studio-port-num-input"
-								value={port.cardinalityMax}
+								value={port.cardinalityMax ?? ""}
 								min={-1}
 								onChange={(e) => this.handleCardinalityChange(port.portId, "cardinalityMax", e.target.value)}
 							/>

--- a/canvas_modules/harness/src/client/components/studio/preview/StudioCanvas.jsx
+++ b/canvas_modules/harness/src/client/components/studio/preview/StudioCanvas.jsx
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { Select, SelectItem, Toggle } from "@carbon/react";
+import { CommonCanvas, CanvasController, CommonProperties } from "common-canvas"; // eslint-disable-line import/no-unresolved
+import propertiesGenerator from "../utils/properties-generator";
+
+const NOOP = () => null;
+
+const LINK_TYPES = ["Curve", "Elbow", "Straight", "Parallax"];
+const LINK_DIRECTIONS = ["LeftRight", "TopBottom", "BottomTop", "RightLeft"];
+const LINK_METHODS = ["Ports", "Freeform"];
+const SNAP_TYPES = ["None", "During", "After"];
+
+export default class StudioCanvas extends React.Component {
+	constructor(props) {
+		super(props);
+		this.canvasController = new CanvasController();
+		this.state = { showProperties: false, propertiesData: null };
+		this.clickActionHandler = this.clickActionHandler.bind(this);
+		this.editActionHandler = this.editActionHandler.bind(this);
+	}
+
+	componentDidMount() {
+		if (this.props.paletteJSON) {
+			this.canvasController.setPipelineFlowPalette(this.props.paletteJSON);
+		}
+	}
+
+	componentDidUpdate(prevProps) {
+		if (prevProps.paletteJSON !== this.props.paletteJSON) {
+			this.canvasController.setPipelineFlowPalette(this.props.paletteJSON);
+		}
+	}
+
+	getCanvasConfig() {
+		const { canvasConfig } = this.props;
+		return {
+			enableParentClass: "studio-canvas",
+			enableSnapToGridType: canvasConfig.enableSnapToGridType || "None",
+			enableLinkType: canvasConfig.enableLinkType || "Curve",
+			enableLinkDirection: canvasConfig.enableLinkDirection || "LeftRight",
+			enableLinkMethod: canvasConfig.enableLinkMethod || "Ports",
+			enablePaletteLayout: canvasConfig.enablePaletteLayout || "Flyout",
+			enableNarrowPalette: Boolean(canvasConfig.enableNarrowPalette),
+			paletteInitialState: true,
+			enableRightFlyoutUnderToolbar: true,
+			tipConfig: { palette: true, nodes: true, ports: false, links: false }
+		};
+	}
+
+	clickActionHandler(source) {
+		if (source.clickType === "DOUBLE_CLICK" && source.objectType === "node") {
+			const node = this.canvasController.getNode(source.id, this.canvasController.getPrimaryPipelineId());
+			if (node) {
+				// Canvas node instances get a fresh UUID as their id — match back to the
+				// node type definition via op (which equals studioId when no op was set).
+				const nodeOp = node.op;
+				let matchedStudioId = null;
+				let nodeLabel = "";
+				let matchedOp = "";
+				(this.props.categories || []).forEach((cat) => {
+					(cat.nodeTypes || []).forEach((nt) => {
+						if ((nt.op || nt.studioId) === nodeOp) {
+							matchedStudioId = nt.studioId;
+							nodeLabel = nt.label;
+							matchedOp = nt.op;
+						}
+					});
+				});
+				const paramDef = matchedStudioId && this.props.paramDefs && this.props.paramDefs[matchedStudioId];
+				if (paramDef) {
+					this.setState({
+						showProperties: true,
+						propertiesData: propertiesGenerator(paramDef, nodeLabel, matchedOp)
+					});
+				}
+			}
+		}
+	}
+
+	editActionHandler() {
+		return null;
+	}
+
+	render() {
+		const { canvasConfig, onCanvasConfigChange } = this.props;
+		const { showProperties, propertiesData } = this.state;
+
+		return (
+			<div className="studio-canvas-column">
+				<div className="studio-canvas-config">
+					<div className="studio-config-row">
+						<span>Snap:</span>
+						<Select id="config-snap" labelText="" value={canvasConfig.enableSnapToGridType || "None"} size="sm"
+							onChange={(e) => onCanvasConfigChange("enableSnapToGridType", e.target.value)}
+						>
+							{SNAP_TYPES.map((v) => <SelectItem key={v} value={v} text={v} />)}
+						</Select>
+					</div>
+					<div className="studio-config-row">
+						<span>Links:</span>
+						<Select id="config-link-type" labelText="" value={canvasConfig.enableLinkType || "Curve"} size="sm"
+							onChange={(e) => onCanvasConfigChange("enableLinkType", e.target.value)}
+						>
+							{LINK_TYPES.map((v) => <SelectItem key={v} value={v} text={v} />)}
+						</Select>
+					</div>
+					<div className="studio-config-row">
+						<span>Direction:</span>
+						<Select id="config-link-dir" labelText="" value={canvasConfig.enableLinkDirection || "LeftRight"} size="sm"
+							onChange={(e) => onCanvasConfigChange("enableLinkDirection", e.target.value)}
+						>
+							{LINK_DIRECTIONS.map((v) => <SelectItem key={v} value={v} text={v} />)}
+						</Select>
+					</div>
+					<div className="studio-config-row">
+						<span>Method:</span>
+						<Select id="config-link-method" labelText="" value={canvasConfig.enableLinkMethod || "Ports"} size="sm"
+							onChange={(e) => onCanvasConfigChange("enableLinkMethod", e.target.value)}
+						>
+							{LINK_METHODS.map((v) => <SelectItem key={v} value={v} text={v} />)}
+						</Select>
+					</div>
+					<div className="studio-config-row">
+						<Toggle
+							id="config-narrow-palette"
+							labelText="Narrow palette"
+							toggled={Boolean(canvasConfig.enableNarrowPalette)}
+							size="sm"
+							onToggle={(v) => onCanvasConfigChange("enableNarrowPalette", v)}
+						/>
+					</div>
+				</div>
+
+				<div className="studio-canvas-preview">
+					<CommonCanvas
+						canvasController={this.canvasController}
+						config={this.getCanvasConfig()}
+						clickActionHandler={this.clickActionHandler}
+						editActionHandler={this.editActionHandler}
+						rightFlyoutContent={showProperties && propertiesData ? (
+							<CommonProperties
+								propertiesInfo={{ parameterDef: propertiesData }}
+								propertiesConfig={{ containerType: "Custom", rightFlyout: true, applyOnBlur: true }}
+								callbacks={{
+									closePropertiesDialog: () => this.setState({ showProperties: false, propertiesData: null }),
+									applyPropertyChanges: NOOP
+								}}
+							/>
+						) : null}
+						showRightFlyout={showProperties && propertiesData !== null}
+					/>
+				</div>
+			</div>
+		);
+	}
+}
+
+StudioCanvas.propTypes = {
+	paletteJSON: PropTypes.object,
+	paramDefs: PropTypes.object,
+	categories: PropTypes.array,
+	canvasConfig: PropTypes.object.isRequired,
+	onCanvasConfigChange: PropTypes.func.isRequired
+};

--- a/canvas_modules/harness/src/client/components/studio/preview/StudioCanvas.jsx
+++ b/canvas_modules/harness/src/client/components/studio/preview/StudioCanvas.jsx
@@ -35,7 +35,8 @@ export default class StudioCanvas extends React.Component {
 			propertiesData: null,
 			propertiesNodeLabel: "",
 			currentPropertiesStudioId: null,
-			savedValues: {}
+			savedValues: {},
+			flyoutExpanded: false
 		};
 		this.clickActionHandler = this.clickActionHandler.bind(this);
 		this.editActionHandler = this.editActionHandler.bind(this);
@@ -109,6 +110,7 @@ export default class StudioCanvas extends React.Component {
 					}
 					this.setState({
 						showProperties: true,
+						flyoutExpanded: false,
 						currentPropertiesStudioId: matchedStudioId,
 						propertiesNodeLabel: nodeLabel || matchedOp || "Node Properties",
 						propertiesData
@@ -125,11 +127,16 @@ export default class StudioCanvas extends React.Component {
 
 	render() {
 		const { canvasConfig, onCanvasConfigChange } = this.props;
-		const { showProperties, propertiesData, propertiesNodeLabel, currentPropertiesStudioId } = this.state;
+		const { showProperties, propertiesData, propertiesNodeLabel, currentPropertiesStudioId, flyoutExpanded } = this.state;
 		const closeProperties = () => this.setState({ showProperties: false, propertiesData: null });
 		const saveProperties = (paramValues) => this.setState((prev) => ({
 			savedValues: { ...prev.savedValues, [currentPropertiesStudioId]: paramValues }
 		}));
+		const onFlyoutClick = (e) => {
+			if (e.target.closest(".properties-btn-resize")) {
+				this.setState((prev) => ({ flyoutExpanded: !prev.flyoutExpanded }));
+			}
+		};
 
 		return (
 			<div className="studio-canvas-column">
@@ -183,7 +190,12 @@ export default class StudioCanvas extends React.Component {
 						config={this.getCanvasConfig()}
 						clickActionHandler={this.clickActionHandler}
 						editActionHandler={this.editActionHandler}
-						rightFlyoutContent={showProperties && propertiesData ? (
+					/>
+					{showProperties && propertiesData && (
+						<div
+							className={`studio-flyout-overlay${flyoutExpanded ? " studio-flyout-overlay--expanded" : ""}`}
+							onClick={onFlyoutClick}
+						>
 							<div className="studio-flyout-panel">
 								<div className="studio-flyout-header">
 									<span className="studio-flyout-title">{propertiesNodeLabel}</span>
@@ -207,9 +219,8 @@ export default class StudioCanvas extends React.Component {
 									<Button kind="primary" onClick={closeProperties}>Save</Button>
 								</div>
 							</div>
-						) : null}
-						showRightFlyout={showProperties && propertiesData !== null}
-					/>
+						</div>
+					)}
 				</div>
 			</div>
 		);

--- a/canvas_modules/harness/src/client/components/studio/preview/StudioCanvas.jsx
+++ b/canvas_modules/harness/src/client/components/studio/preview/StudioCanvas.jsx
@@ -46,6 +46,10 @@ export default class StudioCanvas extends React.Component {
 		if (prevProps.paletteJSON !== this.props.paletteJSON) {
 			this.canvasController.setPipelineFlowPalette(this.props.paletteJSON);
 		}
+		if (prevProps.importedFlow !== this.props.importedFlow && this.props.importedFlow) {
+			this.canvasController.setPipelineFlow(this.props.importedFlow);
+			this.props.onFlowImported();
+		}
 	}
 
 	getCanvasConfig() {
@@ -95,6 +99,7 @@ export default class StudioCanvas extends React.Component {
 	}
 
 	editActionHandler() {
+		this.props.onFlowChange(this.canvasController.getPipelineFlow());
 		return null;
 	}
 
@@ -177,5 +182,8 @@ StudioCanvas.propTypes = {
 	paramDefs: PropTypes.object,
 	categories: PropTypes.array,
 	canvasConfig: PropTypes.object.isRequired,
-	onCanvasConfigChange: PropTypes.func.isRequired
+	onCanvasConfigChange: PropTypes.func.isRequired,
+	importedFlow: PropTypes.object,
+	onFlowChange: PropTypes.func.isRequired,
+	onFlowImported: PropTypes.func.isRequired
 };

--- a/canvas_modules/harness/src/client/components/studio/preview/StudioCanvas.jsx
+++ b/canvas_modules/harness/src/client/components/studio/preview/StudioCanvas.jsx
@@ -48,8 +48,13 @@ export default class StudioCanvas extends React.Component {
 		}
 		if (prevProps.importedFlow !== this.props.importedFlow && this.props.importedFlow) {
 			this.canvasController.setPipelineFlow(this.props.importedFlow);
+			setTimeout(() => this.canvasController.zoomToFit(), 50);
 			this.props.onFlowImported();
 		}
+	}
+
+	getFlow() {
+		return this.canvasController.getPipelineFlow();
 	}
 
 	getCanvasConfig() {

--- a/canvas_modules/harness/src/client/components/studio/preview/StudioCanvas.jsx
+++ b/canvas_modules/harness/src/client/components/studio/preview/StudioCanvas.jsx
@@ -16,11 +16,10 @@
 
 import React from "react";
 import PropTypes from "prop-types";
-import { Select, SelectItem, Toggle } from "@carbon/react";
+import { Button, Select, SelectItem, Toggle } from "@carbon/react";
+import { Close } from "@carbon/react/icons";
 import { CommonCanvas, CanvasController, CommonProperties } from "common-canvas"; // eslint-disable-line import/no-unresolved
 import propertiesGenerator from "../utils/properties-generator";
-
-const NOOP = () => null;
 
 const LINK_TYPES = ["Curve", "Elbow", "Straight", "Parallax"];
 const LINK_DIRECTIONS = ["LeftRight", "TopBottom", "BottomTop", "RightLeft"];
@@ -31,7 +30,13 @@ export default class StudioCanvas extends React.Component {
 	constructor(props) {
 		super(props);
 		this.canvasController = new CanvasController();
-		this.state = { showProperties: false, propertiesData: null };
+		this.state = {
+			showProperties: false,
+			propertiesData: null,
+			propertiesNodeLabel: "",
+			currentPropertiesStudioId: null,
+			savedValues: {}
+		};
 		this.clickActionHandler = this.clickActionHandler.bind(this);
 		this.editActionHandler = this.editActionHandler.bind(this);
 	}
@@ -94,9 +99,19 @@ export default class StudioCanvas extends React.Component {
 				});
 				const paramDef = matchedStudioId && this.props.paramDefs && this.props.paramDefs[matchedStudioId];
 				if (paramDef) {
+					let propertiesData = propertiesGenerator(paramDef, nodeLabel, matchedOp);
+					const saved = this.state.savedValues[matchedStudioId];
+					if (saved) {
+						propertiesData = {
+							...propertiesData,
+							current_parameters: { ...propertiesData.current_parameters, ...saved }
+						};
+					}
 					this.setState({
 						showProperties: true,
-						propertiesData: propertiesGenerator(paramDef, nodeLabel, matchedOp)
+						currentPropertiesStudioId: matchedStudioId,
+						propertiesNodeLabel: nodeLabel || matchedOp || "Node Properties",
+						propertiesData
 					});
 				}
 			}
@@ -110,7 +125,11 @@ export default class StudioCanvas extends React.Component {
 
 	render() {
 		const { canvasConfig, onCanvasConfigChange } = this.props;
-		const { showProperties, propertiesData } = this.state;
+		const { showProperties, propertiesData, propertiesNodeLabel, currentPropertiesStudioId } = this.state;
+		const closeProperties = () => this.setState({ showProperties: false, propertiesData: null });
+		const saveProperties = (paramValues) => this.setState((prev) => ({
+			savedValues: { ...prev.savedValues, [currentPropertiesStudioId]: paramValues }
+		}));
 
 		return (
 			<div className="studio-canvas-column">
@@ -165,14 +184,29 @@ export default class StudioCanvas extends React.Component {
 						clickActionHandler={this.clickActionHandler}
 						editActionHandler={this.editActionHandler}
 						rightFlyoutContent={showProperties && propertiesData ? (
-							<CommonProperties
-								propertiesInfo={{ parameterDef: propertiesData }}
-								propertiesConfig={{ containerType: "Custom", rightFlyout: true, applyOnBlur: true }}
-								callbacks={{
-									closePropertiesDialog: () => this.setState({ showProperties: false, propertiesData: null }),
-									applyPropertyChanges: NOOP
-								}}
-							/>
+							<div className="studio-flyout-panel">
+								<div className="studio-flyout-header">
+									<span className="studio-flyout-title">{propertiesNodeLabel}</span>
+									<button
+										type="button"
+										className="studio-flyout-close-btn"
+										aria-label="Close"
+										title="Close"
+										onClick={closeProperties}
+									>
+										<Close size={16} />
+									</button>
+								</div>
+								<CommonProperties
+									propertiesInfo={{ parameterDef: propertiesData }}
+									propertiesConfig={{ containerType: "Custom", rightFlyout: true, applyOnBlur: true }}
+									callbacks={{ closePropertiesDialog: closeProperties, applyPropertyChanges: saveProperties }}
+								/>
+								<div className="studio-flyout-footer">
+									<Button kind="secondary" onClick={closeProperties}>Cancel</Button>
+									<Button kind="primary" onClick={closeProperties}>Save</Button>
+								</div>
+							</div>
 						) : null}
 						showRightFlyout={showProperties && propertiesData !== null}
 					/>

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/ActionsBuilder.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/ActionsBuilder.jsx
@@ -27,6 +27,7 @@ export default class ActionsBuilder extends React.Component {
 		this.addAction = this.addAction.bind(this);
 		this.removeAction = this.removeAction.bind(this);
 		this.updateAction = this.updateAction.bind(this);
+		this.updateActionSize = this.updateActionSize.bind(this);
 		this.toggleExpanded = this.toggleExpanded.bind(this);
 	}
 
@@ -49,6 +50,11 @@ export default class ActionsBuilder extends React.Component {
 
 	removeAction(actionId) {
 		this.props.onChange((this.props.actions || []).filter((a) => a.actionId !== actionId));
+	}
+
+	updateActionSize(actionId, field, rawValue) {
+		const parsed = parseInt(rawValue, 10);
+		this.updateAction(actionId, field, rawValue === "" ? null : Math.max(1, parsed || 1));
 	}
 
 	updateAction(actionId, field, value) {
@@ -198,9 +204,9 @@ export default class ActionsBuilder extends React.Component {
 													id={`action-width-${action.actionId}`}
 													type="number"
 													className="studio-port-num-input"
-													value={action.width || 25}
+													value={action.width ?? ""}
 													min={1}
-													onChange={(e) => this.updateAction(action.actionId, "width", parseInt(e.target.value, 10) || 25)}
+													onChange={(e) => this.updateActionSize(action.actionId, "width", e.target.value)}
 												/>
 											</div>
 											<div className="studio-port-num">
@@ -209,9 +215,9 @@ export default class ActionsBuilder extends React.Component {
 													id={`action-height-${action.actionId}`}
 													type="number"
 													className="studio-port-num-input"
-													value={action.height || 20}
+													value={action.height ?? ""}
 													min={1}
-													onChange={(e) => this.updateAction(action.actionId, "height", parseInt(e.target.value, 10) || 20)}
+													onChange={(e) => this.updateActionSize(action.actionId, "height", e.target.value)}
 												/>
 											</div>
 										</div>

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/ActionsBuilder.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/ActionsBuilder.jsx
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { Button, TextInput, Select, SelectItem } from "@carbon/react";
+import { Add, ChevronDown, ChevronUp, TrashCan } from "@carbon/react/icons";
+import { v4 as uuid4 } from "uuid";
+
+export default class ActionsBuilder extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = { expanded: {} };
+		this.addAction = this.addAction.bind(this);
+		this.removeAction = this.removeAction.bind(this);
+		this.updateAction = this.updateAction.bind(this);
+		this.toggleExpanded = this.toggleExpanded.bind(this);
+	}
+
+	addAction() {
+		const newAction = {
+			actionId: uuid4(),
+			id: "",
+			label: "",
+			description: "",
+			imageUrl: "",
+			placement: "right",
+			width: 25,
+			height: 20
+		};
+		this.props.onChange([...(this.props.actions || []), newAction]);
+		this.setState((prev) => ({ expanded: { ...prev.expanded, [newAction.actionId]: true } }));
+	}
+
+	removeAction(actionId) {
+		this.props.onChange((this.props.actions || []).filter((a) => a.actionId !== actionId));
+	}
+
+	updateAction(actionId, field, value) {
+		const updated = (this.props.actions || []).map((a) => {
+			if (a.actionId !== actionId) {
+				return a;
+			}
+			return { ...a, [field]: value };
+		});
+		this.props.onChange(updated);
+	}
+
+	toggleExpanded(actionId) {
+		this.setState((prev) => ({
+			expanded: { ...prev.expanded, [actionId]: !prev.expanded[actionId] }
+		}));
+	}
+
+	render() {
+		const { actions } = this.props;
+		const { expanded } = this.state;
+
+		return (
+			<div className="studio-actions-builder">
+				<div className="studio-subsection-header">
+					<span>Actions (icon / button beside fields)</span>
+					<Button kind="ghost" size="sm" renderIcon={Add} onClick={this.addAction}>
+						Add Action
+					</Button>
+				</div>
+
+				{(!actions || actions.length === 0) && (
+					<div className="studio-placeholder-text">
+						No actions yet. Actions are image icons or buttons that appear beside a field.
+						Add one here, then set its ID on the parameter that should show it.
+					</div>
+				)}
+
+				{(actions || []).map((action) => (
+					<div key={action.actionId} className="studio-action-item">
+						<div
+							className="studio-action-header"
+							onClick={() => this.toggleExpanded(action.actionId)}
+							role="button"
+							tabIndex={0}
+							onKeyDown={(e) => e.key === "Enter" && this.toggleExpanded(action.actionId)}
+						>
+							<div className="studio-action-header-label">
+								{expanded[action.actionId]
+									? <ChevronUp size={14} />
+									: <ChevronDown size={14} />
+								}
+								<span>{action.id || "(unnamed action)"}</span>
+								{action.imageUrl && (
+									<img src={action.imageUrl} alt="" className="studio-action-img-preview" />
+								)}
+							</div>
+							<Button
+								kind="ghost"
+								size="sm"
+								hasIconOnly
+								renderIcon={TrashCan}
+								iconDescription="Remove action"
+								onClick={(e) => {
+									e.stopPropagation();
+									this.removeAction(action.actionId);
+								}}
+							/>
+						</div>
+
+						{expanded[action.actionId] && (
+							<div className="studio-action-form">
+								<div className="studio-form-field">
+									<TextInput
+										id={`action-id-${action.actionId}`}
+										labelText="Action ID (referenced by parameter's action_ref)"
+										placeholder="moon_right"
+										value={action.id || ""}
+										size="sm"
+										onChange={(e) => this.updateAction(action.actionId, "id", e.target.value.replace(/\s+/g, "_"))}
+									/>
+								</div>
+
+								<div className="studio-form-field">
+									<TextInput
+										id={`action-label-${action.actionId}`}
+										labelText="Label (tooltip title)"
+										value={action.label || ""}
+										size="sm"
+										onChange={(e) => this.updateAction(action.actionId, "label", e.target.value)}
+									/>
+								</div>
+
+								<div className="studio-form-field">
+									<TextInput
+										id={`action-desc-${action.actionId}`}
+										labelText="Description (tooltip body)"
+										value={action.description || ""}
+										size="sm"
+										onChange={(e) => this.updateAction(action.actionId, "description", e.target.value)}
+									/>
+								</div>
+
+								<div className="studio-form-field">
+									<TextInput
+										id={`action-url-${action.actionId}`}
+										labelText="Image URL"
+										placeholder="/images/moon.jpg"
+										value={action.imageUrl || ""}
+										size="sm"
+										onChange={(e) => this.updateAction(action.actionId, "imageUrl", e.target.value)}
+									/>
+								</div>
+
+								<div className="studio-form-field">
+									<Select
+										id={`action-placement-${action.actionId}`}
+										labelText="Placement"
+										value={action.placement || "right"}
+										size="sm"
+										onChange={(e) => this.updateAction(action.actionId, "placement", e.target.value)}
+									>
+										<SelectItem value="right" text="Right of field" />
+										<SelectItem value="left" text="Left of field" />
+									</Select>
+								</div>
+
+								<div className="studio-two-col-row">
+									<div className="studio-port-num">
+										<label className="studio-port-num-label" htmlFor={`action-width-${action.actionId}`}>Width (px)</label>
+										<input
+											id={`action-width-${action.actionId}`}
+											type="number"
+											className="studio-port-num-input"
+											value={action.width || 25}
+											min={1}
+											onChange={(e) => this.updateAction(action.actionId, "width", parseInt(e.target.value, 10) || 25)}
+										/>
+									</div>
+									<div className="studio-port-num">
+										<label className="studio-port-num-label" htmlFor={`action-height-${action.actionId}`}>Height (px)</label>
+										<input
+											id={`action-height-${action.actionId}`}
+											type="number"
+											className="studio-port-num-input"
+											value={action.height || 20}
+											min={1}
+											onChange={(e) => this.updateAction(action.actionId, "height", parseInt(e.target.value, 10) || 20)}
+										/>
+									</div>
+								</div>
+							</div>
+						)}
+					</div>
+				))}
+			</div>
+		);
+	}
+}
+
+ActionsBuilder.propTypes = {
+	actions: PropTypes.array,
+	onChange: PropTypes.func.isRequired
+};

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/ActionsBuilder.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/ActionsBuilder.jsx
@@ -34,12 +34,14 @@ export default class ActionsBuilder extends React.Component {
 		const newAction = {
 			actionId: uuid4(),
 			id: "",
+			controlType: "image",
 			label: "",
 			description: "",
 			imageUrl: "",
 			placement: "right",
 			width: 25,
-			height: 20
+			height: 20,
+			paramRef: ""
 		};
 		this.props.onChange([...(this.props.actions || []), newAction]);
 		this.setState((prev) => ({ expanded: { ...prev.expanded, [newAction.actionId]: true } }));
@@ -120,6 +122,19 @@ export default class ActionsBuilder extends React.Component {
 						{expanded[action.actionId] && (
 							<div className="studio-action-form">
 								<div className="studio-form-field">
+									<Select
+										id={`action-type-${action.actionId}`}
+										labelText="Action type"
+										value={action.controlType || "image"}
+										size="sm"
+										onChange={(e) => this.updateAction(action.actionId, "controlType", e.target.value)}
+									>
+										<SelectItem value="image" text="Image / icon" />
+										<SelectItem value="button" text="Button" />
+									</Select>
+								</div>
+
+								<div className="studio-form-field">
 									<TextInput
 										id={`action-id-${action.actionId}`}
 										labelText="Action ID (referenced by parameter's action_ref)"
@@ -150,54 +165,71 @@ export default class ActionsBuilder extends React.Component {
 									/>
 								</div>
 
-								<div className="studio-form-field">
-									<TextInput
-										id={`action-url-${action.actionId}`}
-										labelText="Image URL"
-										placeholder="/images/moon.jpg"
-										value={action.imageUrl || ""}
-										size="sm"
-										onChange={(e) => this.updateAction(action.actionId, "imageUrl", e.target.value)}
-									/>
-								</div>
+								{(action.controlType || "image") === "image" && (
+									<>
+										<div className="studio-form-field">
+											<TextInput
+												id={`action-url-${action.actionId}`}
+												labelText="Image URL"
+												placeholder="/images/moon.jpg"
+												value={action.imageUrl || ""}
+												size="sm"
+												onChange={(e) => this.updateAction(action.actionId, "imageUrl", e.target.value)}
+											/>
+										</div>
 
-								<div className="studio-form-field">
-									<Select
-										id={`action-placement-${action.actionId}`}
-										labelText="Placement"
-										value={action.placement || "right"}
-										size="sm"
-										onChange={(e) => this.updateAction(action.actionId, "placement", e.target.value)}
-									>
-										<SelectItem value="right" text="Right of field" />
-										<SelectItem value="left" text="Left of field" />
-									</Select>
-								</div>
+										<div className="studio-form-field">
+											<Select
+												id={`action-placement-${action.actionId}`}
+												labelText="Placement"
+												value={action.placement || "right"}
+												size="sm"
+												onChange={(e) => this.updateAction(action.actionId, "placement", e.target.value)}
+											>
+												<SelectItem value="right" text="Right of field" />
+												<SelectItem value="left" text="Left of field" />
+											</Select>
+										</div>
 
-								<div className="studio-two-col-row">
-									<div className="studio-port-num">
-										<label className="studio-port-num-label" htmlFor={`action-width-${action.actionId}`}>Width (px)</label>
-										<input
-											id={`action-width-${action.actionId}`}
-											type="number"
-											className="studio-port-num-input"
-											value={action.width || 25}
-											min={1}
-											onChange={(e) => this.updateAction(action.actionId, "width", parseInt(e.target.value, 10) || 25)}
+										<div className="studio-two-col-row">
+											<div className="studio-port-num">
+												<label className="studio-port-num-label" htmlFor={`action-width-${action.actionId}`}>Width (px)</label>
+												<input
+													id={`action-width-${action.actionId}`}
+													type="number"
+													className="studio-port-num-input"
+													value={action.width || 25}
+													min={1}
+													onChange={(e) => this.updateAction(action.actionId, "width", parseInt(e.target.value, 10) || 25)}
+												/>
+											</div>
+											<div className="studio-port-num">
+												<label className="studio-port-num-label" htmlFor={`action-height-${action.actionId}`}>Height (px)</label>
+												<input
+													id={`action-height-${action.actionId}`}
+													type="number"
+													className="studio-port-num-input"
+													value={action.height || 20}
+													min={1}
+													onChange={(e) => this.updateAction(action.actionId, "height", parseInt(e.target.value, 10) || 20)}
+												/>
+											</div>
+										</div>
+									</>
+								)}
+
+								{(action.controlType || "image") === "button" && (
+									<div className="studio-form-field">
+										<TextInput
+											id={`action-paramref-${action.actionId}`}
+											labelText="Parameter ref (optional — links button to a parameter)"
+											placeholder="my_param"
+											value={action.paramRef || ""}
+											size="sm"
+											onChange={(e) => this.updateAction(action.actionId, "paramRef", e.target.value)}
 										/>
 									</div>
-									<div className="studio-port-num">
-										<label className="studio-port-num-label" htmlFor={`action-height-${action.actionId}`}>Height (px)</label>
-										<input
-											id={`action-height-${action.actionId}`}
-											type="number"
-											className="studio-port-num-input"
-											value={action.height || 20}
-											min={1}
-											onChange={(e) => this.updateAction(action.actionId, "height", parseInt(e.target.value, 10) || 20)}
-										/>
-									</div>
-								</div>
+								)}
 							</div>
 						)}
 					</div>

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/ConditionsBuilder.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/ConditionsBuilder.jsx
@@ -20,6 +20,12 @@ import { Button, Select, SelectItem, TextInput } from "@carbon/react";
 import { Add, TrashCan } from "@carbon/react/icons";
 import { v4 as uuid4 } from "uuid";
 
+const CONDITION_TYPES = [
+	{ value: "validation", label: "Validation error" },
+	{ value: "enabled", label: "Enable / disable a field" },
+	{ value: "visible", label: "Show / hide a field" }
+];
+
 const CONDITION_OPS = [
 	{ value: "isNotEmpty", label: "is not empty" },
 	{ value: "isEmpty", label: "is empty" },
@@ -49,7 +55,9 @@ export default class ConditionsBuilder extends React.Component {
 	addCondition() {
 		const newCondition = {
 			conditionId: uuid4(),
+			conditionType: "validation",
 			paramRef: (this.props.parameters && this.props.parameters[0] && this.props.parameters[0].id) || "",
+			targetParamRef: "",
 			op: "isNotEmpty",
 			value: "",
 			errorMessage: "This field is required."
@@ -90,64 +98,97 @@ export default class ConditionsBuilder extends React.Component {
 					</div>
 				)}
 
-				{(conditions || []).map((cond) => (
-					<div key={cond.conditionId} className="studio-condition-row">
-						<div className="studio-condition-fields">
-							<Select
-								id={`cond-param-${cond.conditionId}`}
-								labelText="Parameter"
-								value={cond.paramRef || ""}
-								size="sm"
-								onChange={(e) => this.updateCondition(cond.conditionId, "paramRef", e.target.value)}
-							>
-								<SelectItem value="" text="— pick parameter —" />
-								{paramOptions.map((p) => (
-									<SelectItem key={p.paramId} value={p.id} text={p.displayName || p.id} />
-								))}
-							</Select>
-
-							<Select
-								id={`cond-op-${cond.conditionId}`}
-								labelText="Rule"
-								value={cond.op || "isNotEmpty"}
-								size="sm"
-								onChange={(e) => this.updateCondition(cond.conditionId, "op", e.target.value)}
-							>
-								{CONDITION_OPS.map((op) => (
-									<SelectItem key={op.value} value={op.value} text={op.label} />
-								))}
-							</Select>
-
-							{OPS_NEEDING_VALUE.has(cond.op) && (
-								<TextInput
-									id={`cond-val-${cond.conditionId}`}
-									labelText="Value"
-									value={cond.value || ""}
+				{(conditions || []).map((cond) => {
+					const condType = cond.conditionType || "validation";
+					const isEnabledVisible = condType === "enabled" || condType === "visible";
+					return (
+						<div key={cond.conditionId} className="studio-condition-row">
+							<div className="studio-condition-fields">
+								<Select
+									id={`cond-type-${cond.conditionId}`}
+									labelText="Condition type"
+									value={condType}
 									size="sm"
-									onChange={(e) => this.updateCondition(cond.conditionId, "value", e.target.value)}
-								/>
-							)}
+									onChange={(e) => this.updateCondition(cond.conditionId, "conditionType", e.target.value)}
+								>
+									{CONDITION_TYPES.map((t) => (
+										<SelectItem key={t.value} value={t.value} text={t.label} />
+									))}
+								</Select>
 
-							<TextInput
-								id={`cond-msg-${cond.conditionId}`}
-								labelText="Error message"
-								value={cond.errorMessage || ""}
+								{isEnabledVisible && (
+									<Select
+										id={`cond-target-${cond.conditionId}`}
+										labelText={condType === "enabled" ? "Enable/disable this field" : "Show/hide this field"}
+										value={cond.targetParamRef || ""}
+										size="sm"
+										onChange={(e) => this.updateCondition(cond.conditionId, "targetParamRef", e.target.value)}
+									>
+										<SelectItem value="" text="— pick parameter —" />
+										{paramOptions.map((p) => (
+											<SelectItem key={p.paramId} value={p.id} text={p.displayName || p.id} />
+										))}
+									</Select>
+								)}
+
+								<Select
+									id={`cond-param-${cond.conditionId}`}
+									labelText={isEnabledVisible ? "When this parameter" : "Parameter"}
+									value={cond.paramRef || ""}
+									size="sm"
+									onChange={(e) => this.updateCondition(cond.conditionId, "paramRef", e.target.value)}
+								>
+									<SelectItem value="" text="— pick parameter —" />
+									{paramOptions.map((p) => (
+										<SelectItem key={p.paramId} value={p.id} text={p.displayName || p.id} />
+									))}
+								</Select>
+
+								<Select
+									id={`cond-op-${cond.conditionId}`}
+									labelText="Rule"
+									value={cond.op || "isNotEmpty"}
+									size="sm"
+									onChange={(e) => this.updateCondition(cond.conditionId, "op", e.target.value)}
+								>
+									{CONDITION_OPS.map((op) => (
+										<SelectItem key={op.value} value={op.value} text={op.label} />
+									))}
+								</Select>
+
+								{OPS_NEEDING_VALUE.has(cond.op) && (
+									<TextInput
+										id={`cond-val-${cond.conditionId}`}
+										labelText="Value"
+										value={cond.value || ""}
+										size="sm"
+										onChange={(e) => this.updateCondition(cond.conditionId, "value", e.target.value)}
+									/>
+								)}
+
+								{!isEnabledVisible && (
+									<TextInput
+										id={`cond-msg-${cond.conditionId}`}
+										labelText="Error message"
+										value={cond.errorMessage || ""}
+										size="sm"
+										onChange={(e) => this.updateCondition(cond.conditionId, "errorMessage", e.target.value)}
+									/>
+								)}
+							</div>
+
+							<Button
+								kind="ghost"
 								size="sm"
-								onChange={(e) => this.updateCondition(cond.conditionId, "errorMessage", e.target.value)}
+								hasIconOnly
+								renderIcon={TrashCan}
+								iconDescription="Remove rule"
+								className="studio-condition-delete"
+								onClick={() => this.removeCondition(cond.conditionId)}
 							/>
 						</div>
-
-						<Button
-							kind="ghost"
-							size="sm"
-							hasIconOnly
-							renderIcon={TrashCan}
-							iconDescription="Remove rule"
-							className="studio-condition-delete"
-							onClick={() => this.removeCondition(cond.conditionId)}
-						/>
-					</div>
-				))}
+					);
+				})}
 			</div>
 		);
 	}

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/ConditionsBuilder.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/ConditionsBuilder.jsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { Button, Select, SelectItem, TextInput } from "@carbon/react";
+import { Add, TrashCan } from "@carbon/react/icons";
+import { v4 as uuid4 } from "uuid";
+
+const CONDITION_OPS = [
+	{ value: "isNotEmpty", label: "is not empty" },
+	{ value: "isEmpty", label: "is empty" },
+	{ value: "equals", label: "equals value" },
+	{ value: "notEquals", label: "does not equal value" },
+	{ value: "greaterThan", label: "greater than value" },
+	{ value: "lessThan", label: "less than value" },
+	{ value: "contains", label: "contains value" },
+	{ value: "notContains", label: "does not contain value" },
+	{ value: "startsWith", label: "starts with value" },
+	{ value: "endsWith", label: "ends with value" }
+];
+
+const OPS_NEEDING_VALUE = new Set([
+	"equals", "notEquals", "greaterThan", "lessThan",
+	"contains", "notContains", "startsWith", "endsWith"
+]);
+
+export default class ConditionsBuilder extends React.Component {
+	constructor(props) {
+		super(props);
+		this.addCondition = this.addCondition.bind(this);
+		this.removeCondition = this.removeCondition.bind(this);
+		this.updateCondition = this.updateCondition.bind(this);
+	}
+
+	addCondition() {
+		const newCondition = {
+			conditionId: uuid4(),
+			paramRef: (this.props.parameters && this.props.parameters[0] && this.props.parameters[0].id) || "",
+			op: "isNotEmpty",
+			value: "",
+			errorMessage: "This field is required."
+		};
+		this.props.onChange([...(this.props.conditions || []), newCondition]);
+	}
+
+	removeCondition(conditionId) {
+		this.props.onChange((this.props.conditions || []).filter((c) => c.conditionId !== conditionId));
+	}
+
+	updateCondition(conditionId, field, value) {
+		const updated = (this.props.conditions || []).map((c) => {
+			if (c.conditionId !== conditionId) {
+				return c;
+			}
+			return { ...c, [field]: value };
+		});
+		this.props.onChange(updated);
+	}
+
+	render() {
+		const { conditions, parameters } = this.props;
+		const paramOptions = (parameters || []).filter((p) => Boolean(p.id));
+
+		return (
+			<div className="studio-conditions-builder">
+				<div className="studio-subsection-header">
+					<span>Validation Rules</span>
+					<Button kind="ghost" size="sm" renderIcon={Add} onClick={this.addCondition}>
+						Add Rule
+					</Button>
+				</div>
+
+				{(!conditions || conditions.length === 0) && (
+					<div className="studio-placeholder-text">
+						No validation rules yet. Click &quot;Add Rule&quot; to require a field or add other checks.
+					</div>
+				)}
+
+				{(conditions || []).map((cond) => (
+					<div key={cond.conditionId} className="studio-condition-row">
+						<div className="studio-condition-fields">
+							<Select
+								id={`cond-param-${cond.conditionId}`}
+								labelText="Parameter"
+								value={cond.paramRef || ""}
+								size="sm"
+								onChange={(e) => this.updateCondition(cond.conditionId, "paramRef", e.target.value)}
+							>
+								<SelectItem value="" text="— pick parameter —" />
+								{paramOptions.map((p) => (
+									<SelectItem key={p.paramId} value={p.id} text={p.displayName || p.id} />
+								))}
+							</Select>
+
+							<Select
+								id={`cond-op-${cond.conditionId}`}
+								labelText="Rule"
+								value={cond.op || "isNotEmpty"}
+								size="sm"
+								onChange={(e) => this.updateCondition(cond.conditionId, "op", e.target.value)}
+							>
+								{CONDITION_OPS.map((op) => (
+									<SelectItem key={op.value} value={op.value} text={op.label} />
+								))}
+							</Select>
+
+							{OPS_NEEDING_VALUE.has(cond.op) && (
+								<TextInput
+									id={`cond-val-${cond.conditionId}`}
+									labelText="Value"
+									value={cond.value || ""}
+									size="sm"
+									onChange={(e) => this.updateCondition(cond.conditionId, "value", e.target.value)}
+								/>
+							)}
+
+							<TextInput
+								id={`cond-msg-${cond.conditionId}`}
+								labelText="Error message"
+								value={cond.errorMessage || ""}
+								size="sm"
+								onChange={(e) => this.updateCondition(cond.conditionId, "errorMessage", e.target.value)}
+							/>
+						</div>
+
+						<Button
+							kind="ghost"
+							size="sm"
+							hasIconOnly
+							renderIcon={TrashCan}
+							iconDescription="Remove rule"
+							className="studio-condition-delete"
+							onClick={() => this.removeCondition(cond.conditionId)}
+						/>
+					</div>
+				))}
+			</div>
+		);
+	}
+}
+
+ConditionsBuilder.propTypes = {
+	conditions: PropTypes.array,
+	parameters: PropTypes.array,
+	onChange: PropTypes.func.isRequired
+};

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/GroupBuilder.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/GroupBuilder.jsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { Button, Select, SelectItem, TextInput } from "@carbon/react";
+import { Add, TrashCan } from "@carbon/react/icons";
+import { v4 as uuid4 } from "uuid";
+
+export default class GroupBuilder extends React.Component {
+	constructor(props) {
+		super(props);
+		this.addGroup = this.addGroup.bind(this);
+		this.removeGroup = this.removeGroup.bind(this);
+		this.updateGroup = this.updateGroup.bind(this);
+		this.toggleParam = this.toggleParam.bind(this);
+	}
+
+	addGroup() {
+		const groups = [...(this.props.groups || []), { groupId: uuid4(), label: "New Tab", paramRefs: [] }];
+		this.props.onGroupsChange(groups);
+	}
+
+	removeGroup(groupId) {
+		this.props.onGroupsChange((this.props.groups || []).filter((g) => g.groupId !== groupId));
+	}
+
+	updateGroup(groupId, field, value) {
+		this.props.onGroupsChange(
+			(this.props.groups || []).map((g) => (g.groupId === groupId ? { ...g, [field]: value } : g))
+		);
+	}
+
+	toggleParam(groupId, paramId) {
+		const group = (this.props.groups || []).find((g) => g.groupId === groupId);
+		if (!group) {
+			return;
+		}
+		const current = group.paramRefs || [];
+		const next = current.includes(paramId)
+			? current.filter((id) => id !== paramId)
+			: [...current, paramId];
+		this.updateGroup(groupId, "paramRefs", next);
+	}
+
+	render() {
+		const { groupLayout, groups, parameters, onLayoutChange } = this.props;
+		const paramOptions = (parameters || []).filter((p) => Boolean(p.id));
+
+		return (
+			<div className="studio-group-builder">
+				<div className="studio-subsection-header">
+					<span>Layout</span>
+				</div>
+
+				<div className="studio-form-field">
+					<Select
+						id="studio-group-layout"
+						labelText="Panel layout"
+						value={groupLayout || "flat"}
+						size="sm"
+						onChange={(e) => onLayoutChange(e.target.value)}
+					>
+						<SelectItem value="flat" text="Flat (all parameters in one panel)" />
+						<SelectItem value="tabs" text="Tabs" />
+					</Select>
+				</div>
+
+				{(groupLayout === "tabs") && (
+					<div className="studio-groups-list">
+						{(!groups || groups.length === 0) && (
+							<div className="studio-placeholder-text">
+								No tabs yet. Click &quot;Add Tab&quot; to create one, then assign parameters to it.
+							</div>
+						)}
+
+						{(groups || []).map((group) => (
+							<div key={group.groupId} className="studio-group-item">
+								<div className="studio-group-header">
+									<TextInput
+										id={`group-label-${group.groupId}`}
+										labelText="Tab label"
+										value={group.label || ""}
+										size="sm"
+										onChange={(e) => this.updateGroup(group.groupId, "label", e.target.value)}
+									/>
+									<Button
+										kind="ghost"
+										size="sm"
+										hasIconOnly
+										renderIcon={TrashCan}
+										iconDescription="Remove tab"
+										className="studio-group-delete"
+										onClick={() => this.removeGroup(group.groupId)}
+									/>
+								</div>
+
+								<div className="studio-group-params">
+									<div className="studio-ports-section-label">Parameters in this tab</div>
+									{paramOptions.length === 0 && (
+										<div className="studio-placeholder-text">No parameters defined yet.</div>
+									)}
+									{paramOptions.map((p) => (
+										<label key={p.paramId} className="studio-group-param-check">
+											<input
+												type="checkbox"
+												checked={(group.paramRefs || []).includes(p.id)}
+												onChange={() => this.toggleParam(group.groupId, p.id)}
+											/>
+											<span>{p.displayName || p.id}</span>
+										</label>
+									))}
+								</div>
+							</div>
+						))}
+
+						<Button kind="ghost" size="sm" renderIcon={Add} onClick={this.addGroup}>
+							Add Tab
+						</Button>
+					</div>
+				)}
+			</div>
+		);
+	}
+}
+
+GroupBuilder.propTypes = {
+	groupLayout: PropTypes.string,
+	groups: PropTypes.array,
+	parameters: PropTypes.array,
+	onLayoutChange: PropTypes.func.isRequired,
+	onGroupsChange: PropTypes.func.isRequired
+};

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/ParameterForm.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/ParameterForm.jsx
@@ -66,8 +66,91 @@ export default class ParameterForm extends React.Component {
 		this.handleChange("enumValues", enumValues);
 	}
 
-	render() {
+	renderExtraFields() {
 		const { param, availableActions } = this.props;
+		const notBoolEnum = param.type !== "boolean" && param.type !== "enum";
+		const defaultVal = param.default !== null && param.default !== "" ? String(param.default) : "";
+		return (
+			<>
+				{notBoolEnum && (
+					<div className="studio-form-field">
+						<TextInput
+							id={`param-default-${param.paramId}`}
+							labelText="Default value"
+							value={defaultVal}
+							size="sm"
+							onChange={(e) => this.handleChange("default", e.target.value)}
+						/>
+					</div>
+				)}
+				{notBoolEnum && (
+					<div className="studio-form-field">
+						<TextInput
+							id={`param-placeholder-${param.paramId}`}
+							labelText="Placeholder text"
+							value={param.placeholder || ""}
+							size="sm"
+							onChange={(e) => this.handleChange("placeholder", e.target.value)}
+						/>
+					</div>
+				)}
+				<div className="studio-form-field">
+					<TextInput
+						id={`param-helper-${param.paramId}`}
+						labelText="Helper text (shown below the field)"
+						value={param.helperText || ""}
+						size="sm"
+						onChange={(e) => this.handleChange("helperText", e.target.value)}
+					/>
+				</div>
+				{TEXT_LIKE_TYPES.has(param.type || "") && (
+					<div className="studio-form-field">
+						<div className="studio-port-num">
+							<label className="studio-port-num-label" htmlFor={`param-charlimit-${param.paramId}`}>
+								Character limit (0 = unlimited)
+							</label>
+							<input
+								id={`param-charlimit-${param.paramId}`}
+								type="number"
+								className="studio-port-num-input"
+								value={param.charLimit || 0}
+								min={0}
+								onChange={(e) => this.handleChange("charLimit", parseInt(e.target.value, 10) || 0)}
+							/>
+						</div>
+					</div>
+				)}
+				<div className="studio-form-field">
+					<Toggle
+						id={`param-readonly-${param.paramId}`}
+						labelText="Read-only"
+						toggled={Boolean(param.readOnly)}
+						size="sm"
+						onToggle={(v) => this.handleChange("readOnly", v)}
+					/>
+				</div>
+				{availableActions && availableActions.length > 0 && (
+					<div className="studio-form-field">
+						<Select
+							id={`param-actionref-${param.paramId}`}
+							labelText="Action (icon button beside this field)"
+							value={param.actionRef || ""}
+							size="sm"
+							onChange={(e) => this.handleChange("actionRef", e.target.value)}
+						>
+							<SelectItem value="" text="— None —" />
+							{availableActions.map((a) => (
+								<SelectItem key={a.actionId} value={a.id} text={a.id || "(unnamed action)"} />
+							))}
+						</Select>
+					</div>
+				)}
+			</>
+		);
+	}
+
+	render() {
+		const { param } = this.props;
 
 		return (
 			<div className="studio-parameter-form">
@@ -126,84 +209,7 @@ export default class ParameterForm extends React.Component {
 					/>
 				</div>
 
-				{param.type !== "boolean" && param.type !== "enum" && (
-					<div className="studio-form-field">
-						<TextInput
-							id={`param-default-${param.paramId}`}
-							labelText="Default value"
-							value={param.default !== null && param.default !== "" ? String(param.default) : ""}
-							size="sm"
-							onChange={(e) => this.handleChange("default", e.target.value)}
-						/>
-					</div>
-				)}
-
-				{param.type !== "boolean" && param.type !== "enum" && (
-					<div className="studio-form-field">
-						<TextInput
-							id={`param-placeholder-${param.paramId}`}
-							labelText="Placeholder text"
-							value={param.placeholder || ""}
-							size="sm"
-							onChange={(e) => this.handleChange("placeholder", e.target.value)}
-						/>
-					</div>
-				)}
-
-				<div className="studio-form-field">
-					<TextInput
-						id={`param-helper-${param.paramId}`}
-						labelText="Helper text (shown below the field)"
-						value={param.helperText || ""}
-						size="sm"
-						onChange={(e) => this.handleChange("helperText", e.target.value)}
-					/>
-				</div>
-
-				{TEXT_LIKE_TYPES.has(param.type || "") && (
-					<div className="studio-form-field">
-						<div className="studio-port-num">
-							<label className="studio-port-num-label" htmlFor={`param-charlimit-${param.paramId}`}>
-								Character limit (0 = unlimited)
-							</label>
-							<input
-								id={`param-charlimit-${param.paramId}`}
-								type="number"
-								className="studio-port-num-input"
-								value={param.charLimit || 0}
-								min={0}
-								onChange={(e) => this.handleChange("charLimit", parseInt(e.target.value, 10) || 0)}
-							/>
-						</div>
-					</div>
-				)}
-
-				<div className="studio-form-field">
-					<Toggle
-						id={`param-readonly-${param.paramId}`}
-						labelText="Read-only"
-						toggled={Boolean(param.readOnly)}
-						size="sm"
-						onToggle={(v) => this.handleChange("readOnly", v)}
-					/>
-				</div>
-
-				{availableActions && availableActions.length > 0 && (
-					<div className="studio-form-field">
-						<Select
-							id={`param-actionref-${param.paramId}`}
-							labelText="Action (icon button beside this field)"
-							value={param.actionRef || ""}
-							size="sm"
-							onChange={(e) => this.handleChange("actionRef", e.target.value)}
-						>
-							<SelectItem value="" text="— None —" />
-							{availableActions.map((a) => (
-								<SelectItem key={a.actionId} value={a.id} text={a.id || "(unnamed action)"} />
-							))}
-						</Select>
-					</div>
-				)}
+				{this.renderExtraFields()}
 
 				{param.type === "enum" && (
 					<div className="studio-enum-values">

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/ParameterForm.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/ParameterForm.jsx
@@ -113,9 +113,9 @@ export default class ParameterForm extends React.Component {
 								id={`param-charlimit-${param.paramId}`}
 								type="number"
 								className="studio-port-num-input"
-								value={param.charLimit || 0}
+								value={param.charLimit ?? ""}
 								min={0}
-								onChange={(e) => this.handleChange("charLimit", parseInt(e.target.value, 10) || 0)}
+								onChange={(e) => this.handleChange("charLimit", e.target.value === "" ? null : Math.max(0, parseInt(e.target.value, 10) || 0))}
 							/>
 						</div>
 					</div>

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/ParameterForm.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/ParameterForm.jsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { TextInput, Select, SelectItem, Toggle, Button } from "@carbon/react";
+import { Add, TrashCan } from "@carbon/react/icons";
+
+const PARAM_TYPES = [
+	{ value: "string", label: "Text" },
+	{ value: "integer", label: "Integer" },
+	{ value: "double", label: "Number (decimal)" },
+	{ value: "boolean", label: "Boolean (toggle)" },
+	{ value: "enum", label: "Dropdown (enum)" }
+];
+
+export default class ParameterForm extends React.Component {
+	constructor(props) {
+		super(props);
+		this.handleChange = this.handleChange.bind(this);
+		this.addEnumValue = this.addEnumValue.bind(this);
+		this.removeEnumValue = this.removeEnumValue.bind(this);
+		this.updateEnumValue = this.updateEnumValue.bind(this);
+	}
+
+	handleChange(field, value) {
+		const updated = { ...this.props.param, [field]: value };
+		if (field === "type" && value !== "enum") {
+			updated.enumValues = [];
+		}
+		this.props.onChange(updated);
+	}
+
+	addEnumValue() {
+		const enumValues = [...(this.props.param.enumValues || []), ""];
+		this.handleChange("enumValues", enumValues);
+	}
+
+	removeEnumValue(index) {
+		const enumValues = (this.props.param.enumValues || []).filter((_, i) => i !== index);
+		this.handleChange("enumValues", enumValues);
+	}
+
+	updateEnumValue(index, value) {
+		const enumValues = (this.props.param.enumValues || []).map((v, i) => (i === index ? value : v));
+		this.handleChange("enumValues", enumValues);
+	}
+
+	render() {
+		const { param, availableActions } = this.props;
+
+		return (
+			<div className="studio-parameter-form">
+				<div className="studio-form-field">
+					<TextInput
+						id={`param-displayname-${param.paramId}`}
+						labelText="Display Label"
+						value={param.displayName || ""}
+						size="sm"
+						onChange={(e) => this.handleChange("displayName", e.target.value)}
+					/>
+				</div>
+
+				<div className="studio-form-field">
+					<TextInput
+						id={`param-id-${param.paramId}`}
+						labelText="Field ID (no spaces)"
+						placeholder="my_param"
+						value={param.id || ""}
+						size="sm"
+						onChange={(e) => this.handleChange("id", e.target.value.replace(/\s+/g, "_"))}
+					/>
+				</div>
+
+				<div className="studio-form-field">
+					<TextInput
+						id={`param-desc-${param.paramId}`}
+						labelText="Description (optional helper text below the field)"
+						value={param.description || ""}
+						size="sm"
+						onChange={(e) => this.handleChange("description", e.target.value)}
+					/>
+				</div>
+
+				<div className="studio-form-field">
+					<Select
+						id={`param-type-${param.paramId}`}
+						labelText="Type"
+						value={param.type || "string"}
+						size="sm"
+						onChange={(e) => this.handleChange("type", e.target.value)}
+					>
+						{PARAM_TYPES.map((t) => (
+							<SelectItem key={t.value} value={t.value} text={t.label} />
+						))}
+					</Select>
+				</div>
+
+				<div className="studio-form-field">
+					<Toggle
+						id={`param-required-${param.paramId}`}
+						labelText="Required"
+						toggled={Boolean(param.required)}
+						size="sm"
+						onToggle={(checked) => this.handleChange("required", checked)}
+					/>
+				</div>
+
+				{param.type !== "boolean" && param.type !== "enum" && (
+					<div className="studio-form-field">
+						<TextInput
+							id={`param-default-${param.paramId}`}
+							labelText="Default value"
+							value={param.default !== null && param.default !== "" ? String(param.default) : ""}
+							size="sm"
+							onChange={(e) => this.handleChange("default", e.target.value)}
+						/>
+					</div>
+				)}
+
+				{availableActions && availableActions.length > 0 && (
+					<div className="studio-form-field">
+						<Select
+							id={`param-actionref-${param.paramId}`}
+							labelText="Action (icon button beside this field)"
+							value={param.actionRef || ""}
+							size="sm"
+							onChange={(e) => this.handleChange("actionRef", e.target.value)}
+						>
+							<SelectItem value="" text="— None —" />
+							{availableActions.map((a) => (
+								<SelectItem key={a.actionId} value={a.id} text={a.id || "(unnamed action)"} />
+							))}
+						</Select>
+					</div>
+				)}
+
+				{param.type === "enum" && (
+					<div className="studio-enum-values">
+						<div className="studio-ports-section-label">Allowed Values</div>
+						{(param.enumValues || []).map((val, i) => (
+							<div key={i} className="studio-enum-row">
+								<TextInput
+									id={`enum-val-${param.paramId}-${i}`}
+									labelText=""
+									value={val}
+									size="sm"
+									placeholder={`Option ${i + 1}`}
+									onChange={(e) => this.updateEnumValue(i, e.target.value)}
+								/>
+								<Button
+									kind="ghost"
+									size="sm"
+									hasIconOnly
+									renderIcon={TrashCan}
+									iconDescription="Remove value"
+									onClick={() => this.removeEnumValue(i)}
+								/>
+							</div>
+						))}
+						<Button kind="ghost" size="sm" renderIcon={Add} onClick={this.addEnumValue}>
+							Add option
+						</Button>
+					</div>
+				)}
+			</div>
+		);
+	}
+}
+
+ParameterForm.propTypes = {
+	param: PropTypes.object.isRequired,
+	onChange: PropTypes.func.isRequired,
+	availableActions: PropTypes.array
+};

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/ParameterForm.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/ParameterForm.jsx
@@ -24,8 +24,15 @@ const PARAM_TYPES = [
 	{ value: "integer", label: "Integer" },
 	{ value: "double", label: "Number (decimal)" },
 	{ value: "boolean", label: "Boolean (toggle)" },
-	{ value: "enum", label: "Dropdown (enum)" }
+	{ value: "enum", label: "Dropdown (enum)" },
+	{ value: "textarea", label: "Multi-line text" },
+	{ value: "expression", label: "Expression editor" },
+	{ value: "date", label: "Date" },
+	{ value: "time", label: "Time" },
+	{ value: "timestamp", label: "Date & time" }
 ];
+
+const TEXT_LIKE_TYPES = new Set(["string", "textarea", "expression", ""]);
 
 export default class ParameterForm extends React.Component {
 	constructor(props) {
@@ -130,6 +137,56 @@ export default class ParameterForm extends React.Component {
 						/>
 					</div>
 				)}
+
+				{param.type !== "boolean" && param.type !== "enum" && (
+					<div className="studio-form-field">
+						<TextInput
+							id={`param-placeholder-${param.paramId}`}
+							labelText="Placeholder text"
+							value={param.placeholder || ""}
+							size="sm"
+							onChange={(e) => this.handleChange("placeholder", e.target.value)}
+						/>
+					</div>
+				)}
+
+				<div className="studio-form-field">
+					<TextInput
+						id={`param-helper-${param.paramId}`}
+						labelText="Helper text (shown below the field)"
+						value={param.helperText || ""}
+						size="sm"
+						onChange={(e) => this.handleChange("helperText", e.target.value)}
+					/>
+				</div>
+
+				{TEXT_LIKE_TYPES.has(param.type || "") && (
+					<div className="studio-form-field">
+						<div className="studio-port-num">
+							<label className="studio-port-num-label" htmlFor={`param-charlimit-${param.paramId}`}>
+								Character limit (0 = unlimited)
+							</label>
+							<input
+								id={`param-charlimit-${param.paramId}`}
+								type="number"
+								className="studio-port-num-input"
+								value={param.charLimit || 0}
+								min={0}
+								onChange={(e) => this.handleChange("charLimit", parseInt(e.target.value, 10) || 0)}
+							/>
+						</div>
+					</div>
+				)}
+
+				<div className="studio-form-field">
+					<Toggle
+						id={`param-readonly-${param.paramId}`}
+						labelText="Read-only"
+						toggled={Boolean(param.readOnly)}
+						size="sm"
+						onToggle={(v) => this.handleChange("readOnly", v)}
+					/>
+				</div>
 
 				{availableActions && availableActions.length > 0 && (
 					<div className="studio-form-field">

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/PropertiesBuilder.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/PropertiesBuilder.jsx
@@ -22,6 +22,8 @@ import { v4 as uuid4 } from "uuid";
 import ParameterForm from "./ParameterForm";
 import ConditionsBuilder from "./ConditionsBuilder";
 import ActionsBuilder from "./ActionsBuilder";
+import GroupBuilder from "./GroupBuilder";
+import ResourcesEditor from "./ResourcesEditor";
 import PropertiesPreview from "./PropertiesPreview";
 
 export default class PropertiesBuilder extends React.Component {
@@ -174,6 +176,9 @@ export default class PropertiesBuilder extends React.Component {
 		const parameters = (paramDef && paramDef.parameters) || [];
 		const conditions = (paramDef && paramDef.conditions) || [];
 		const actions = (paramDef && paramDef.actions) || [];
+		const groups = (paramDef && paramDef.groups) || [];
+		const groupLayout = (paramDef && paramDef.groupLayout) || "flat";
+		const resources = (paramDef && paramDef.resources) || {};
 		const titleDef = (paramDef && paramDef.titleDefinition) || { title: "", editable: true };
 
 		return (
@@ -261,6 +266,23 @@ export default class PropertiesBuilder extends React.Component {
 								conditions={conditions}
 								parameters={parameters}
 								onChange={(updated) => this.updateField("conditions", updated)}
+							/>
+						</div>
+
+						<div className="studio-subsection">
+							<GroupBuilder
+								groupLayout={groupLayout}
+								groups={groups}
+								parameters={parameters}
+								onLayoutChange={(layout) => this.updateField("groupLayout", layout)}
+								onGroupsChange={(updated) => this.updateField("groups", updated)}
+							/>
+						</div>
+
+						<div className="studio-subsection">
+							<ResourcesEditor
+								resources={resources}
+								onChange={(updated) => this.updateField("resources", updated)}
 							/>
 						</div>
 

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/PropertiesBuilder.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/PropertiesBuilder.jsx
@@ -53,6 +53,19 @@ export default class PropertiesBuilder extends React.Component {
 		return nodes.find((n) => n.studioId === this.props.selectedNodeStudioId) || null;
 	}
 
+	getParamDefFields() {
+		const { paramDef } = this.props;
+		return {
+			parameters: (paramDef && paramDef.parameters) || [],
+			conditions: (paramDef && paramDef.conditions) || [],
+			actions: (paramDef && paramDef.actions) || [],
+			groups: (paramDef && paramDef.groups) || [],
+			groupLayout: (paramDef && paramDef.groupLayout) || "flat",
+			resources: (paramDef && paramDef.resources) || {},
+			titleDef: (paramDef && paramDef.titleDefinition) || { title: "", editable: true }
+		};
+	}
+
 	updateField(field, value) {
 		const paramDef = this.props.paramDef || {};
 		this.props.onParamDefChange({ ...paramDef, [field]: value });
@@ -173,13 +186,7 @@ export default class PropertiesBuilder extends React.Component {
 		const { selectedNodeStudioId, onSelectNode, paramDef } = this.props;
 		const allNodes = this.getAllNodes();
 		const selectedNode = this.getSelectedNode();
-		const parameters = (paramDef && paramDef.parameters) || [];
-		const conditions = (paramDef && paramDef.conditions) || [];
-		const actions = (paramDef && paramDef.actions) || [];
-		const groups = (paramDef && paramDef.groups) || [];
-		const groupLayout = (paramDef && paramDef.groupLayout) || "flat";
-		const resources = (paramDef && paramDef.resources) || {};
-		const titleDef = (paramDef && paramDef.titleDefinition) || { title: "", editable: true };
+		const { parameters, conditions, actions, groups, groupLayout, resources, titleDef } = this.getParamDefFields();
 
 		return (
 			<div className="studio-properties-builder">

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/PropertiesBuilder.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/PropertiesBuilder.jsx
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { Select, SelectItem, Button, TextInput, Toggle } from "@carbon/react";
+import { Add, ChevronDown, ChevronUp, TrashCan } from "@carbon/react/icons";
+import { v4 as uuid4 } from "uuid";
+import ParameterForm from "./ParameterForm";
+import ConditionsBuilder from "./ConditionsBuilder";
+import ActionsBuilder from "./ActionsBuilder";
+import PropertiesPreview from "./PropertiesPreview";
+
+export default class PropertiesBuilder extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = { expandedParams: {} };
+		this.addParameter = this.addParameter.bind(this);
+		this.removeParameter = this.removeParameter.bind(this);
+		this.updateParameter = this.updateParameter.bind(this);
+		this.moveParameter = this.moveParameter.bind(this);
+		this.toggleParam = this.toggleParam.bind(this);
+		this.updateField = this.updateField.bind(this);
+	}
+
+	getAllNodes() {
+		const nodes = [];
+		(this.props.categories || []).forEach((cat) => {
+			(cat.nodeTypes || []).forEach((node) => {
+				nodes.push({ studioId: node.studioId, label: node.label, op: node.op, catLabel: cat.label });
+			});
+		});
+		return nodes;
+	}
+
+	getSelectedNode() {
+		const nodes = this.getAllNodes();
+		return nodes.find((n) => n.studioId === this.props.selectedNodeStudioId) || null;
+	}
+
+	updateField(field, value) {
+		const paramDef = this.props.paramDef || {};
+		this.props.onParamDefChange({ ...paramDef, [field]: value });
+	}
+
+	addParameter() {
+		const newParam = {
+			paramId: uuid4(),
+			id: "",
+			displayName: "New Parameter",
+			description: "",
+			actionRef: "",
+			type: "string",
+			required: false,
+			default: "",
+			enumValues: []
+		};
+		const paramDef = this.props.paramDef || {};
+		const updated = { ...paramDef, parameters: [...(paramDef.parameters || []), newParam] };
+		this.props.onParamDefChange(updated);
+		this.setState({ expandedParams: { ...this.state.expandedParams, [newParam.paramId]: true } });
+	}
+
+	removeParameter(paramId) {
+		const paramDef = this.props.paramDef || {};
+		const updated = { ...paramDef, parameters: (paramDef.parameters || []).filter((p) => p.paramId !== paramId) };
+		this.props.onParamDefChange(updated);
+		const expanded = { ...this.state.expandedParams };
+		delete expanded[paramId];
+		this.setState({ expandedParams: expanded });
+	}
+
+	updateParameter(updatedParam) {
+		const paramDef = this.props.paramDef || {};
+		const updated = {
+			...paramDef,
+			parameters: (paramDef.parameters || []).map((p) => (p.paramId === updatedParam.paramId ? updatedParam : p))
+		};
+		this.props.onParamDefChange(updated);
+	}
+
+	moveParameter(index, direction) {
+		const paramDef = this.props.paramDef || {};
+		const params = [...(paramDef.parameters || [])];
+		const targetIndex = index + direction;
+		if (targetIndex < 0 || targetIndex >= params.length) {
+			return;
+		}
+		[params[index], params[targetIndex]] = [params[targetIndex], params[index]];
+		this.props.onParamDefChange({ ...paramDef, parameters: params });
+	}
+
+	toggleParam(paramId) {
+		const expanded = { ...this.state.expandedParams };
+		expanded[paramId] = !expanded[paramId];
+		this.setState({ expandedParams: expanded });
+	}
+
+	renderParameterItem(param, index, parameters, actions) {
+		const { expandedParams } = this.state;
+		const reqBadge = param.required
+			? (
+				<span
+					className="studio-parameter-type-badge"
+					style={{ background: "var(--cds-tag-background-red)", color: "var(--cds-tag-color-red)" }}
+				>
+					required
+				</span>
+			)
+			: null;
+
+		return (
+			<div key={param.paramId} className="studio-parameter-item">
+				<div
+					className="studio-parameter-header"
+					onClick={() => this.toggleParam(param.paramId)}
+					role="button"
+					tabIndex={0}
+					onKeyDown={(e) => e.key === "Enter" && this.toggleParam(param.paramId)}
+				>
+					<div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+						<span className="studio-parameter-label">{param.displayName || "(unnamed)"}</span>
+						<span className="studio-parameter-type-badge">{param.type || "string"}</span>
+						{reqBadge}
+					</div>
+					<div className="studio-parameter-actions" onClick={(e) => e.stopPropagation()}>
+						<Button
+							kind="ghost" size="sm" hasIconOnly
+							renderIcon={ChevronUp} iconDescription="Move up"
+							disabled={index === 0}
+							onClick={() => this.moveParameter(index, -1)}
+						/>
+						<Button
+							kind="ghost" size="sm" hasIconOnly
+							renderIcon={ChevronDown} iconDescription="Move down"
+							disabled={index === parameters.length - 1}
+							onClick={() => this.moveParameter(index, 1)}
+						/>
+						<Button
+							kind="ghost" size="sm" hasIconOnly
+							renderIcon={TrashCan} iconDescription="Delete parameter"
+							onClick={() => this.removeParameter(param.paramId)}
+						/>
+					</div>
+				</div>
+				{expandedParams[param.paramId] && (
+					<ParameterForm
+						param={param}
+						onChange={this.updateParameter}
+						availableActions={actions || []}
+					/>
+				)}
+			</div>
+		);
+	}
+
+	render() {
+		const { selectedNodeStudioId, onSelectNode, paramDef } = this.props;
+		const allNodes = this.getAllNodes();
+		const selectedNode = this.getSelectedNode();
+		const parameters = (paramDef && paramDef.parameters) || [];
+		const conditions = (paramDef && paramDef.conditions) || [];
+		const actions = (paramDef && paramDef.actions) || [];
+		const titleDef = (paramDef && paramDef.titleDefinition) || { title: "", editable: true };
+
+		return (
+			<div className="studio-properties-builder">
+				<div className="studio-form-field">
+					<Select
+						id="studio-node-selector"
+						labelText="Configure properties for node"
+						value={selectedNodeStudioId || ""}
+						size="sm"
+						onChange={(e) => onSelectNode(e.target.value || null)}
+					>
+						<SelectItem value="" text="— Select a node type —" />
+						{allNodes.map((node) => (
+							<SelectItem
+								key={node.studioId}
+								value={node.studioId}
+								text={`${node.catLabel}: ${node.label || "(unnamed)"}`}
+							/>
+						))}
+					</Select>
+				</div>
+
+				{!selectedNodeStudioId && (
+					<div className="studio-no-node-placeholder">
+						<p>Select a node type above to configure its properties form.</p>
+					</div>
+				)}
+
+				{selectedNodeStudioId && (
+					<div>
+						<div className="studio-subsection">
+							<div className="studio-subsection-header studio-subsection-header--top">
+								<span>Dialog Title</span>
+							</div>
+							<div className="studio-form-field">
+								<TextInput
+									id="studio-title-def"
+									labelText="Title"
+									placeholder="Node Properties"
+									value={titleDef.title || ""}
+									size="sm"
+									onChange={(e) => this.updateField("titleDefinition", { ...titleDef, title: e.target.value })}
+								/>
+							</div>
+							<div className="studio-form-field">
+								<Toggle
+									id="studio-title-editable"
+									labelText="Title editable by user"
+									toggled={titleDef.editable !== false}
+									size="sm"
+									onToggle={(v) => this.updateField("titleDefinition", { ...titleDef, editable: v })}
+								/>
+							</div>
+						</div>
+
+						<div className="studio-subsection">
+							<div className="studio-parameter-list">
+								<div className="studio-node-type-list-header">
+									<span>Parameters ({parameters.length})</span>
+									<Button kind="ghost" size="sm" renderIcon={Add} onClick={this.addParameter}>
+										Add Parameter
+									</Button>
+								</div>
+
+								{parameters.length === 0 && (
+									<div className="studio-placeholder-text">
+										No parameters yet. Click &quot;Add Parameter&quot; to begin.
+									</div>
+								)}
+
+								{parameters.map((param, index) => this.renderParameterItem(param, index, parameters, actions))}
+							</div>
+						</div>
+
+						<div className="studio-subsection">
+							<ActionsBuilder
+								actions={actions}
+								onChange={(updated) => this.updateField("actions", updated)}
+							/>
+						</div>
+
+						<div className="studio-subsection">
+							<ConditionsBuilder
+								conditions={conditions}
+								parameters={parameters}
+								onChange={(updated) => this.updateField("conditions", updated)}
+							/>
+						</div>
+
+						<PropertiesPreview
+							paramDef={paramDef}
+							nodeLabel={selectedNode ? selectedNode.label : ""}
+							nodeOp={selectedNode ? selectedNode.op : ""}
+						/>
+					</div>
+				)}
+			</div>
+		);
+	}
+}
+
+PropertiesBuilder.propTypes = {
+	categories: PropTypes.array.isRequired,
+	selectedNodeStudioId: PropTypes.string,
+	paramDef: PropTypes.object,
+	onSelectNode: PropTypes.func.isRequired,
+	onParamDefChange: PropTypes.func.isRequired
+};

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/PropertiesPreview.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/PropertiesPreview.jsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { CommonProperties } from "common-canvas"; // eslint-disable-line import/no-unresolved
+import propertiesGenerator from "../utils/properties-generator";
+
+const NOOP = () => null;
+
+export default class PropertiesPreview extends React.Component {
+	render() {
+		const { paramDef, nodeLabel, nodeOp } = this.props;
+
+		if (!paramDef || !paramDef.parameters || paramDef.parameters.length === 0) {
+			return (
+				<div className="studio-properties-preview">
+					<div className="studio-preview-label">Properties Preview</div>
+					<div className="studio-preview-content" style={{ color: "var(--cds-text-placeholder)", fontSize: "0.8125rem", padding: "1rem" }}>
+						Add parameters above to see a live preview of the properties form.
+					</div>
+				</div>
+			);
+		}
+
+		const parameterDef = propertiesGenerator(paramDef, nodeLabel, nodeOp);
+
+		return (
+			<div className="studio-properties-preview">
+				<div className="studio-preview-label">Properties Preview</div>
+				<div className="studio-preview-content">
+					<CommonProperties
+						propertiesInfo={{ parameterDef }}
+						propertiesConfig={{
+							containerType: "Custom",
+							rightFlyout: false,
+							applyOnBlur: true
+						}}
+						callbacks={{
+							closePropertiesDialog: NOOP,
+							applyPropertyChanges: NOOP
+						}}
+					/>
+				</div>
+			</div>
+		);
+	}
+}
+
+PropertiesPreview.propTypes = {
+	paramDef: PropTypes.object,
+	nodeLabel: PropTypes.string,
+	nodeOp: PropTypes.string
+};

--- a/canvas_modules/harness/src/client/components/studio/properties-builder/ResourcesEditor.jsx
+++ b/canvas_modules/harness/src/client/components/studio/properties-builder/ResourcesEditor.jsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import { Button, TextInput } from "@carbon/react";
+import { Add, TrashCan } from "@carbon/react/icons";
+
+export default class ResourcesEditor extends React.Component {
+	constructor(props) {
+		super(props);
+		this.addEntry = this.addEntry.bind(this);
+		this.removeEntry = this.removeEntry.bind(this);
+		this.updateKey = this.updateKey.bind(this);
+		this.updateValue = this.updateValue.bind(this);
+	}
+
+	getEntries() {
+		return Object.entries(this.props.resources || {});
+	}
+
+	updateResources(entries) {
+		const resources = {};
+		entries.forEach(([k, v]) => {
+			if (k) {
+				resources[k] = v;
+			}
+		});
+		this.props.onChange(resources);
+	}
+
+	addEntry() {
+		this.updateResources([...this.getEntries(), ["", ""]]);
+	}
+
+	removeEntry(index) {
+		const entries = this.getEntries().filter((_, i) => i !== index);
+		this.updateResources(entries);
+	}
+
+	updateKey(index, newKey) {
+		const entries = this.getEntries().map(([k, v], i) => (i === index ? [newKey, v] : [k, v]));
+		this.updateResources(entries);
+	}
+
+	updateValue(index, newValue) {
+		const entries = this.getEntries().map(([k, v], i) => (i === index ? [k, newValue] : [k, v]));
+		this.updateResources(entries);
+	}
+
+	render() {
+		const entries = this.getEntries();
+
+		return (
+			<div className="studio-resources-editor">
+				<div className="studio-subsection-header">
+					<span>Localization Resources</span>
+					<Button kind="ghost" size="sm" renderIcon={Add} onClick={this.addEntry}>
+						Add Resource
+					</Button>
+				</div>
+
+				{entries.length === 0 && (
+					<div className="studio-placeholder-text">
+						No resources yet. Resources are key/value string pairs used for localization.
+						Reference a key in a field label using its resource_key.
+					</div>
+				)}
+
+				{entries.map(([key, value], index) => (
+					<div key={index} className="studio-resource-row">
+						<TextInput
+							id={`resource-key-${index}`}
+							labelText="Key"
+							value={key}
+							size="sm"
+							placeholder="my.label.key"
+							onChange={(e) => this.updateKey(index, e.target.value)}
+						/>
+						<TextInput
+							id={`resource-val-${index}`}
+							labelText="Value"
+							value={value}
+							size="sm"
+							placeholder="My Label"
+							onChange={(e) => this.updateValue(index, e.target.value)}
+						/>
+						<Button
+							kind="ghost"
+							size="sm"
+							hasIconOnly
+							renderIcon={TrashCan}
+							iconDescription="Remove resource"
+							className="studio-resource-delete"
+							onClick={() => this.removeEntry(index)}
+						/>
+					</div>
+				))}
+			</div>
+		);
+	}
+}
+
+ResourcesEditor.propTypes = {
+	resources: PropTypes.object,
+	onChange: PropTypes.func.isRequired
+};

--- a/canvas_modules/harness/src/client/components/studio/utils/palette-generator.js
+++ b/canvas_modules/harness/src/client/components/studio/utils/palette-generator.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function slugify(str) {
+	return (str || "")
+		.toLowerCase()
+		.replace(/\s+/g, "-")
+		.replace(/[^a-z0-9-]/g, "");
+}
+
+function buildPort(port, index) {
+	return {
+		id: port.portId || `port${index}`,
+		app_data: {
+			ui_data: {
+				label: port.label || `Port ${index}`,
+				cardinality: {
+					min: Number(port.cardinalityMin) || 0,
+					max: Number(port.cardinalityMax) === -1 ? -1 : (Number(port.cardinalityMax) || 1)
+				}
+			}
+		}
+	};
+}
+
+function buildNodeType(nodeType) {
+	return {
+		id: nodeType.studioId,
+		type: "execution_node",
+		op: nodeType.op || nodeType.studioId,
+		inputs: (nodeType.inputs || []).map(buildPort),
+		outputs: (nodeType.outputs || []).map(buildPort),
+		app_data: {
+			ui_data: {
+				label: nodeType.label || "Node",
+				description: nodeType.description || "",
+				image: nodeType.image || ""
+			}
+		}
+	};
+}
+
+function buildCategory(category) {
+	return {
+		id: slugify(category.label) || category.studioId,
+		label: category.label || "Category",
+		description: category.description || "",
+		image: category.image || "",
+		is_open: Boolean(category.is_open),
+		node_types: (category.nodeTypes || []).map(buildNodeType)
+	};
+}
+
+export default function paletteGenerator(categories) {
+	return {
+		version: "3.0",
+		categories: (categories || []).map(buildCategory)
+	};
+}

--- a/canvas_modules/harness/src/client/components/studio/utils/properties-generator.js
+++ b/canvas_modules/harness/src/client/components/studio/utils/properties-generator.js
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const CONTROL_TYPE_MAP = {
+	string: "textfield",
+	integer: "numberfield",
+	double: "numberfield",
+	boolean: "toggletext",
+	enum: "oneofselect"
+};
+
+const OPS_NEEDING_VALUE = new Set([
+	"equals", "notEquals", "greaterThan", "lessThan",
+	"contains", "notContains", "startsWith", "endsWith"
+]);
+
+function coerceDefault(value, type) {
+	if (value === null || value === "") {
+		if (type === "boolean") {
+			return false;
+		}
+		if (type === "integer" || type === "double") {
+			return 0;
+		}
+		return "";
+	}
+	if (type === "integer") {
+		return parseInt(value, 10) || 0;
+	}
+	if (type === "double") {
+		return parseFloat(value) || 0;
+	}
+	if (type === "boolean") {
+		return Boolean(value);
+	}
+	return value;
+}
+
+function buildCondition(cond) {
+	if (!cond.paramRef) {
+		return null;
+	}
+	const evaluateCondition = { parameter_ref: cond.paramRef, op: cond.op || "isNotEmpty" };
+	if (OPS_NEEDING_VALUE.has(cond.op) && cond.value) {
+		evaluateCondition.value = cond.value;
+	}
+	return {
+		validation: {
+			fail_message: {
+				type: "error",
+				focus_parameter_ref: cond.paramRef,
+				message: { default: cond.errorMessage || "This field is required." }
+			},
+			evaluate: { condition: evaluateCondition }
+		}
+	};
+}
+
+function buildActionInfo(actions) {
+	return (actions || [])
+		.filter((a) => Boolean(a.id))
+		.map((a) => ({
+			id: a.id,
+			label: { default: a.label || a.id },
+			description: { default: a.description || "" },
+			control: "image",
+			data: {},
+			image: {
+				url: a.imageUrl || "",
+				placement: a.placement || "right",
+				size: { height: Number(a.height) || 20, width: Number(a.width) || 25 }
+			}
+		}));
+}
+
+export default function propertiesGenerator(paramDefEntry, nodeLabel, nodeOp) {
+	const parameters = (paramDefEntry && paramDefEntry.parameters) || [];
+	const titleDefinition = paramDefEntry && paramDefEntry.titleDefinition;
+	const conditions = (paramDefEntry && paramDefEntry.conditions) || [];
+	const actions = (paramDefEntry && paramDefEntry.actions) || [];
+
+	const currentParameters = {};
+	const parametersSchema = [];
+	const parameterInfo = [];
+	const parameterRefs = [];
+
+	parameters.forEach((param) => {
+		if (!param.id) {
+			return;
+		}
+
+		currentParameters[param.id] = coerceDefault(param.default, param.type);
+
+		const schemaParam = {
+			id: param.id,
+			type: param.type === "enum" ? "string" : (param.type || "string"),
+			required: Boolean(param.required)
+		};
+		if (param.type === "enum" && param.enumValues && param.enumValues.length > 0) {
+			schemaParam.enum = param.enumValues.filter(Boolean);
+		}
+		parametersSchema.push(schemaParam);
+
+		const infoEntry = {
+			parameter_ref: param.id,
+			label: { default: param.displayName || param.id },
+			control_type: CONTROL_TYPE_MAP[param.type] || "textfield"
+		};
+		if (param.description) {
+			infoEntry.description = { default: param.description };
+		}
+		if (param.actionRef) {
+			infoEntry.action_ref = param.actionRef;
+		}
+		parameterInfo.push(infoEntry);
+		parameterRefs.push(param.id);
+	});
+
+	const uiHintsId = nodeOp || "studio-node";
+	const actionInfo = buildActionInfo(actions);
+	const builtConditions = conditions.map(buildCondition).filter(Boolean);
+
+	const result = {
+		current_parameters: currentParameters,
+		parameters: parametersSchema,
+		uihints: {
+			id: uiHintsId,
+			label: { default: nodeLabel || "Node Properties" },
+			parameter_info: parameterInfo,
+			group_info: [
+				{
+					id: "main-group",
+					type: "controls",
+					parameter_refs: parameterRefs
+				}
+			]
+		},
+		resources: {}
+	};
+
+	if (titleDefinition && titleDefinition.title) {
+		result.titleDefinition = {
+			title: titleDefinition.title,
+			editable: titleDefinition.editable !== false
+		};
+	}
+
+	if (actionInfo.length > 0) {
+		result.uihints.action_info = actionInfo;
+	}
+
+	if (builtConditions.length > 0) {
+		result.conditions = builtConditions;
+	}
+
+	return result;
+}

--- a/canvas_modules/harness/src/client/components/studio/utils/properties-generator.js
+++ b/canvas_modules/harness/src/client/components/studio/utils/properties-generator.js
@@ -19,13 +19,31 @@ const CONTROL_TYPE_MAP = {
 	integer: "numberfield",
 	double: "numberfield",
 	boolean: "toggletext",
-	enum: "oneofselect"
+	enum: "oneofselect",
+	textarea: "textarea",
+	expression: "expression",
+	date: "datepicker",
+	time: "timepicker",
+	timestamp: "datetimepicker"
 };
 
 const OPS_NEEDING_VALUE = new Set([
 	"equals", "notEquals", "greaterThan", "lessThan",
 	"contains", "notContains", "startsWith", "endsWith"
 ]);
+
+const SCHEMA_TYPE_MAP = {
+	string: "string",
+	integer: "integer",
+	double: "double",
+	boolean: "boolean",
+	enum: "string",
+	textarea: "string",
+	expression: "string",
+	date: "date",
+	time: "time",
+	timestamp: "timestamp"
+};
 
 function coerceDefault(value, type) {
 	if (value === null || value === "") {
@@ -57,6 +75,15 @@ function buildCondition(cond) {
 	if (OPS_NEEDING_VALUE.has(cond.op) && cond.value) {
 		evaluateCondition.value = cond.value;
 	}
+	const condType = cond.conditionType || "validation";
+	if (condType === "enabled" || condType === "visible") {
+		return {
+			[condType]: {
+				parameter_refs: cond.targetParamRef ? [cond.targetParamRef] : [cond.paramRef],
+				evaluate: { condition: evaluateCondition }
+			}
+		};
+	}
 	return {
 		validation: {
 			fail_message: {
@@ -72,18 +99,40 @@ function buildCondition(cond) {
 function buildActionInfo(actions) {
 	return (actions || [])
 		.filter((a) => Boolean(a.id))
-		.map((a) => ({
-			id: a.id,
-			label: { default: a.label || a.id },
-			description: { default: a.description || "" },
-			control: "image",
-			data: {},
-			image: {
-				url: a.imageUrl || "",
-				placement: a.placement || "right",
-				size: { height: Number(a.height) || 20, width: Number(a.width) || 25 }
+		.map((a) => {
+			const control = a.controlType || "image";
+			const entry = {
+				id: a.id,
+				label: { default: a.label || a.id },
+				description: { default: a.description || "" },
+				control,
+				data: a.paramRef ? { parameter_ref: a.paramRef } : {}
+			};
+			if (control === "image") {
+				entry.image = {
+					url: a.imageUrl || "",
+					placement: a.placement || "right",
+					size: { height: Number(a.height) || 20, width: Number(a.width) || 25 }
+				};
 			}
-		}));
+			return entry;
+		});
+}
+
+function buildGroupInfo(groups, groupLayout, parameterRefs) {
+	if (groupLayout === "tabs" && groups && groups.length > 0) {
+		return [{
+			id: "main-tabs",
+			type: "tabs",
+			group_info: groups.map((g) => ({
+				id: g.groupId,
+				type: "controls",
+				label: { default: g.label || "Tab" },
+				parameter_refs: g.paramRefs || []
+			}))
+		}];
+	}
+	return [{ id: "main-group", type: "controls", parameter_refs: parameterRefs }];
 }
 
 export default function propertiesGenerator(paramDefEntry, nodeLabel, nodeOp) {
@@ -91,6 +140,9 @@ export default function propertiesGenerator(paramDefEntry, nodeLabel, nodeOp) {
 	const titleDefinition = paramDefEntry && paramDefEntry.titleDefinition;
 	const conditions = (paramDefEntry && paramDefEntry.conditions) || [];
 	const actions = (paramDefEntry && paramDefEntry.actions) || [];
+	const groups = (paramDefEntry && paramDefEntry.groups) || [];
+	const groupLayout = (paramDefEntry && paramDefEntry.groupLayout) || "flat";
+	const resources = (paramDefEntry && paramDefEntry.resources) || {};
 
 	const currentParameters = {};
 	const parametersSchema = [];
@@ -106,7 +158,7 @@ export default function propertiesGenerator(paramDefEntry, nodeLabel, nodeOp) {
 
 		const schemaParam = {
 			id: param.id,
-			type: param.type === "enum" ? "string" : (param.type || "string"),
+			type: SCHEMA_TYPE_MAP[param.type] || "string",
 			required: Boolean(param.required)
 		};
 		if (param.type === "enum" && param.enumValues && param.enumValues.length > 0) {
@@ -121,6 +173,18 @@ export default function propertiesGenerator(paramDefEntry, nodeLabel, nodeOp) {
 		};
 		if (param.description) {
 			infoEntry.description = { default: param.description };
+		}
+		if (param.placeholder) {
+			infoEntry.place_holder_text = { default: param.placeholder };
+		}
+		if (param.helperText) {
+			infoEntry.helper_text = { default: param.helperText };
+		}
+		if (param.charLimit > 0) {
+			infoEntry.char_limit = param.charLimit;
+		}
+		if (param.readOnly) {
+			infoEntry.read_only = true;
 		}
 		if (param.actionRef) {
 			infoEntry.action_ref = param.actionRef;
@@ -140,15 +204,9 @@ export default function propertiesGenerator(paramDefEntry, nodeLabel, nodeOp) {
 			id: uiHintsId,
 			label: { default: nodeLabel || "Node Properties" },
 			parameter_info: parameterInfo,
-			group_info: [
-				{
-					id: "main-group",
-					type: "controls",
-					parameter_refs: parameterRefs
-				}
-			]
+			group_info: buildGroupInfo(groups, groupLayout, parameterRefs)
 		},
-		resources: {}
+		resources
 	};
 
 	if (titleDefinition && titleDefinition.title) {

--- a/canvas_modules/harness/src/client/index.js
+++ b/canvas_modules/harness/src/client/index.js
@@ -19,6 +19,7 @@ import { createRoot } from "react-dom/client.js";
 
 import CommonPropertiesComponents from "./components/common-properties-components.jsx";
 import CommonPropertiesConditions from "./components/common-properties-conditions.jsx";
+import StudioPage from "./components/studio/StudioPage.jsx";
 import App from "./App.js";
 import AppSmall from "./app-small.js";
 import AppTiny from "./app-tiny.js";
@@ -38,6 +39,7 @@ root.render(
 				<Route exact path="/app-tiny-ts" component={ AppTinyTS } />
 				<Route path="/properties" component={ CommonPropertiesComponents } />
 				<Route path="/conditions" component={ CommonPropertiesConditions } />
+				<Route exact path="/studio" component={ StudioPage } />
 			</div>
 		</IntlProvider>
 	</HashRouter>

--- a/canvas_modules/harness/src/styles/studio.scss
+++ b/canvas_modules/harness/src/styles/studio.scss
@@ -95,7 +95,7 @@
 .studio-column-content {
 	flex: 1;
 	overflow-y: auto;
-	overflow-x: hidden; 
+	overflow-x: hidden;
 	padding: 1rem;
 }
 

--- a/canvas_modules/harness/src/styles/studio.scss
+++ b/canvas_modules/harness/src/styles/studio.scss
@@ -1,0 +1,707 @@
+/*
+ * Copyright 2017-2026 Elyra Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.studio-page {
+	display: flex;
+	flex-direction: column;
+	height: 100vh;
+	overflow: hidden;
+	background-color: var(--cds-background);
+}
+
+.studio-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0 1rem;
+	height: 3rem;
+	background-color: var(--cds-layer-01);
+	border-bottom: 1px solid var(--cds-border-subtle-01);
+	flex-shrink: 0;
+
+	.studio-header-left {
+		display: flex;
+		align-items: center;
+		gap: 1rem;
+
+		.studio-title {
+			font-size: 1rem;
+			font-weight: 600;
+			color: var(--cds-text-primary);
+		}
+
+		.studio-back-link {
+			font-size: 0.875rem;
+			color: var(--cds-link-primary);
+			text-decoration: none;
+			cursor: pointer;
+
+			&:hover {
+				text-decoration: underline;
+			}
+		}
+	}
+
+	.studio-header-actions {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+	}
+}
+
+.studio-body {
+	display: grid;
+	grid-template-columns: 320px 320px 1fr;
+	flex: 1;
+	min-height: 0; // prevents flex child from overflowing its container
+	overflow: hidden;
+}
+
+.studio-column {
+	display: flex;
+	flex-direction: column;
+	min-height: 0; // prevents grid child from expanding past its track
+	overflow: hidden;
+	border-right: 1px solid var(--cds-border-subtle-01);
+
+	&:last-child {
+		border-right: none;
+	}
+}
+
+.studio-column-header {
+	padding: 0.75rem 1rem;
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: var(--cds-text-primary);
+	background-color: var(--cds-layer-01);
+	border-bottom: 1px solid var(--cds-border-subtle-01);
+	flex-shrink: 0;
+}
+
+.studio-column-content {
+	flex: 1;
+	overflow-y: auto;
+	overflow-x: hidden; 
+	padding: 1rem;
+}
+
+// ---- Palette Builder ----
+
+.studio-palette-builder {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+}
+
+.studio-section-actions {
+	display: flex;
+	gap: 0.5rem;
+	margin-bottom: 0.75rem;
+	flex-shrink: 0;
+}
+
+.studio-category-item {
+	border: 1px solid var(--cds-border-subtle-01);
+	border-radius: 4px;
+	margin-bottom: 0.5rem;
+	background-color: var(--cds-layer-02);
+}
+
+.studio-category-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.5rem 0.75rem;
+	cursor: pointer;
+	user-select: none;
+
+	&:hover {
+		background-color: var(--cds-layer-hover-02);
+	}
+
+	.studio-category-label {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.875rem;
+		font-weight: 500;
+		color: var(--cds-text-primary);
+	}
+
+	.studio-category-icon-preview {
+		width: 20px;
+		height: 20px;
+		object-fit: contain;
+	}
+
+	.studio-category-actions {
+		display: flex;
+		gap: 0.25rem;
+	}
+}
+
+.studio-category-body {
+	padding: 0.75rem;
+	border-top: 1px solid var(--cds-border-subtle-01);
+}
+
+.studio-form-field {
+	margin-bottom: 1rem;
+
+	&:last-child {
+		margin-bottom: 0;
+	}
+}
+
+.studio-node-type-list {
+	margin-top: 0.75rem;
+}
+
+.studio-node-type-list-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 0.5rem;
+
+	span {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--cds-text-secondary);
+	}
+}
+
+.studio-node-type-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.5rem 0.625rem;
+	border: 1px solid var(--cds-border-subtle-01);
+	border-radius: 4px;
+	margin-bottom: 0.375rem;
+	background-color: var(--cds-layer-01);
+	cursor: pointer;
+
+	&:hover {
+		background-color: var(--cds-layer-hover-01);
+	}
+
+	&.studio-node-type-item--selected {
+		border-color: var(--cds-focus);
+		background-color: var(--cds-layer-selected-01);
+	}
+
+	.studio-node-type-label {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.875rem;
+		color: var(--cds-text-primary);
+	}
+
+	.studio-node-icon-preview {
+		width: 20px;
+		height: 20px;
+		object-fit: contain;
+	}
+
+	.studio-node-type-actions {
+		display: flex;
+		gap: 0.25rem;
+	}
+}
+
+// Node type form (inline below list)
+.studio-node-type-form {
+	border: 1px solid var(--cds-focus);
+	border-radius: 4px;
+	padding: 0.75rem;
+	margin-top: 0.5rem;
+	background-color: var(--cds-layer-01);
+}
+
+.studio-node-type-form-title {
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: var(--cds-text-primary);
+	margin-bottom: 0.75rem;
+}
+
+// Ports editor
+.studio-ports-editor {
+	margin-top: 0.5rem;
+}
+
+.studio-ports-section-label {
+	font-size: 0.8125rem;
+	font-weight: 600;
+	color: var(--cds-text-secondary);
+	margin-bottom: 0.375rem;
+}
+
+.studio-port-row {
+	display: grid;
+	grid-template-columns: 1fr 1fr 2rem;
+	gap: 0.375rem;
+	align-items: flex-end;
+	margin-bottom: 0.75rem;
+	min-width: 0;
+
+	// Label input occupies the full first row
+	> *:first-child {
+		grid-column: 1 / -1;
+	}
+
+	// Override Carbon's internal min-width so NumberInput respects the grid track
+	> * {
+		min-width: 0;
+	}
+
+	.cds--number,
+	.cds--text-input-wrapper,
+	.cds--form-item {
+		min-width: 0;
+		width: 100%;
+	}
+}
+
+// Two equal columns for width + height number inputs (Actions builder)
+.studio-two-col-row {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 0.5rem;
+	align-items: flex-end;
+	min-width: 0;
+
+	> * {
+		min-width: 0;
+	}
+
+	.cds--number,
+	.cds--form-item {
+		min-width: 0;
+		width: 100%;
+	}
+}
+
+.studio-port-num {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.studio-port-num-label {
+	display: block;
+	font-size: 0.75rem;
+	font-weight: 400;
+	color: var(--cds-text-secondary);
+	margin-bottom: 0.25rem;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.studio-port-num-input {
+	width: 100%;
+	min-width: 0;
+	border: none;
+	border-bottom: 1px solid var(--cds-border-strong-01);
+	background: transparent;
+	padding: 0.375rem 0;
+	font-size: 0.875rem;
+	color: var(--cds-text-primary);
+	-moz-appearance: textfield;
+
+	&::-webkit-outer-spin-button,
+	&::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
+
+	&:focus {
+		outline: 2px solid var(--cds-focus);
+		outline-offset: -2px;
+	}
+}
+
+.studio-add-port-btn {
+	margin-top: 0.375rem;
+}
+
+// ---- Icon Picker ----
+
+.studio-icon-picker {
+	border: 1px solid var(--cds-border-subtle-01);
+	border-radius: 4px;
+	overflow: hidden;
+}
+
+.studio-icon-picker-tabs {
+	display: flex;
+	border-bottom: 1px solid var(--cds-border-subtle-01);
+	background-color: var(--cds-layer-01);
+	overflow-x: auto;
+
+	.studio-icon-tab {
+		padding: 0.375rem 0.75rem;
+		font-size: 0.8125rem;
+		cursor: pointer;
+		white-space: nowrap;
+		color: var(--cds-text-secondary);
+		border-bottom: 2px solid transparent;
+
+		&:hover {
+			background-color: var(--cds-layer-hover-01);
+			color: var(--cds-text-primary);
+		}
+
+		&.studio-icon-tab--active {
+			color: var(--cds-text-primary);
+			border-bottom-color: var(--cds-interactive);
+			font-weight: 600;
+		}
+	}
+}
+
+.studio-icon-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, 36px);
+	gap: 0.25rem;
+	padding: 0.5rem;
+	max-height: 150px;
+	overflow-y: auto;
+	background-color: var(--cds-layer-02);
+}
+
+.studio-icon-cell {
+	width: 36px;
+	height: 36px;
+	padding: 4px;
+	border-radius: 4px;
+	cursor: pointer;
+	border: 2px solid transparent;
+
+	&:hover {
+		background-color: var(--cds-layer-hover-02);
+	}
+
+	&.studio-icon-cell--selected {
+		border-color: var(--cds-focus);
+		background-color: var(--cds-layer-selected-02);
+	}
+
+	img {
+		width: 100%;
+		height: 100%;
+		object-fit: contain;
+	}
+}
+
+.studio-icon-custom-url {
+	padding: 0.5rem;
+	background-color: var(--cds-layer-02);
+}
+
+// ---- Properties Builder ----
+
+.studio-properties-builder {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+}
+
+.studio-no-node-placeholder {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	color: var(--cds-text-placeholder);
+	text-align: center;
+	padding: 2rem;
+	font-size: 0.875rem;
+}
+
+.studio-parameter-list {
+	margin-top: 0.75rem;
+}
+
+.studio-parameter-item {
+	border: 1px solid var(--cds-border-subtle-01);
+	border-radius: 4px;
+	margin-bottom: 0.375rem;
+	background-color: var(--cds-layer-02);
+}
+
+.studio-parameter-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.5rem 0.75rem;
+	cursor: pointer;
+	gap: 0.25rem;
+
+	&:hover {
+		background-color: var(--cds-layer-hover-02);
+	}
+
+	// Left info side: must be able to shrink below its content size
+	> div:first-child {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.25rem;
+		min-width: 0;
+		flex: 1;
+	}
+
+	.studio-parameter-label {
+		font-size: 0.875rem;
+		color: var(--cds-text-primary);
+		word-break: break-word;
+	}
+
+	.studio-parameter-type-badge {
+		font-size: 0.75rem;
+		background-color: var(--cds-tag-background-blue);
+		color: var(--cds-tag-color-blue);
+		padding: 1px 6px;
+		border-radius: 10px;
+		white-space: nowrap;
+		flex-shrink: 0;
+	}
+
+	// Action buttons must never be pushed off screen
+	.studio-parameter-actions {
+		display: flex;
+		gap: 0.25rem;
+		align-items: center;
+		flex-shrink: 0;
+	}
+}
+
+.studio-parameter-form {
+	padding: 0.75rem;
+	border-top: 1px solid var(--cds-border-subtle-01);
+}
+
+.studio-enum-values {
+	margin-top: 0.5rem;
+}
+
+.studio-enum-row {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	gap: 0.5rem;
+	align-items: flex-end;
+	margin-bottom: 0.375rem;
+}
+
+// Subsections (titleDefinition, conditions, actions)
+.studio-subsection {
+	margin-bottom: 1rem;
+	border: 1px solid var(--cds-border-subtle-01);
+	border-radius: 4px;
+	overflow: hidden;
+}
+
+.studio-subsection-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.4rem 0.75rem;
+	background-color: var(--cds-layer-01);
+	border-bottom: 1px solid var(--cds-border-subtle-01);
+	font-size: 0.8125rem;
+	font-weight: 600;
+	color: var(--cds-text-secondary);
+
+	&--top {
+		border-bottom: none;
+	}
+}
+
+.studio-subsection > .studio-parameter-list,
+.studio-subsection > .studio-conditions-builder,
+.studio-subsection > .studio-actions-builder {
+	padding: 0.75rem;
+}
+
+.studio-placeholder-text {
+	font-size: 0.8125rem;
+	color: var(--cds-text-placeholder);
+	padding: 0.375rem 0;
+}
+
+// Conditions builder
+.studio-conditions-builder {
+	.studio-subsection-header {
+		border-bottom: none;
+		padding: 0;
+		margin-bottom: 0.5rem;
+		background: none;
+	}
+}
+
+.studio-condition-row {
+	display: flex;
+	align-items: flex-end;
+	gap: 0.5rem;
+	margin-bottom: 0.75rem;
+	padding-bottom: 0.75rem;
+	border-bottom: 1px solid var(--cds-border-subtle-01);
+
+	&:last-of-type {
+		border-bottom: none;
+		margin-bottom: 0;
+	}
+}
+
+.studio-condition-fields {
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
+.studio-condition-delete {
+	flex-shrink: 0;
+	align-self: flex-end;
+}
+
+// Actions builder
+.studio-actions-builder {
+	.studio-subsection-header {
+		border-bottom: none;
+		padding: 0;
+		margin-bottom: 0.5rem;
+		background: none;
+	}
+}
+
+.studio-action-item {
+	border: 1px solid var(--cds-border-subtle-01);
+	border-radius: 4px;
+	margin-bottom: 0.375rem;
+	background-color: var(--cds-layer-01);
+}
+
+.studio-action-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.5rem 0.75rem;
+	cursor: pointer;
+
+	&:hover {
+		background-color: var(--cds-layer-hover-01);
+	}
+
+	.studio-action-header-label {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.875rem;
+		color: var(--cds-text-primary);
+	}
+
+	.studio-action-img-preview {
+		width: 24px;
+		height: 20px;
+		object-fit: contain;
+		border-radius: 2px;
+	}
+}
+
+.studio-action-form {
+	padding: 0.75rem;
+	border-top: 1px solid var(--cds-border-subtle-01);
+}
+
+// Properties Preview
+.studio-properties-preview {
+	margin-top: 1rem;
+	border: 1px solid var(--cds-border-subtle-01);
+	border-radius: 4px;
+	overflow: hidden;
+
+	.studio-preview-label {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--cds-text-secondary);
+		padding: 0.5rem 0.75rem;
+		background-color: var(--cds-layer-01);
+		border-bottom: 1px solid var(--cds-border-subtle-01);
+	}
+
+	.studio-preview-content {
+		padding: 0.5rem;
+		background-color: var(--cds-layer-02);
+		max-height: 300px;
+		overflow-y: auto;
+	}
+}
+
+// ---- Canvas Preview column ----
+
+.studio-canvas-column {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	overflow: hidden;
+}
+
+.studio-canvas-config {
+	padding: 0.5rem 1rem;
+	border-bottom: 1px solid var(--cds-border-subtle-01);
+	background-color: var(--cds-layer-01);
+	display: flex;
+	gap: 1rem;
+	align-items: center;
+	flex-wrap: wrap;
+	flex-shrink: 0;
+
+	.studio-config-row {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.8125rem;
+		color: var(--cds-text-secondary);
+	}
+}
+
+.studio-canvas-preview {
+	flex: 1;
+	overflow: hidden;
+	position: relative;
+
+	.common-canvas-drop-div {
+		height: 100%;
+	}
+}
+
+// Empty state
+.studio-empty-canvas {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	color: var(--cds-text-placeholder);
+	text-align: center;
+	padding: 2rem;
+	font-size: 0.875rem;
+}

--- a/canvas_modules/harness/src/styles/studio.scss
+++ b/canvas_modules/harness/src/styles/studio.scss
@@ -21,26 +21,6 @@
 	inset: 0;
 	overflow: hidden;
 	background-color: var(--cds-background);
-
-	.right-flyout {
-		border-left: none !important;
-	}
-
-	.properties-right-flyout {
-		border-left: none !important;
-	}
-
-	.properties-btn-resize {
-		position: absolute;
-		left: 0;
-		top: 50%;
-		transform: translate(-50%, -50%);
-		opacity: 1 !important;
-		visibility: visible !important;
-		z-index: 100;
-		right: unset !important;
-		bottom: unset !important;
-	}
 }
 
 .studio-header {
@@ -752,10 +732,6 @@
 		flex: 1;
 		min-height: 0;
 	}
-
-	.properties-close-button {
-		display: none;
-	}
 }
 
 .studio-flyout-footer {
@@ -809,6 +785,42 @@
 	}
 }
 
+// The properties panel is an absolute overlay on top of the canvas so its width
+// is fully under our control and never overflows the canvas column.
+.studio-flyout-overlay {
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	width: clamp(320px, 30%, 500px);
+	z-index: 50;
+	background-color: var(--cds-layer-01);
+	border-left: 1px solid var(--cds-border-subtle-01);
+
+	&.studio-flyout-overlay--expanded {
+		width: min(clamp(480px, 55%, 700px), 100%);
+	}
+
+	.properties-right-flyout {
+		border-left: none;
+	}
+
+	.properties-btn-resize {
+		position: absolute;
+		left: 0;
+		top: 50%;
+		transform: translate(-50%, -50%);
+		opacity: 1 !important;
+		visibility: visible !important;
+		z-index: 100;
+		right: unset !important;
+		bottom: unset !important;
+	}
+
+	.properties-close-button {
+		display: none;
+	}
+}
 
 .studio-empty-canvas {
 	display: flex;

--- a/canvas_modules/harness/src/styles/studio.scss
+++ b/canvas_modules/harness/src/styles/studio.scss
@@ -21,6 +21,26 @@
 	inset: 0;
 	overflow: hidden;
 	background-color: var(--cds-background);
+
+	.right-flyout {
+		border-left: none !important;
+	}
+
+	.properties-right-flyout {
+		border-left: none !important;
+	}
+
+	.properties-btn-resize {
+		position: absolute;
+		left: 0;
+		top: 50%;
+		transform: translate(-50%, -50%);
+		opacity: 1 !important;
+		visibility: visible !important;
+		z-index: 100;
+		right: unset !important;
+		bottom: unset !important;
+	}
 }
 
 .studio-header {
@@ -64,14 +84,14 @@
 	display: grid;
 	grid-template-columns: 320px 320px 1fr;
 	flex: 1;
-	min-height: 0; // prevents flex child from overflowing its container
+	min-height: 0; 
 	overflow: hidden;
 }
 
 .studio-column {
 	display: flex;
 	flex-direction: column;
-	min-height: 0; // prevents grid child from expanding past its track
+	min-height: 0; 
 	overflow: hidden;
 	border-right: 1px solid var(--cds-border-subtle-01);
 
@@ -226,7 +246,6 @@
 	}
 }
 
-// Collapsed column strip
 .studio-column--collapsed {
 	overflow: hidden;
 	display: flex;
@@ -254,7 +273,6 @@
 	padding: 1rem 0;
 }
 
-// Node type form (inline below list)
 .studio-node-type-form {
 	border: 1px solid var(--cds-focus);
 	border-radius: 4px;
@@ -270,7 +288,6 @@
 	margin-bottom: 0.75rem;
 }
 
-// Ports editor
 .studio-ports-editor {
 	margin-top: 0.5rem;
 }
@@ -290,12 +307,10 @@
 	margin-bottom: 0.75rem;
 	min-width: 0;
 
-	// Label input occupies the full first row
 	> *:first-child {
 		grid-column: 1 / -1;
 	}
 
-	// Override Carbon's internal min-width so NumberInput respects the grid track
 	> * {
 		min-width: 0;
 	}
@@ -308,7 +323,6 @@
 	}
 }
 
-// Two equal columns for width + height number inputs (Actions builder)
 .studio-two-col-row {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
@@ -488,7 +502,6 @@
 		background-color: var(--cds-layer-hover-02);
 	}
 
-	// Left info side: must be able to shrink below its content size
 	> div:first-child {
 		display: flex;
 		align-items: center;
@@ -514,7 +527,6 @@
 		flex-shrink: 0;
 	}
 
-	// Action buttons must never be pushed off screen
 	.studio-parameter-actions {
 		display: flex;
 		gap: 0.25rem;
@@ -540,7 +552,7 @@
 	margin-bottom: 0.375rem;
 }
 
-// Subsections (titleDefinition, conditions, actions)
+
 .studio-subsection {
 	margin-bottom: 1rem;
 	border: 1px solid var(--cds-border-subtle-01);
@@ -576,7 +588,7 @@
 	padding: 0.375rem 0;
 }
 
-// Conditions builder
+
 .studio-conditions-builder {
 	.studio-subsection-header {
 		border-bottom: none;
@@ -612,7 +624,6 @@
 	align-self: flex-end;
 }
 
-// Actions builder
 .studio-actions-builder {
 	.studio-subsection-header {
 		border-bottom: none;
@@ -661,7 +672,6 @@
 	border-top: 1px solid var(--cds-border-subtle-01);
 }
 
-// Properties Preview
 .studio-properties-preview {
 	margin-top: 1rem;
 	border: 1px solid var(--cds-border-subtle-01);
@@ -682,6 +692,82 @@
 		background-color: var(--cds-layer-02);
 		max-height: 300px;
 		overflow-y: auto;
+	}
+}
+
+// ---- Node properties right flyout ----
+
+.studio-flyout-panel {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	position: relative;
+}
+
+.studio-flyout-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.75rem 1rem;
+	border-bottom: 1px solid var(--cds-border-subtle-01);
+	background-color: var(--cds-layer-01);
+	flex-shrink: 0;
+	position: relative;
+	z-index: 10;
+	overflow: visible;
+}
+
+.studio-flyout-title {
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: var(--cds-text-primary);
+}
+
+.studio-flyout-close-btn {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	padding: 0;
+	background: none;
+	border: none;
+	cursor: pointer;
+	border-radius: 2px;
+	color: var(--cds-icon-primary);
+	flex-shrink: 0;
+
+	&:hover {
+		background-color: var(--cds-layer-hover-01);
+	}
+
+	&:focus {
+		outline: 2px solid var(--cds-focus);
+		outline-offset: -2px;
+	}
+}
+
+.studio-flyout-panel {
+	.properties-right-flyout-container {
+		flex: 1;
+		min-height: 0;
+	}
+
+	.properties-close-button {
+		display: none;
+	}
+}
+
+.studio-flyout-footer {
+	display: flex;
+	flex-shrink: 0;
+	border-top: 1px solid var(--cds-border-subtle-01);
+
+	.cds--btn {
+		flex: 1;
+		max-width: none;
+		justify-content: center;
+		min-height: 3rem;
 	}
 }
 
@@ -723,7 +809,7 @@
 	}
 }
 
-// Empty state
+
 .studio-empty-canvas {
 	display: flex;
 	flex-direction: column;

--- a/canvas_modules/harness/src/styles/studio.scss
+++ b/canvas_modules/harness/src/styles/studio.scss
@@ -80,13 +80,17 @@
 }
 
 .studio-column-header {
-	padding: 0.75rem 1rem;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.5rem 1rem 0.5rem 1rem;
 	font-size: 0.875rem;
 	font-weight: 600;
 	color: var(--cds-text-primary);
 	background-color: var(--cds-layer-01);
 	border-bottom: 1px solid var(--cds-border-subtle-01);
 	flex-shrink: 0;
+	min-height: 2.5rem;
 }
 
 .studio-column-content {
@@ -219,6 +223,34 @@
 		display: flex;
 		gap: 0.25rem;
 	}
+}
+
+// Collapsed column strip
+.studio-column--collapsed {
+	overflow: hidden;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: pointer;
+	background-color: var(--cds-layer-01);
+	border-right: 1px solid var(--cds-border-subtle-01);
+	user-select: none;
+	min-height: 0;
+
+	&:hover {
+		background-color: var(--cds-layer-hover-01);
+	}
+}
+
+.studio-column-collapsed-label {
+	writing-mode: vertical-rl;
+	text-orientation: mixed;
+	transform: rotate(180deg);
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: var(--cds-text-secondary);
+	white-space: nowrap;
+	padding: 1rem 0;
 }
 
 // Node type form (inline below list)

--- a/canvas_modules/harness/src/styles/studio.scss
+++ b/canvas_modules/harness/src/styles/studio.scss
@@ -84,14 +84,14 @@
 	display: grid;
 	grid-template-columns: 320px 320px 1fr;
 	flex: 1;
-	min-height: 0; 
+	min-height: 0;
 	overflow: hidden;
 }
 
 .studio-column {
 	display: flex;
 	flex-direction: column;
-	min-height: 0; 
+	min-height: 0;
 	overflow: hidden;
 	border-right: 1px solid var(--cds-border-subtle-01);
 

--- a/canvas_modules/harness/src/styles/studio.scss
+++ b/canvas_modules/harness/src/styles/studio.scss
@@ -705,3 +705,63 @@
 	padding: 2rem;
 	font-size: 0.875rem;
 }
+
+// ---- Group Builder ----
+
+.studio-groups-list {
+	margin-top: 0.5rem;
+}
+
+.studio-group-item {
+	border: 1px solid var(--cds-border-subtle-01);
+	border-radius: 4px;
+	padding: 0.75rem;
+	margin-bottom: 0.75rem;
+}
+
+.studio-group-header {
+	display: flex;
+	align-items: flex-end;
+	gap: 0.5rem;
+	margin-bottom: 0.75rem;
+
+	> .cds--form-item {
+		flex: 1;
+	}
+}
+
+.studio-group-delete {
+	flex-shrink: 0;
+}
+
+.studio-group-params {
+	display: flex;
+	flex-direction: column;
+	gap: 0.375rem;
+}
+
+.studio-group-param-check {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-size: 0.875rem;
+	cursor: pointer;
+
+	input[type="checkbox"] {
+		cursor: pointer;
+	}
+}
+
+// ---- Resources Editor ----
+
+.studio-resource-row {
+	display: grid;
+	grid-template-columns: 1fr 1fr auto;
+	gap: 0.5rem;
+	align-items: flex-end;
+	margin-bottom: 0.5rem;
+}
+
+.studio-resource-delete {
+	flex-shrink: 0;
+}

--- a/canvas_modules/harness/src/styles/studio.scss
+++ b/canvas_modules/harness/src/styles/studio.scss
@@ -43,22 +43,19 @@
 			color: var(--cds-text-primary);
 		}
 
-		.studio-back-link {
-			font-size: 0.875rem;
-			color: var(--cds-link-primary);
-			text-decoration: none;
-			cursor: pointer;
-
-			&:hover {
-				text-decoration: underline;
-			}
-		}
 	}
 
 	.studio-header-actions {
 		display: flex;
 		align-items: center;
 		gap: 0.5rem;
+	}
+
+	.studio-header-divider {
+		width: 1px;
+		height: 1.5rem;
+		background-color: var(--cds-border-subtle-01);
+		margin: 0 0.25rem;
 	}
 }
 

--- a/canvas_modules/harness/src/styles/studio.scss
+++ b/canvas_modules/harness/src/styles/studio.scss
@@ -17,7 +17,8 @@
 .studio-page {
 	display: flex;
 	flex-direction: column;
-	height: 100vh;
+	position: fixed;
+	inset: 0;
 	overflow: hidden;
 	background-color: var(--cds-background);
 }

--- a/studio.md
+++ b/studio.md
@@ -251,7 +251,8 @@ Double-clicking a node on the canvas opens its configured properties panel in th
   "studio": {
     "categories": [...],
     "paramDefs": { "<nodeStudioId>": { "titleDefinition": {}, "parameters": [], "conditions": [], "actions": [], "groups": [], "groupLayout": "flat", "resources": {} } },
-    "canvasConfig": {}
+    "canvasConfig": {},
+    "pipelineFlow": { "version": "3.0", "pipelines": [...] }
   },
   "palette": { "version": "3.0", "categories": [...] }
 }
@@ -277,8 +278,12 @@ StudioPage.state
 │       ├── groups[]              → GroupBuilder tab definitions
 │       └── resources{}           → ResourcesEditor key/value pairs
 ├── selectedNodeStudioId          → PaletteBuilder (highlights selected) + PropertiesBuilder (shows params)
-└── canvasConfig{}                → StudioCanvas config toggles → CommonCanvas
+├── canvasConfig{}                → StudioCanvas config toggles → CommonCanvas
+├── pipelineFlow                  → captured from StudioCanvas on every edit; included in Export JSON
+└── importedFlow                  → one-shot trigger: set on Import/mount, consumed by StudioCanvas, then cleared
 ```
+
+`categories`, `paramDefs`, `canvasConfig`, and `pipelineFlow` are persisted to `localStorage` in `componentDidUpdate` and restored in `componentDidMount`, so navigating away from `/#/studio` and returning does not lose the canvas state. `importedFlow` is never persisted — it is only used to hand a restored flow to `StudioCanvas` on remount.
 
 The two generator utilities (`palette-generator.js`, `properties-generator.js`) are pure functions called on every render. Edit a field → state updates → generator runs → JSON changes → canvas/preview re-renders.
 

--- a/studio.md
+++ b/studio.md
@@ -1,0 +1,317 @@
+# Canvas Studio
+
+Canvas Studio is a no-code UI builder added to the Elyra Canvas test harness. It lets non-technical users visually create palette nodes, configure node property forms, and tune canvas settings — without writing any JSON.
+
+**URL:** `http://localhost:3001/#/studio`
+**Entry point:** Click the Canvas Studio button (window icon) in the top-right of the main harness navbar.
+
+---
+
+## How much can the Studio cover?
+
+The CommonProperties `parameterDef` JSON format is a **finite, well-defined specification** of approximately 200 distinct features. It is not infinitely extensible. The Studio currently covers the most commonly used subset. The table below shows the full scope:
+
+| Category | Total in format | Studio covers |
+|---|---|---|
+| Top-level paramDef keys | 9 | 5 (`titleDefinition`, `current_parameters`, `parameters`, `uihints`, `conditions`) |
+| Parameter types | 8 (`string`, `integer`, `double`, `boolean`, `date`, `time`, `timestamp`, `custom`) | 5 (all except `date`, `time`, `timestamp`) |
+| Control types | 33 | 5 auto-mapped from type (`textfield`, `numberfield`, `toggletext`, `oneofselect`, custom) |
+| `parameter_info` fields | 42+ | 5 (`label`, `description`, `control_type`, `action_ref`, auto) |
+| Group/panel types | 14 | 1 (`controls` — single flat group) |
+| Condition types | 7 | 1 (`validation`) |
+| Condition operators | 24+ | 10 (`isNotEmpty`, `isEmpty`, `equals`, `notEquals`, `greaterThan`, `lessThan`, `contains`, `notContains`, `startsWith`, `endsWith`) |
+| Action types | 3 (`button`, `image`, `custom`) | 1 (`image`) |
+| Action fields | 9 | 7 (`id`, `label`, `description`, `image.url`, `image.placement`, `image.size`) |
+
+**What's not yet in the Studio** (features in the format that need manual JSON for now): complex types, tabs/sub-panels, column selection controls, date/time pickers, expression editors, `enabled`/`visible` conditions, dataset metadata, localization resource keys, and custom controls/actions.
+
+---
+
+## Files Added / Modified
+
+### New files
+
+All new files live under `canvas_modules/harness/src/client/components/studio/`.
+
+| File | Purpose |
+|------|---------|
+| `StudioPage.jsx` | Root page — holds all state, 3-column layout, header with Import/Export |
+| `palette-builder/PaletteBuilder.jsx` | Category list with expand/collapse, add/delete |
+| `palette-builder/CategoryForm.jsx` | Form for one category's label, description, icon, open-state |
+| `palette-builder/NodeTypeForm.jsx` | Form for one node type's label, op, description, icon |
+| `palette-builder/PortsEditor.jsx` | Dynamic rows for input/output ports (label + cardinality) |
+| `palette-builder/IconPicker.jsx` | Tab grid of SVGs from `assets/images/` + custom URL tab |
+| `properties-builder/PropertiesBuilder.jsx` | Node selector, titleDefinition, parameter list, ActionsBuilder, ConditionsBuilder |
+| `properties-builder/ParameterForm.jsx` | Form for one parameter's label, id, description, type, required, default, action_ref, enum values |
+| `properties-builder/ConditionsBuilder.jsx` | Validation rule builder — parameter + operator + error message |
+| `properties-builder/ActionsBuilder.jsx` | Image action builder — id, label, tooltip, image URL, placement, size |
+| `properties-builder/PropertiesPreview.jsx` | Live `<CommonProperties>` render of the generated paramDef |
+| `preview/StudioCanvas.jsx` | Live `<CommonCanvas>` with its own CanvasController and config toggles |
+| `utils/palette-generator.js` | Pure function: form state → palette v3.0 JSON |
+| `utils/properties-generator.js` | Pure function: form state → CommonProperties parameterDef JSON |
+| `src/styles/studio.scss` | All Studio styles |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/client/index.js` | Added `<Route exact path="/studio" component={StudioPage} />` |
+| `src/client/App.js` | Added Studio button to `rightBar` in `getNavigationBar()` + `case "studio"` in `toolbarActionHandler` |
+| `assets/styles/harness.scss` | Added `@forward "../../src/styles/studio.scss"` |
+
+---
+
+## UI ↔ JSON ↔ Old Harness Parallel
+
+### 1. Palette Builder → Palette JSON
+
+**Old harness:** Users picked a file from the "Pipeline Flow file" dropdown in the side panel (`sidepanel-canvas.jsx`), or uploaded their own `.json` file. Those files live in `test_resources/palettes/` (e.g. `commonPalette.json`, `carbonPalette.json`).
+
+**New Studio:** The Palette Builder forms write to `StudioPage` state. `palette-generator.js` converts that state to the identical JSON structure on every render and feeds it live to the canvas.
+
+#### CategoryForm → `categories[]`
+
+| UI control | JSON field |
+|------------|-----------|
+| "Category Label" TextInput | `categories[].label` |
+| "Description" TextInput | `categories[].description` |
+| IconPicker selection | `categories[].image` |
+| "Open by default" Toggle | `categories[].is_open` |
+| *(slugified from label)* | `categories[].id` |
+
+#### NodeTypeForm → `categories[].node_types[]`
+
+| UI control | JSON field |
+|------------|-----------|
+| "Label" TextInput | `node_types[].app_data.ui_data.label` |
+| "Operation ID" TextInput | `node_types[].op` |
+| "Description" TextInput | `node_types[].app_data.ui_data.description` |
+| IconPicker selection | `node_types[].app_data.ui_data.image` |
+| *(always set)* | `node_types[].type = "execution_node"` |
+| *(internal studioId)* | `node_types[].id` |
+
+#### PortsEditor → `inputs[]` / `outputs[]`
+
+| UI control | JSON field |
+|------------|-----------|
+| "Label" TextInput | `inputs[]/outputs[].app_data.ui_data.label` |
+| "Min" NumberInput | `inputs[]/outputs[].app_data.ui_data.cardinality.min` |
+| "Max" NumberInput | `inputs[]/outputs[].app_data.ui_data.cardinality.max` |
+| *(uuid)* | `inputs[]/outputs[].id` |
+
+#### Equivalent raw JSON
+
+```json
+{
+  "version": "3.0",
+  "categories": [{
+    "id": "my-nodes",
+    "label": "My Nodes",
+    "description": "",
+    "image": "/images/carbon/gears.svg",
+    "is_open": true,
+    "node_types": [{
+      "id": "<studioId>",
+      "type": "execution_node",
+      "op": "com.example.filter",
+      "inputs": [{ "id": "<portId>", "app_data": { "ui_data": { "label": "Input", "cardinality": { "min": 0, "max": 1 } } } }],
+      "outputs": [{ "id": "<portId>", "app_data": { "ui_data": { "label": "Output", "cardinality": { "min": 0, "max": -1 } } } }],
+      "app_data": { "ui_data": { "label": "Filter", "description": "", "image": "/images/carbon/filter.svg" } }
+    }]
+  }]
+}
+```
+
+---
+
+### 2. Properties Builder → Common Properties parameterDef JSON
+
+**Old harness:** Users picked a file from the "Parameter Defs file" dropdown in the Properties side panel, or uploaded their own. Files live in `test_resources/parameterDefs/`.
+
+**New Studio:** All form fields write to `StudioPage.state.paramDefs[nodeStudioId]`. `properties-generator.js` converts that state to the identical JSON that `<CommonProperties propertiesInfo={{ parameterDef }}>` consumes.
+
+#### Dialog Title (titleDefinition section)
+
+| UI control | JSON field |
+|------------|-----------|
+| "Title" TextInput | `titleDefinition.title` |
+| "Title editable by user" Toggle | `titleDefinition.editable` |
+
+#### ParameterForm → `parameters[]` + `uihints.parameter_info[]`
+
+| UI control | JSON field |
+|------------|-----------|
+| "Display Label" TextInput | `uihints.parameter_info[].label.default` |
+| "Field ID" TextInput | `parameters[].id`, `parameter_info[].parameter_ref`, key in `current_parameters` |
+| "Description" TextInput | `uihints.parameter_info[].description.default` *(omitted if blank)* |
+| "Type" → `string` | `parameters[].type = "string"`, `control_type = "textfield"` |
+| "Type" → `integer` | `parameters[].type = "integer"`, `control_type = "numberfield"` |
+| "Type" → `double` | `parameters[].type = "double"`, `control_type = "numberfield"` |
+| "Type" → `boolean` | `parameters[].type = "boolean"`, `control_type = "toggletext"` |
+| "Type" → `enum` | `parameters[].type = "string"`, `parameters[].enum[]`, `control_type = "oneofselect"` |
+| "Required" Toggle | `parameters[].required` |
+| "Default value" TextInput | `current_parameters[id]` |
+| "Action" Select | `uihints.parameter_info[].action_ref` *(omitted if none)* |
+| Enum option rows | `parameters[].enum[]` |
+
+#### ActionsBuilder → `uihints.action_info[]`
+
+| UI control | JSON field |
+|------------|-----------|
+| "Action ID" TextInput | `action_info[].id` |
+| "Label" TextInput | `action_info[].label.default` |
+| "Description" TextInput | `action_info[].description.default` |
+| "Image URL" TextInput | `action_info[].image.url` |
+| "Placement" Select | `action_info[].image.placement` (`"right"` or `"left"`) |
+| "Width" NumberInput | `action_info[].image.size.width` |
+| "Height" NumberInput | `action_info[].image.size.height` |
+| *(always set)* | `action_info[].control = "image"`, `action_info[].data = {}` |
+
+#### ConditionsBuilder → `conditions[]`
+
+| UI control | JSON field |
+|------------|-----------|
+| "Parameter" Select | `conditions[].validation.fail_message.focus_parameter_ref` and `evaluate.condition.parameter_ref` |
+| "Rule" Select | `conditions[].validation.evaluate.condition.op` |
+| "Value" TextInput *(shown for comparison ops)* | `conditions[].validation.evaluate.condition.value` |
+| "Error message" TextInput | `conditions[].validation.fail_message.message.default` |
+| *(always set)* | `fail_message.type = "error"` |
+
+#### Equivalent raw JSON (matching the example file from the user)
+
+```json
+{
+  "titleDefinition": { "title": "Action Image Alignment Test", "editable": false },
+  "current_parameters": { "text_right": "", "text_left": "" },
+  "parameters": [
+    { "id": "text_right", "type": "string", "required": true },
+    { "id": "dropdown_right", "type": "string", "required": true, "enum": ["Alpha", "Beta", "Gamma"] }
+  ],
+  "uihints": {
+    "id": "action_image_alignment_test",
+    "parameter_info": [
+      { "parameter_ref": "text_right", "label": { "default": "Text input — action RIGHT" }, "action_ref": "moon_right" },
+      { "parameter_ref": "dropdown_right", "label": { "default": "Dropdown — action RIGHT" }, "control_type": "oneofselect", "action_ref": "moon_right" }
+    ],
+    "action_info": [{
+      "id": "moon_right",
+      "label": { "default": "Moon" },
+      "description": { "default": "Moon action tooltip" },
+      "control": "image",
+      "data": {},
+      "image": { "url": "/images/moon.jpg", "placement": "right", "size": { "height": 20, "width": 25 } }
+    }],
+    "group_info": [{ "id": "main-group", "type": "controls", "parameter_refs": ["text_right", "dropdown_right"] }]
+  },
+  "conditions": [{
+    "validation": {
+      "fail_message": { "type": "error", "focus_parameter_ref": "text_right", "message": { "default": "This field is required." } },
+      "evaluate": { "condition": { "parameter_ref": "text_right", "op": "isNotEmpty" } }
+    }
+  }]
+}
+```
+
+---
+
+### 3. Canvas Config Toggles → `canvasConfig` prop
+
+**Old harness:** The "Common Canvas Options" side panel (`sidepanel-canvas.jsx`) had `RadioButtonGroup`, `Toggle`, and `Select` controls that each called `setStateValue()` to update `App.js` state.
+
+**New Studio:** The config row at the top of the canvas preview column does the same thing, calling `StudioPage.handleCanvasConfigChange(key, value)`.
+
+| Studio UI control | `canvasConfig` key | Old harness equivalent |
+|-------------------|--------------------|----------------------|
+| "Snap" Select | `enableSnapToGridType` | "Snap to Grid" RadioButtonGroup |
+| "Links" Select | `enableLinkType` | "Link Type" RadioButtonGroup |
+| "Direction" Select | `enableLinkDirection` | "Link Direction" RadioButtonGroup |
+| "Method" Select | `enableLinkMethod` | "Link Method" RadioButtonGroup |
+| "Narrow palette" Toggle | `enableNarrowPalette` | "Narrow Palette" Toggle |
+
+---
+
+### 4. Live Canvas Preview → CanvasController
+
+**Old harness:** `App.js` held a single `CanvasController`. When the user selected a palette file, it called `this.canvasController.setPipelineFlowPalette(json)`.
+
+**New Studio:** `StudioCanvas.jsx` owns its own `CanvasController` (created in constructor, same pattern as `flows-canvas.jsx`). `componentDidUpdate` detects when `paletteJSON` prop changed and calls `setPipelineFlowPalette` again.
+
+```
+Old harness                              New Studio
+────────────────────────────────         ──────────────────────────────────
+User picks file from dropdown       →    User edits a form field
+↓                                        ↓
+FormsService fetches JSON from       →    palette-generator.js converts
+test_resources/palettes/                  StudioPage state to JSON
+↓                                        ↓
+canvasController                    →    canvasController
+  .setPipelineFlowPalette(json)            .setPipelineFlowPalette(json)
+↓                                        ↓
+CommonCanvas re-renders palette      →    CommonCanvas re-renders palette
+```
+
+Double-clicking a node on the canvas opens its configured properties panel in the right flyout via `properties-generator.js`.
+
+---
+
+### 5. Export / Import → JSON bundle
+
+**Old harness:** JSON files in `test_resources/` were static files. To create a new configuration you had to write it by hand.
+
+**New Studio:** "Export JSON" downloads `studio-config.json`. The exported `palette` block is identical in format to any file in `test_resources/palettes/` and can be used directly in the existing harness dropdown.
+
+```json
+{
+  "version": "1.0",
+  "studio": {
+    "categories": [...],
+    "paramDefs": { "<nodeStudioId>": { "titleDefinition": {}, "parameters": [], "conditions": [], "actions": [] } },
+    "canvasConfig": {}
+  },
+  "palette": { "version": "3.0", "categories": [...] }
+}
+```
+
+---
+
+## State Architecture
+
+All Studio state lives in `StudioPage` and flows down as props. No Redux, no separate context.
+
+```
+StudioPage.state
+├── categories[]                  → PaletteBuilder → palette-generator.js → StudioCanvas
+│   └── nodeTypes[]
+├── paramDefs{}                   → PropertiesBuilder → properties-generator.js
+│   └── [nodeStudioId]:
+│       ├── titleDefinition       → titleDefinition section
+│       ├── parameters[]          → ParameterForm rows
+│       ├── conditions[]          → ConditionsBuilder rows
+│       └── actions[]             → ActionsBuilder rows
+├── selectedNodeStudioId          → PaletteBuilder (highlights selected) + PropertiesBuilder (shows params)
+└── canvasConfig{}                → StudioCanvas config toggles → CommonCanvas
+```
+
+The two generator utilities (`palette-generator.js`, `properties-generator.js`) are pure functions called on every render. Edit a field → state updates → generator runs → JSON changes → canvas/preview re-renders.
+
+---
+
+## What Could Be Added Next
+
+Features in the CommonProperties format not yet in the Studio, roughly ordered by how commonly they appear in real paramDef files:
+
+| Feature | JSON key | Complexity to add |
+|---|---|---|
+| Placeholder text per field | `parameter_info[].place_holder_text` | Low — one TextInput in ParameterForm |
+| `enabled` / `visible` conditions | `conditions[].enabled`, `conditions[].visible` | Low — extend ConditionsBuilder with type selector |
+| Panel tabs / sub-tabs | `group_info[].type = "tabs"` | Medium — GroupBuilder component |
+| Date / time fields | `type = "date"`, `control = "datepicker"` | Medium — add types to ParameterForm |
+| Button-type actions | `action_info[].control = "button"` | Low — add type toggle to ActionsBuilder |
+| Character limit per field | `parameter_info[].char_limit` | Low — one NumberInput in ParameterForm |
+| Helper text per field | `parameter_info[].helper_text` | Low — one TextInput in ParameterForm |
+| Read-only fields | `parameter_info[].read_only` | Low — one Toggle in ParameterForm |
+| Textarea (multi-line) | `control_type = "textarea"` | Low — add to type options |
+| Expression editor | `control_type = "expression"` | Low — add to type options |
+| Complex types (tables) | `complex_types[]` | High — requires a separate ComplexTypeBuilder |
+| Column selection controls | `control = "selectcolumn"` | High — requires dataset_metadata |
+| Localization resources | `resources{}`, `resource_key` | Medium — ResourcesEditor |

--- a/studio.md
+++ b/studio.md
@@ -2,28 +2,28 @@
 
 Canvas Studio is a no-code UI builder added to the Elyra Canvas test harness. It lets non-technical users visually create palette nodes, configure node property forms, and tune canvas settings — without writing any JSON.
 
-**URL:** `http://localhost:3001/#/studio`
+**URL:** `http://localhost:3001/#/studio` 
 **Entry point:** Click the Canvas Studio button (window icon) in the top-right of the main harness navbar.
 
 ---
 
 ## How much can the Studio cover?
 
-The CommonProperties `parameterDef` JSON format is a **finite, well-defined specification** of approximately 200 distinct features. It is not infinitely extensible. The Studio currently covers the most commonly used subset. The table below shows the full scope:
+The CommonProperties `parameterDef` JSON format is a specification of approximately 200 distinct features. The Studio currently covers a specific subset of those features. The table below shows the full scope:
 
 | Category | Total in format | Studio covers |
 |---|---|---|
-| Top-level paramDef keys | 9 | 5 (`titleDefinition`, `current_parameters`, `parameters`, `uihints`, `conditions`) |
-| Parameter types | 8 (`string`, `integer`, `double`, `boolean`, `date`, `time`, `timestamp`, `custom`) | 5 (all except `date`, `time`, `timestamp`) |
-| Control types | 33 | 5 auto-mapped from type (`textfield`, `numberfield`, `toggletext`, `oneofselect`, custom) |
-| `parameter_info` fields | 42+ | 5 (`label`, `description`, `control_type`, `action_ref`, auto) |
-| Group/panel types | 14 | 1 (`controls` — single flat group) |
-| Condition types | 7 | 1 (`validation`) |
+| Top-level paramDef keys | 9 | 7 (`titleDefinition`, `current_parameters`, `parameters`, `uihints`, `conditions`, `resources`, `group_info` via layout) |
+| Parameter types | 8 (`string`, `integer`, `double`, `boolean`, `date`, `time`, `timestamp`, `custom`) | 7 (all except `custom`) |
+| Control types | 33 | 9 auto-mapped from type (`textfield`, `numberfield`, `toggletext`, `oneofselect`, `textarea`, `expression`, `datepicker`, `timepicker`, `datetimepicker`) |
+| `parameter_info` fields | 42+ | 9 (`label`, `description`, `control_type`, `action_ref`, `place_holder_text`, `helper_text`, `char_limit`, `read_only`, auto) |
+| Group/panel types | 14 | 2 (`controls` flat, `tabs`) |
+| Condition types | 7 | 3 (`validation`, `enabled`, `visible`) |
 | Condition operators | 24+ | 10 (`isNotEmpty`, `isEmpty`, `equals`, `notEquals`, `greaterThan`, `lessThan`, `contains`, `notContains`, `startsWith`, `endsWith`) |
-| Action types | 3 (`button`, `image`, `custom`) | 1 (`image`) |
-| Action fields | 9 | 7 (`id`, `label`, `description`, `image.url`, `image.placement`, `image.size`) |
+| Action types | 3 (`button`, `image`, `custom`) | 2 (`image`, `button`) |
+| Action fields | 9 | 8 (`id`, `label`, `description`, `control`, `image.url`, `image.placement`, `image.size`, `data.parameter_ref`) |
 
-**What's not yet in the Studio** (features in the format that need manual JSON for now): complex types, tabs/sub-panels, column selection controls, date/time pickers, expression editors, `enabled`/`visible` conditions, dataset metadata, localization resource keys, and custom controls/actions.
+**What's not yet in the Studio** (features in the format that need manual JSON for now): complex types, column selection controls, dataset metadata, and custom controls/actions.
 
 ---
 
@@ -31,7 +31,7 @@ The CommonProperties `parameterDef` JSON format is a **finite, well-defined spec
 
 ### New files
 
-All new files live under `canvas_modules/harness/src/client/components/studio/`.
+Most new files live under `canvas_modules/harness/src/client/components/studio/`. The stylesheet is at `canvas_modules/harness/src/styles/studio.scss`.
 
 | File | Purpose |
 |------|---------|
@@ -41,10 +41,12 @@ All new files live under `canvas_modules/harness/src/client/components/studio/`.
 | `palette-builder/NodeTypeForm.jsx` | Form for one node type's label, op, description, icon |
 | `palette-builder/PortsEditor.jsx` | Dynamic rows for input/output ports (label + cardinality) |
 | `palette-builder/IconPicker.jsx` | Tab grid of SVGs from `assets/images/` + custom URL tab |
-| `properties-builder/PropertiesBuilder.jsx` | Node selector, titleDefinition, parameter list, ActionsBuilder, ConditionsBuilder |
-| `properties-builder/ParameterForm.jsx` | Form for one parameter's label, id, description, type, required, default, action_ref, enum values |
-| `properties-builder/ConditionsBuilder.jsx` | Validation rule builder — parameter + operator + error message |
-| `properties-builder/ActionsBuilder.jsx` | Image action builder — id, label, tooltip, image URL, placement, size |
+| `properties-builder/PropertiesBuilder.jsx` | Node selector, titleDefinition, parameter list, ActionsBuilder, ConditionsBuilder, GroupBuilder, ResourcesEditor |
+| `properties-builder/ParameterForm.jsx` | Form for one parameter's label, id, description, type, required, default, placeholder, helper text, char limit, read-only, action_ref, enum values |
+| `properties-builder/ConditionsBuilder.jsx` | Rule builder — validation errors, enabled/disabled fields, show/hide fields |
+| `properties-builder/ActionsBuilder.jsx` | Action builder — image/icon or button type, id, label, tooltip, image URL, placement, size |
+| `properties-builder/GroupBuilder.jsx` | Layout selector (flat / tabs) and tab group definitions |
+| `properties-builder/ResourcesEditor.jsx` | Key/value editor for localization resource strings |
 | `properties-builder/PropertiesPreview.jsx` | Live `<CommonProperties>` render of the generated paramDef |
 | `preview/StudioCanvas.jsx` | Live `<CommonCanvas>` with its own CanvasController and config toggles |
 | `utils/palette-generator.js` | Pure function: form state → palette v3.0 JSON |
@@ -84,7 +86,7 @@ All new files live under `canvas_modules/harness/src/client/components/studio/`.
 | UI control | JSON field |
 |------------|-----------|
 | "Label" TextInput | `node_types[].app_data.ui_data.label` |
-| "Operation ID" TextInput | `node_types[].op` |
+| "Operation ID (op)" TextInput | `node_types[].op` |
 | "Description" TextInput | `node_types[].app_data.ui_data.description` |
 | IconPicker selection | `node_types[].app_data.ui_data.image` |
 | *(always set)* | `node_types[].type = "execution_node"` |
@@ -95,32 +97,9 @@ All new files live under `canvas_modules/harness/src/client/components/studio/`.
 | UI control | JSON field |
 |------------|-----------|
 | "Label" TextInput | `inputs[]/outputs[].app_data.ui_data.label` |
-| "Min" NumberInput | `inputs[]/outputs[].app_data.ui_data.cardinality.min` |
-| "Max" NumberInput | `inputs[]/outputs[].app_data.ui_data.cardinality.max` |
+| "Min" number input | `inputs[]/outputs[].app_data.ui_data.cardinality.min` |
+| "Max" number input | `inputs[]/outputs[].app_data.ui_data.cardinality.max` |
 | *(uuid)* | `inputs[]/outputs[].id` |
-
-#### Equivalent raw JSON
-
-```json
-{
-  "version": "3.0",
-  "categories": [{
-    "id": "my-nodes",
-    "label": "My Nodes",
-    "description": "",
-    "image": "/images/carbon/gears.svg",
-    "is_open": true,
-    "node_types": [{
-      "id": "<studioId>",
-      "type": "execution_node",
-      "op": "com.example.filter",
-      "inputs": [{ "id": "<portId>", "app_data": { "ui_data": { "label": "Input", "cardinality": { "min": 0, "max": 1 } } } }],
-      "outputs": [{ "id": "<portId>", "app_data": { "ui_data": { "label": "Output", "cardinality": { "min": 0, "max": -1 } } } }],
-      "app_data": { "ui_data": { "label": "Filter", "description": "", "image": "/images/carbon/filter.svg" } }
-    }]
-  }]
-}
-```
 
 ---
 
@@ -149,68 +128,74 @@ All new files live under `canvas_modules/harness/src/client/components/studio/`.
 | "Type" → `double` | `parameters[].type = "double"`, `control_type = "numberfield"` |
 | "Type" → `boolean` | `parameters[].type = "boolean"`, `control_type = "toggletext"` |
 | "Type" → `enum` | `parameters[].type = "string"`, `parameters[].enum[]`, `control_type = "oneofselect"` |
+| "Type" → `textarea` | `parameters[].type = "string"`, `control_type = "textarea"` |
+| "Type" → `expression` | `parameters[].type = "string"`, `control_type = "expression"` |
+| "Type" → `date` | `parameters[].type = "date"`, `control_type = "datepicker"` |
+| "Type" → `time` | `parameters[].type = "time"`, `control_type = "timepicker"` |
+| "Type" → `timestamp` | `parameters[].type = "timestamp"`, `control_type = "datetimepicker"` |
 | "Required" Toggle | `parameters[].required` |
-| "Default value" TextInput | `current_parameters[id]` |
-| "Action" Select | `uihints.parameter_info[].action_ref` *(omitted if none)* |
-| Enum option rows | `parameters[].enum[]` |
+| "Default value" TextInput | `current_parameters[id]` *(hidden for boolean and enum)* |
+| "Placeholder text" TextInput | `uihints.parameter_info[].place_holder_text.default` *(omitted if blank; hidden for boolean and enum)* |
+| "Helper text" TextInput | `uihints.parameter_info[].helper_text.default` *(omitted if blank)* |
+| "Character limit" number input | `uihints.parameter_info[].char_limit` *(omitted if 0; shown for string/textarea/expression only)* |
+| "Read-only" Toggle | `uihints.parameter_info[].read_only` *(omitted if false)* |
+| "Action" Select | `uihints.parameter_info[].action_ref` *(omitted if none; only shown when actions exist)* |
+| Enum option rows | `parameters[].enum[]` *(only shown when type = enum)* |
 
 #### ActionsBuilder → `uihints.action_info[]`
 
 | UI control | JSON field |
 |------------|-----------|
+| "Action type" Select | `action_info[].control` (`"image"` or `"button"`) |
 | "Action ID" TextInput | `action_info[].id` |
 | "Label" TextInput | `action_info[].label.default` |
 | "Description" TextInput | `action_info[].description.default` |
-| "Image URL" TextInput | `action_info[].image.url` |
-| "Placement" Select | `action_info[].image.placement` (`"right"` or `"left"`) |
-| "Width" NumberInput | `action_info[].image.size.width` |
-| "Height" NumberInput | `action_info[].image.size.height` |
-| *(always set)* | `action_info[].control = "image"`, `action_info[].data = {}` |
+| "Image URL" TextInput *(image type only)* | `action_info[].image.url` |
+| "Placement" Select *(image type only)* | `action_info[].image.placement` (`"right"` or `"left"`) |
+| "Width" number input *(image type only)* | `action_info[].image.size.width` |
+| "Height" number input *(image type only)* | `action_info[].image.size.height` |
+| "Parameter ref" TextInput *(button type only)* | `action_info[].data.parameter_ref` *(omitted if blank)* |
 
 #### ConditionsBuilder → `conditions[]`
 
+Each condition row produces one of three JSON shapes depending on the "Condition type" Select:
+
+**Validation error** (`conditionType = "validation"`):
+
 | UI control | JSON field |
 |------------|-----------|
-| "Parameter" Select | `conditions[].validation.fail_message.focus_parameter_ref` and `evaluate.condition.parameter_ref` |
-| "Rule" Select | `conditions[].validation.evaluate.condition.op` |
-| "Value" TextInput *(shown for comparison ops)* | `conditions[].validation.evaluate.condition.value` |
-| "Error message" TextInput | `conditions[].validation.fail_message.message.default` |
+| "Condition type" Select | selects `conditions[].validation` shape |
+| "Parameter" Select | `validation.fail_message.focus_parameter_ref` and `evaluate.condition.parameter_ref` |
+| "Rule" Select | `validation.evaluate.condition.op` |
+| "Value" TextInput *(shown for comparison ops)* | `validation.evaluate.condition.value` |
+| "Error message" TextInput | `validation.fail_message.message.default` |
 | *(always set)* | `fail_message.type = "error"` |
 
-#### Equivalent raw JSON (matching the example file from the user)
+**Enable / disable a field** (`conditionType = "enabled"`) or **Show / hide a field** (`conditionType = "visible"`):
 
-```json
-{
-  "titleDefinition": { "title": "Action Image Alignment Test", "editable": false },
-  "current_parameters": { "text_right": "", "text_left": "" },
-  "parameters": [
-    { "id": "text_right", "type": "string", "required": true },
-    { "id": "dropdown_right", "type": "string", "required": true, "enum": ["Alpha", "Beta", "Gamma"] }
-  ],
-  "uihints": {
-    "id": "action_image_alignment_test",
-    "parameter_info": [
-      { "parameter_ref": "text_right", "label": { "default": "Text input — action RIGHT" }, "action_ref": "moon_right" },
-      { "parameter_ref": "dropdown_right", "label": { "default": "Dropdown — action RIGHT" }, "control_type": "oneofselect", "action_ref": "moon_right" }
-    ],
-    "action_info": [{
-      "id": "moon_right",
-      "label": { "default": "Moon" },
-      "description": { "default": "Moon action tooltip" },
-      "control": "image",
-      "data": {},
-      "image": { "url": "/images/moon.jpg", "placement": "right", "size": { "height": 20, "width": 25 } }
-    }],
-    "group_info": [{ "id": "main-group", "type": "controls", "parameter_refs": ["text_right", "dropdown_right"] }]
-  },
-  "conditions": [{
-    "validation": {
-      "fail_message": { "type": "error", "focus_parameter_ref": "text_right", "message": { "default": "This field is required." } },
-      "evaluate": { "condition": { "parameter_ref": "text_right", "op": "isNotEmpty" } }
-    }
-  }]
-}
-```
+| UI control | JSON field |
+|------------|-----------|
+| "Condition type" Select | selects `conditions[].enabled` or `conditions[].visible` shape |
+| "Enable/Show this field" Select | `enabled.parameter_refs[0]` / `visible.parameter_refs[0]` |
+| "When this parameter" Select | `enabled.evaluate.condition.parameter_ref` |
+| "Rule" Select | `enabled.evaluate.condition.op` |
+| "Value" TextInput *(shown for comparison ops)* | `enabled.evaluate.condition.value` |
+
+#### GroupBuilder → `uihints.group_info[]`
+
+| UI control | JSON field |
+|------------|-----------|
+| "Panel layout" Select → `flat` | `group_info: [{ id: "main-group", type: "controls", parameter_refs: [...all params] }]` |
+| "Panel layout" Select → `tabs` | `group_info: [{ id: "main-tabs", type: "tabs", group_info: [...tabs] }]` |
+| Tab "Tab label" TextInput | `group_info[].group_info[].label.default` |
+| Tab parameter checkboxes | `group_info[].group_info[].parameter_refs[]` |
+
+#### ResourcesEditor → `resources{}`
+
+| UI control | JSON field |
+|------------|-----------|
+| "Key" TextInput | key in `resources` object |
+| "Value" TextInput | value in `resources` object |
 
 ---
 
@@ -265,7 +250,7 @@ Double-clicking a node on the canvas opens its configured properties panel in th
   "version": "1.0",
   "studio": {
     "categories": [...],
-    "paramDefs": { "<nodeStudioId>": { "titleDefinition": {}, "parameters": [], "conditions": [], "actions": [] } },
+    "paramDefs": { "<nodeStudioId>": { "titleDefinition": {}, "parameters": [], "conditions": [], "actions": [], "groups": [], "groupLayout": "flat", "resources": {} } },
     "canvasConfig": {}
   },
   "palette": { "version": "3.0", "categories": [...] }
@@ -287,7 +272,10 @@ StudioPage.state
 │       ├── titleDefinition       → titleDefinition section
 │       ├── parameters[]          → ParameterForm rows
 │       ├── conditions[]          → ConditionsBuilder rows
-│       └── actions[]             → ActionsBuilder rows
+│       ├── actions[]             → ActionsBuilder rows
+│       ├── groupLayout           → GroupBuilder layout selector
+│       ├── groups[]              → GroupBuilder tab definitions
+│       └── resources{}           → ResourcesEditor key/value pairs
 ├── selectedNodeStudioId          → PaletteBuilder (highlights selected) + PropertiesBuilder (shows params)
 └── canvasConfig{}                → StudioCanvas config toggles → CommonCanvas
 ```
@@ -298,20 +286,12 @@ The two generator utilities (`palette-generator.js`, `properties-generator.js`) 
 
 ## What Could Be Added Next
 
-Features in the CommonProperties format not yet in the Studio, roughly ordered by how commonly they appear in real paramDef files:
+Features in the CommonProperties format not yet in the Studio:
 
-| Feature | JSON key | Complexity to add |
+| Feature | JSON key | Note |
 |---|---|---|
-| Placeholder text per field | `parameter_info[].place_holder_text` | Low — one TextInput in ParameterForm |
-| `enabled` / `visible` conditions | `conditions[].enabled`, `conditions[].visible` | Low — extend ConditionsBuilder with type selector |
-| Panel tabs / sub-tabs | `group_info[].type = "tabs"` | Medium — GroupBuilder component |
-| Date / time fields | `type = "date"`, `control = "datepicker"` | Medium — add types to ParameterForm |
-| Button-type actions | `action_info[].control = "button"` | Low — add type toggle to ActionsBuilder |
-| Character limit per field | `parameter_info[].char_limit` | Low — one NumberInput in ParameterForm |
-| Helper text per field | `parameter_info[].helper_text` | Low — one TextInput in ParameterForm |
-| Read-only fields | `parameter_info[].read_only` | Low — one Toggle in ParameterForm |
-| Textarea (multi-line) | `control_type = "textarea"` | Low — add to type options |
-| Expression editor | `control_type = "expression"` | Low — add to type options |
-| Complex types (tables) | `complex_types[]` | High — requires a separate ComplexTypeBuilder |
-| Column selection controls | `control = "selectcolumn"` | High — requires dataset_metadata |
-| Localization resources | `resources{}`, `resource_key` | Medium — ResourcesEditor |
+| Complex types (tables) | `complex_types[]` | Requires a ComplexTypeBuilder sub-editor for defining struct/table schemas |
+| Column selection controls | `control = "selectcolumn"` | Requires `dataset_metadata` — runtime external data (column names from a dataset) |
+| Resource key on fields | `parameter_info[].resource_key` | Would replace `label.default` with a key into the `resources` object — ResourcesEditor is already implemented |
+| Sub-tabs / nested groups | `group_info[].type = "subTabs"` | Currently only top-level tabs are supported |
+| Multiple targets per enabled/visible condition | `enabled.parameter_refs[]` | Currently one target parameter per rule; multi-select would allow controlling several at once |


### PR DESCRIPTION
**Implements:** #3259 

**Summary:** adds Canvas Studio, a visual builder to the Elyra Canvas test harness that lets users create and test canvas configurations without writing JSON. Accessible at /#/studio via the new toolbar button.

**Documentation:** https://ibm.box.com/s/ek3iit1n7g05gy2rgaren75fp2aophdn
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

