### PR TITLE
#3303 Fix eslint-a11y warnings for common-canvas component

### DIFF
--- a/canvas_modules/common-canvas/locales/common-canvas/locales/en.json
+++ b/canvas_modules/common-canvas/locales/common-canvas/locales/en.json
@@ -9,6 +9,8 @@
   "edit.pasteSelection": "Paste",
   "canvas.label": "Flow Editor",
   "canvas.contents": "Flow editor contents",
+  "canvas.bottomPanelResize": "Resize bottom panel",
+  "canvas.rightFlyoutResize": "Resize right flyout panel",
   "canvas.addComment": "New comment",
   "canvas.addWysiwygComment": "New WYSIWYG comment",
   "canvas.selectAll": "Select all",

--- a/canvas_modules/common-canvas/locales/common-canvas/locales/eo.json
+++ b/canvas_modules/common-canvas/locales/common-canvas/locales/eo.json
@@ -9,6 +9,8 @@
 	"edit.pasteSelection": "[Esperanto~Paste~eo]",
 	"canvas.label": "[Esperanto~Flow Editor~eo]",
 	"canvas.contents": "[Esperanto~Flow editor contents~eo]",
+	"canvas.bottomPanelResize": "[Esperanto~Resize bottom panel~eo]",
+	"canvas.rightFlyoutResize": "[Esperanto~Resize right flyout panel~eo]",
 	"canvas.addComment": "[Esperanto~New comment~eo]",
 	"canvas.addWysiwygComment": "[Esperanto~New WYSIWYG comment~~~~~eo]",
 	"canvas.selectAll": "[Esperanto~Select all~~~~~~eo]",

