### PR TITLE
Resolve accessibility violations in the context menu

### DIFF
--- a/canvas_modules/common-canvas/src/context-menu/common-context-menu.jsx
+++ b/canvas_modules/common-canvas/src/context-menu/common-context-menu.jsx
@@ -276,7 +276,7 @@ class CommonContextMenu extends React.Component {
 					menuRefs.push(ref);
 
 					menuItem = (
-						<div key={i} ref={ref} tabIndex={0} className={"context-menu-item disabled"} onKeyDown={this.onKeyDown} role="menuitem">
+						<div key={i} ref={ref} tabIndex={0} className={"context-menu-item disabled"} onKeyDown={this.onKeyDown} role="menuitem" aria-disabled={true}>
 							{menuDefinition[i].label}
 						</div>
 					);
@@ -304,7 +304,7 @@ class CommonContextMenu extends React.Component {
 
 				} else if (menuDefinition[i].enable === false) {
 					menuItem = (
-						<div key={i} className={"context-menu-item disabled"} role="menuitem">
+						<div key={i} className={"context-menu-item disabled"} role="menuitem" aria-disabled={true}>
 							{menuDefinition[i].label}
 						</div>
 					);
@@ -386,7 +386,7 @@ class CommonContextMenu extends React.Component {
 		this.subMenuPosData[menuItem.action] = subMenuPosStyle;
 
 		return (
-			<div key={index} ref={ref} className={menuItemClass} aria-haspopup tabIndex={itemTabIndex} data-action={menuItem.action} role="menuitem"
+			<div key={index} ref={ref} className={menuItemClass} aria-haspopup tabIndex={itemTabIndex} data-action={menuItem.action} role="menuitem" aria-disabled={disabled}
 				onMouseEnter={onMouseEnter}
 				onMouseLeave={onMouseLeave}
 				onKeyDown={this.onKeyDown}

--- a/canvas_modules/common-canvas/src/context-menu/common-context-menu.jsx
+++ b/canvas_modules/common-canvas/src/context-menu/common-context-menu.jsx
@@ -276,7 +276,7 @@ class CommonContextMenu extends React.Component {
 					menuRefs.push(ref);
 
 					menuItem = (
-						<div key={i} ref={ref} tabIndex={0} className={"context-menu-item disabled"} onKeyDown={this.onKeyDown} role="menuitem" aria-disabled={true}>
+						<div key={i} ref={ref} tabIndex={0} className={"context-menu-item disabled"} onKeyDown={this.onKeyDown} role="menuitem" aria-disabled>
 							{menuDefinition[i].label}
 						</div>
 					);
@@ -304,7 +304,7 @@ class CommonContextMenu extends React.Component {
 
 				} else if (menuDefinition[i].enable === false) {
 					menuItem = (
-						<div key={i} className={"context-menu-item disabled"} role="menuitem" aria-disabled={true}>
+						<div key={i} className={"context-menu-item disabled"} role="menuitem" aria-disabled>
 							{menuDefinition[i].label}
 						</div>
 					);
@@ -314,7 +314,7 @@ class CommonContextMenu extends React.Component {
 					const ref = React.createRef();
 					const itemTabIndex = menuRefs.length === 0 ? 0 : -1;
 					menuRefs.push(ref);
-	
+
 					menuItem = (
 						<div key={i} ref={ref} tabIndex={itemTabIndex} data-action={menuDefinition[i].action}
 							className={"context-menu-item"} onClick={onClickFunction} onKeyDown={this.onKeyDown} role="menuitem"

--- a/canvas_modules/common-canvas/src/context-menu/common-context-menu.jsx
+++ b/canvas_modules/common-canvas/src/context-menu/common-context-menu.jsx
@@ -312,10 +312,11 @@ class CommonContextMenu extends React.Component {
 				} else {
 					const onClickFunction = this.itemSelected.bind(null, menuDefinition[i].action);
 					const ref = React.createRef();
+					const itemTabIndex = menuRefs.length === 0 ? 0 : -1;
 					menuRefs.push(ref);
-
+	
 					menuItem = (
-						<div key={i} ref={ref} tabIndex={-1} data-action={menuDefinition[i].action}
+						<div key={i} ref={ref} tabIndex={itemTabIndex} data-action={menuDefinition[i].action}
 							className={"context-menu-item"} onClick={onClickFunction} onKeyDown={this.onKeyDown} role="menuitem"
 						>
 							{menuDefinition[i].label}
@@ -375,6 +376,7 @@ class CommonContextMenu extends React.Component {
 		const onMouseLeave = (disabled ? null : this.subMenuClose.bind(this));
 
 		const ref = disabled ? null : React.createRef();
+		const itemTabIndex = (!disabled && menuRefs.length === 0) ? 0 : -1;
 		if (!disabled) {
 			menuRefs.push(ref);
 		}
@@ -384,7 +386,7 @@ class CommonContextMenu extends React.Component {
 		this.subMenuPosData[menuItem.action] = subMenuPosStyle;
 
 		return (
-			<div key={index} ref={ref} className={menuItemClass} aria-haspopup tabIndex={-1} data-action={menuItem.action} role="menuitem"
+			<div key={index} ref={ref} className={menuItemClass} aria-haspopup tabIndex={itemTabIndex} data-action={menuItem.action} role="menuitem"
 				onMouseEnter={onMouseEnter}
 				onMouseLeave={onMouseLeave}
 				onKeyDown={this.onKeyDown}
@@ -455,7 +457,7 @@ class CommonContextMenu extends React.Component {
 		this.menuRefs = menuInfo.menuRefs;
 
 		return (
-			<div ref={this.menuPopoverRef} id="context-menu-popover" role="menu" tabIndex={0} className="context-menu-popover" onContextMenu={this.onContextMenu}>
+			<div ref={this.menuPopoverRef} id="context-menu-popover" role="menu" className="context-menu-popover" onContextMenu={this.onContextMenu}>
 				{menuInfo.menuItems}
 			</div>
 		);


### PR DESCRIPTION
Fixes #3313 

Resolves the two accessibility findings in `common-context-menu.jsx`:

- Set `tabIndex={0}` on the first enabled menuitem (roving-tabindex entry point) and removed the redundant `tabIndex={0}` from the `role="menu"` container so only one element inside the menu is tabbable.
- Added `aria-disabled={true}` to disabled menu items

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

