### PR TITLE
#4427 Password type field is not masked when used as a part of complex

### DIFF
--- a/canvas_modules/common-canvas/__tests__/common-properties/controls/passwordfield-test.js
+++ b/canvas_modules/common-canvas/__tests__/common-properties/controls/passwordfield-test.js
@@ -279,3 +279,49 @@ describe("passwordfield classnames appear correctly", () => {
 		expect(tableControlDiv.querySelectorAll(".table-subpanel-passwordfield-control-class")).to.have.length(3);
 	});
 });
+
+describe("passwordfield values are masked in table cells", () => {
+	let wrapper;
+	beforeEach(() => {
+		const renderedObject = propertyUtilsRTL.flyoutEditorForm(passwordfieldParamDef);
+		wrapper = renderedObject.wrapper;
+		propertyUtilsRTL.openSummaryPanel(wrapper, "passwordfield-table-summary");
+	});
+
+	it("passwordfield with edit_style on_panel should be masked in the table cell", () => {
+		const cell = wrapper.container.querySelector("div.properties-readonly[data-id='properties-pwd_table_0_2']");
+		expect(cell.querySelector("span.properties-field-type").textContent).to.equal("•••••••");
+	});
+
+	it("passwordfield with edit_style subpanel should be masked in the table cell", () => {
+		const cell = wrapper.container.querySelector("div.properties-readonly[data-id='properties-pwd_table_0_3']");
+		expect(cell.querySelector("span.properties-field-type").textContent).to.equal("•••••••");
+	});
+
+	it("masked passwordfield should not display the value in the tooltip", () => {
+		const cell = wrapper.container.querySelector("div.properties-readonly[data-id='properties-pwd_table_0_3']");
+		expect(cell.textContent.includes("Babbage")).to.equal(false);
+	});
+
+	it("passwordfield without a value should not be masked in the table cell", () => {
+		const cell = wrapper.container.querySelector("div.properties-readonly[data-id='properties-pwd_table_1_3']");
+		expect(cell.querySelector("span.properties-field-type").textContent).to.equal("");
+	});
+});
+
+describe("passwordfield values are masked in the summary panel", () => {
+	let wrapper;
+	beforeEach(() => {
+		const renderedObject = propertyUtilsRTL.flyoutEditorForm(passwordfieldParamDef);
+		wrapper = renderedObject.wrapper;
+	});
+
+	it("passwordfield summary value should be masked", () => {
+		const summaryPanel = wrapper.container.querySelector("div[data-id='properties-passwordfield-table-summary']");
+		const summaryRows = summaryPanel.querySelectorAll("tr.properties-summary-row");
+		expect(summaryRows).to.have.length(2);
+		summaryRows.forEach((summaryRow) => {
+			expect(summaryRow.textContent.trim()).to.equal("••••••");
+		});
+	});
+});

--- a/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/passwordfield_paramDef.json
+++ b/canvas_modules/common-canvas/__tests__/test_resources/paramDefs/passwordfield_paramDef.json
@@ -251,6 +251,7 @@
             "label": {
               "default": "Standard"
             },