--- a/canvas_modules/common-canvas/src/common-canvas/cc-bottom-panel.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/cc-bottom-panel.jsx
@@ -110,7 +110,13 @@ class CanvasBottomPanel extends React.Component {
 
 			bottomPanel = (
 				<div ref={this.bottomPanelRef} className="bottom-panel">
-					<div className={className} onMouseDown={this.onMouseDown} />
+					{/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
+					<div className={className}
+						role="separator"
+						aria-orientation="horizontal"
+						aria-label={this.props.canvasController.labelUtil.getLabel("canvas.bottomPanelResize")}
+						onMouseDown={this.onMouseDown}
+					/>
 					<div className="bottom-panel-contents">
 						{this.props.bottomPanelContent}
 					</div>

--- a/canvas_modules/common-canvas/src/common-canvas/cc-bottom-panel.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/cc-bottom-panel.jsx
@@ -110,6 +110,7 @@ class CanvasBottomPanel extends React.Component {
 
 			bottomPanel = (
 				<div ref={this.bottomPanelRef} className="bottom-panel">
+					{/* role="separator" is classified non-interactive by the linter, but a mouse-draggable divider is the standard accessible pattern for this. */}
 					{/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
 					<div className={className}
 						role="separator"

--- a/canvas_modules/common-canvas/src/common-canvas/cc-contents.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/cc-contents.jsx
@@ -507,6 +507,7 @@ class CanvasContents extends React.Component {
 	getSVGCanvasDiv() {
 		if (this.props.canvasConfig.enableKeyboardNavigation) {
 			// Set tabindex to 0 so the focus can go to the <div>
+			// role="application" hands keyboard handling to this widget by design, but the linter still classifies it as non-interactive.
 			/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */
 			return (
 				<div role="application"
@@ -528,6 +529,7 @@ class CanvasContents extends React.Component {
 		// the user cannot tab to the div. Keyboard events are handled in svg-canvas-d3.js.
 		// https://stackoverflow.com/questions/32911355/whats-the-tabindex-1-in-bootstrap-for
 		return (
+			// This div isn't tabbable (tabIndex -1) and has no accurate native/ARIA equivalent role to give it.
 			// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 			<div tabIndex="-1" className="d3-svg-canvas-div" id={this.svgCanvasDivId}
 				onKeyDown={this.onKeyDown} onKeyUp={this.onKeyUp}

--- a/canvas_modules/common-canvas/src/common-canvas/cc-contents.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/cc-contents.jsx
@@ -507,6 +507,7 @@ class CanvasContents extends React.Component {
 	getSVGCanvasDiv() {
 		if (this.props.canvasConfig.enableKeyboardNavigation) {
 			// Set tabindex to 0 so the focus can go to the <div>
+			/* eslint-disable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */
 			return (
 				<div role="application"
 					id={this.svgCanvasDivId}
@@ -519,6 +520,7 @@ class CanvasContents extends React.Component {
 					aria-label={this.getLabel("canvas.label")}
 				/>
 			);
+			/* eslint-enable jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex */
 		}
 
 		// Set tabindex to -1 so the focus (see componentDidMount above) can go to
@@ -526,6 +528,7 @@ class CanvasContents extends React.Component {
 		// the user cannot tab to the div. Keyboard events are handled in svg-canvas-d3.js.
 		// https://stackoverflow.com/questions/32911355/whats-the-tabindex-1-in-bootstrap-for
 		return (
+			// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 			<div tabIndex="-1" className="d3-svg-canvas-div" id={this.svgCanvasDivId}
 				onKeyDown={this.onKeyDown} onKeyUp={this.onKeyUp}
 			/>

--- a/canvas_modules/common-canvas/src/common-canvas/cc-right-flyout.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/cc-right-flyout.jsx
@@ -90,7 +90,15 @@ class CommonCanvasRightFlyout extends React.Component {
 		if (this.props.enableRightFlyoutDragToResize) {
 			const className = "right-flyout-drag" + (this.state.isBeingDragging ? " is-being-dragged" : "");
 
-			resizeContent = (<div className={className} onMouseDown={this.onMouseDown} />);
+			resizeContent = (
+				// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+				<div className={className}
+					role="separator"
+					aria-orientation="vertical"
+					aria-label={this.props.canvasController.labelUtil.getLabel("canvas.rightFlyoutResize")}
+					onMouseDown={this.onMouseDown}
+				/>
+			);
 		}
 
 		return resizeContent;

--- a/canvas_modules/common-canvas/src/common-canvas/cc-right-flyout.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/cc-right-flyout.jsx
@@ -91,6 +91,7 @@ class CommonCanvasRightFlyout extends React.Component {
 			const className = "right-flyout-drag" + (this.state.isBeingDragging ? " is-being-dragged" : "");
 
 			resizeContent = (
+				// role="separator" is classified non-interactive by the linter, but a mouse-draggable divider is the standard accessible pattern for this.
 				// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
 				<div className={className}
 					role="separator"

--- a/canvas_modules/common-canvas/src/common-canvas/cc-state-tag.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/cc-state-tag.jsx
@@ -30,8 +30,14 @@ class CommonCanvasStateTag extends React.Component {
 		super(props);
 		this.logger = new Logger("CC-StateTag");
 
+		this.onFocus = this.onFocus.bind(this);
 		this.onMouseOver = this.onMouseOver.bind(this);
+		this.onBlur = this.onBlur.bind(this);
 		this.onMouseLeave = this.onMouseLeave.bind(this);
+	}
+
+	onFocus(ev) {
+		this.onMouseOver(ev);
 	}
 
 	onMouseOver(ev) {
@@ -53,6 +59,10 @@ class CommonCanvasStateTag extends React.Component {
 		});
 	}
 
+	onBlur() {
+		this.onMouseLeave();
+	}
+
 	onMouseLeave() {
 		this.props.canvasController.closeTip();
 	}
@@ -66,6 +76,8 @@ class CommonCanvasStateTag extends React.Component {
 			<div className={"state-tag"}
 				onMouseOver={this.onMouseOver}
 				onMouseLeave={this.onMouseLeave}
+				onFocus={this.onFocus}
+				onBlur={this.onBlur}
 			>
 				{icon}
 				<span>{label}</span>

--- a/canvas_modules/common-canvas/src/common-canvas/cc-text-toolbar.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/cc-text-toolbar.jsx
@@ -330,6 +330,7 @@ class CommonCanvasTextToolbar extends React.Component {
 
 		if (this.props.isOpen) {
 			textToolbar = (
+				// This div is just a positioning/focus wrapper; the nested <Toolbar> already provides role="toolbar".
 				// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 				<div
 					ref={this.toolbarDivRef}

--- a/canvas_modules/common-canvas/src/common-canvas/cc-text-toolbar.jsx
+++ b/canvas_modules/common-canvas/src/common-canvas/cc-text-toolbar.jsx
@@ -330,6 +330,7 @@ class CommonCanvasTextToolbar extends React.Component {
 
 		if (this.props.isOpen) {
 			textToolbar = (
+				// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 				<div
 					ref={this.toolbarDivRef}
 					className={"text-toolbar floating-toolbar"}


### PR DESCRIPTION
Fix: #3303 

### **Note**
Four files needed an eslint-disable because the code was already accessibility correct and the warning to my understanding was a limitation of the linter's static aria role table and not an actual bug:
- `cc-bottom-panel.jsx` / `cc-right-flyout.jsx` - these are "window splitter" drag handles, now given role="separator". aria query classifies separator as non interactive so the mouse handler on it still trips the linter even though a draggable separator is the standard accessible pattern.
- `cc-contents.jsx`- role="application" hands all keyboard handling to this canvas widget. aria-query still files application under "non-interactive," so both rules false positive here.
- `cc-text-toolbar.jsx` - this div is a positioning/focus management wrapper only; the actual toolbar behavior is provided by the nested `<Toolbar>` it wraps so there's no role to add to the wrapper itself that would be accurate.

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

