### PR TITLE
elyra-ai#4431 Fix context menu disabled text contrast violation

### DIFF
--- a/canvas_modules/common-canvas/src/context-menu/common-context-menu.jsx
+++ b/canvas_modules/common-canvas/src/context-menu/common-context-menu.jsx
@@ -276,7 +276,7 @@ class CommonContextMenu extends React.Component {
 					menuRefs.push(ref);
 
 					menuItem = (
-						<div key={i} ref={ref} tabIndex={0} className={"context-menu-item disabled"} onKeyDown={this.onKeyDown} role="menuitem">
+						<div key={i} ref={ref} tabIndex={0} className={"context-menu-item disabled"} onKeyDown={this.onKeyDown} role="menuitem" aria-disabled>
 							{menuDefinition[i].label}
 						</div>
 					);
@@ -304,7 +304,7 @@ class CommonContextMenu extends React.Component {
 
 				} else if (menuDefinition[i].enable === false) {
 					menuItem = (
-						<div key={i} className={"context-menu-item disabled"} role="menuitem">
+						<div key={i} className={"context-menu-item disabled"} role="menuitem" aria-disabled>
 							{menuDefinition[i].label}
 						</div>
 					);
@@ -385,6 +385,7 @@ class CommonContextMenu extends React.Component {
 
 		return (
 			<div key={index} ref={ref} className={menuItemClass} aria-haspopup tabIndex={-1} data-action={menuItem.action} role="menuitem"
+				aria-disabled={disabled}
 				onMouseEnter={onMouseEnter}
 				onMouseLeave={onMouseLeave}
 				onKeyDown={this.onKeyDown}

--- a/canvas_modules/common-canvas/src/context-menu/context-menu.scss
+++ b/canvas_modules/common-canvas/src/context-menu/context-menu.scss
@@ -63,8 +63,11 @@
 	position: relative; // Needed to allow sub-menu, if there is one,  to be positioned correctly
 
 	&.disabled {
-		opacity: 0.5;
-		cursor: not-allowed;
+		color: carbon.$text-secondary;
+
+		& svg {
+			color: carbon.$text-secondary;
+		}
 	}
 
 	&:active,

--- a/canvas_modules/common-canvas/src/context-menu/context-menu.scss
+++ b/canvas_modules/common-canvas/src/context-menu/context-menu.scss
@@ -63,10 +63,11 @@
 	position: relative; // Needed to allow sub-menu, if there is one,  to be positioned correctly
 
 	&.disabled {
-		color: carbon.$text-secondary;
+		color: carbon.$text-disabled;
+		cursor: not-allowed;
 
 		& svg {
-			color: carbon.$text-secondary;
+			color: carbon.$icon-disabled;
 		}
 	}
 


### PR DESCRIPTION
Fix #3316

<img width="1728" height="539" alt="image" src="https://github.com/user-attachments/assets/ca5ce8eb-d188-4c36-99dd-712aecddde74" />

Disabled context menu items lacked explicit text color, causing insufficient contrast between the dimmed text and background. 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