+            "summary": true,
             "class_name": "table-passwordfield-control-class"
           },
           {

--- a/canvas_modules/common-canvas/src/common-properties/constants/constants.js
+++ b/canvas_modules/common-canvas/src/common-properties/constants/constants.js
@@ -139,6 +139,8 @@ export const MESSAGE_KEYS = {
 
 export const TRUNCATE_LIMIT = 10000;
 
+export const MASK_CHARACTER = "•";
+
 export const CONDITION_ERROR_MESSAGE = {
 	HIDDEN: "0px",
 	VISIBLE: "30px"

--- a/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/readonly/readonly.jsx
@@ -85,6 +85,10 @@ class ReadonlyControl extends React.Component {
 			controlValue = controlValue.toString();
 		}
 
+		if (this.props.control.controlType === ControlType.PASSWORDFIELD) {
+			controlValue = ControlUtils.maskDisplayValue(controlValue);
+		}
+
 		controlValue = ControlUtils.truncateDisplayValue(controlValue);
 
 		if (this.props.control.controlType === ControlType.CUSTOM) {

--- a/canvas_modules/common-canvas/src/common-properties/panels/summary/summary.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/panels/summary/summary.jsx
@@ -29,7 +29,7 @@ import * as PropertyUtils from "./../../util/property-utils";
 import * as ControlUtils from "./../../util/control-utils";
 import { MESSAGE_KEYS, CONDITION_MESSAGE_TYPE } from "./../../constants/constants";
 import { STATES } from "./../../constants/constants.js";
-import { Type, ParamRole } from "./../../constants/form-constants.js";
+import { Type, ParamRole, ControlType } from "./../../constants/form-constants.js";
 import classNames from "classnames";
 
 import Tooltip from "./../../../tooltip/tooltip.jsx";
@@ -223,6 +223,10 @@ class SummaryPanel extends React.Component {
 				// We don't know what this object is, but we know we can't display it as an object
 				returnValue = JSON.stringify(returnValue);
 			}
+		}
+
+		if (control.controlType === ControlType.PASSWORDFIELD) {
+			returnValue = ControlUtils.maskDisplayValue(returnValue);
 		}
 
 		return returnValue;

--- a/canvas_modules/common-canvas/src/common-properties/util/control-utils.js
+++ b/canvas_modules/common-canvas/src/common-properties/util/control-utils.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { v4 as uuid4 } from "uuid";
-import { TRUNCATE_LIMIT, DEFAULT_DATEPICKER_FORMAT, DEFAULT_DATE_FORMAT, DEFAULT_TIME_FORMAT } from "../constants/constants";
+import { TRUNCATE_LIMIT, MASK_CHARACTER, DEFAULT_DATEPICKER_FORMAT, DEFAULT_DATE_FORMAT, DEFAULT_TIME_FORMAT } from "../constants/constants";
 import { ControlType } from "../constants/form-constants";
 
 /**
@@ -95,6 +95,14 @@ function truncateDisplayValue(value) {
 	return value;
 }
 
+// mask the value that gets displayed for controls that shouldn't show their value in plain text
+function maskDisplayValue(value) {
+	if (typeof value === "string") {
+		return MASK_CHARACTER.repeat(value.length);
+	}
+	return value;
+}
+
 function getValidationProps(messageInfo, inTable) {
 	const validationProps = {};
 	// inline in tables don't show carbon error/warn
@@ -131,6 +139,7 @@ export {
 	splitNewlines,
 	joinNewlines,
 	truncateDisplayValue,
+	maskDisplayValue,
 	getValidationProps,
 	getDateTimeFormat
 };

--- a/canvas_modules/harness/test_resources/parameterDefs/passwordfield_paramDef.json
+++ b/canvas_modules/harness/test_resources/parameterDefs/passwordfield_paramDef.json
@@ -254,6 +254,7 @@
             "label": {
               "default": "Standard"
             },
+            "summary": true,
             "class_name": "table-passwordfield-control-class"
           },
           {

--- a/docs/pages/04.04-controls.md
+++ b/docs/pages/04.04-controls.md
@@ -32,7 +32,7 @@ The following controls are supported in the Common Properties editor. Control ty
 * `readonly` A read only text field. Used for fields users shouldn't edit.
 * `hidden` A control that has no UI to display.
 * `textfield` A single line editable text field.
-* `passwordfield` A masked single line text field with tooltip. The tooltip text can be customized by setting `[parameter_id].passwordHide.tooltip` and `[parameter_id].passwordShow.tooltip` in resources section.
+* `passwordfield` A masked single line text field with tooltip. The tooltip text can be customized by setting `[parameter_id].passwordHide.tooltip` and `[parameter_id].passwordShow.tooltip` in resources section. The value is also masked wherever it is displayed as read only text, for example in a table cell of a column using `edit_style` `subpanel` or `on_panel`, or in a summary panel.
 * `textarea` A multi-line text area.
 * `list` A single column table for editing a list of values.
 * `expression` An expression editing field  that provides language specific syntax highlighting and text auto complete.  An expression builder addon is available with the expression control.  You must provide the `expressionInfo` field for the `propertiesInfo` config. See [Common Properties Documentation](04-common-properties.md#step-2-set-the-data) for more details. To maximize in a tearsheet add this attribute and define a `tearsheetPanel` in `group_info`.


### PR DESCRIPTION
Fixes: [3296](https://github.com/elyra-ai/canvas/issues/3296)

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.