### PR TITLE
Fix eslint-a11y warnings for palette component

### DIFF
--- a/canvas_modules/common-canvas/src/palette/palette-content-list-item-btn.jsx
+++ b/canvas_modules/common-canvas/src/palette/palette-content-list-item-btn.jsx
@@ -17,17 +17,42 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { injectIntl } from "react-intl";
+import KeyboardUtils from "../common-canvas/keyboard-utils.js";
 import defaultMessages from "../../locales/palette/locales/en.json";
 
 class PaletteContentListItemBtn extends React.Component {
+	constructor(props) {
+		super(props);
+
+		this.onClick = this.onClick.bind(this);
+		this.onKeyDown = this.onKeyDown.bind(this);
+	}
+
+	onClick(evt) {
+		// Stop the click reaching the parent palette list item which would
+		// otherwise add a node to the canvas.
+		evt.stopPropagation();
+		this.props.onClick(evt);
+	}
+
+	onKeyDown(evt) {
+		// Enter and Space activate the button (which generates a click event) so
+		// stop those keys reaching the parent palette list item which would
+		// otherwise add a node to the canvas.
+		if (KeyboardUtils.createAutoNode(evt) || KeyboardUtils.createAutoNodeNoLink(evt)) {
+			evt.stopPropagation();
+		}
+	}
 
 	render() {
 		const less =
 			this.props.intl.formatMessage({ id: this.props.id, defaultMessage: defaultMessages[this.props.id] });
 		return (
-			<div key="l_btn" className = "palette-list-item-desc-button" onClick={this.props.onClick}>
+			<button key="l_btn" type="button" className="palette-list-item-desc-button"
+				onClick={this.onClick} onKeyDown={this.onKeyDown}
+			>
 				{less}
-			</div>
+			</button>
 		);
 	}
 }

--- a/canvas_modules/common-canvas/src/palette/palette-content-list-item.jsx
+++ b/canvas_modules/common-canvas/src/palette/palette-content-list-item.jsx
@@ -48,6 +48,7 @@ class PaletteContentListItem extends React.Component {
 		this.onDoubleClick = this.onDoubleClick.bind(this);
 		this.onMouseOver = this.onMouseOver.bind(this);
 		this.onMouseLeave = this.onMouseLeave.bind(this);
+		this.onFocus = this.onFocus.bind(this);
 		this.onMouseDown = this.onMouseDown.bind(this);
 		this.onKeyDown = this.onKeyDown.bind(this);
 	}
@@ -138,6 +139,14 @@ class PaletteContentListItem extends React.Component {
 
 	onMouseLeave() {
 		this.props.canvasController.closeTip();
+	}
+
+	// Displays the tip when the user moves focus to this item using the
+	// keyboard. This is the keyboard equivalent of onMouseOver.
+	onFocus() {
+		if (!this.props.isDisplaySearchResult) {
+			this.displayTip();
+		}
 	}
 
 	getHighlightedCategoryLabel() {
@@ -414,6 +423,8 @@ class PaletteContentListItem extends React.Component {
 				className={mainDivClass}
 				onMouseOver={this.onMouseOver}
 				onMouseLeave={this.onMouseLeave}
+				onFocus={this.onFocus}
+				onBlur={this.onMouseLeave}
 				onKeyDown={this.props.isEditingEnabled ? this.onKeyDown : null}
 				onMouseDown={this.props.isEditingEnabled ? this.onMouseDown : null}
 				onDragStart={this.props.isEditingEnabled ? this.onDragStart : null}

--- a/canvas_modules/common-canvas/src/palette/palette-dialog-content-category.jsx
+++ b/canvas_modules/common-canvas/src/palette/palette-dialog-content-category.jsx
@@ -17,6 +17,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { InlineLoading } from "@carbon/react";
+import KeyboardUtils from "../common-canvas/keyboard-utils.js";
 
 class PaletteDialogContentCategory extends React.Component {
 	constructor(props) {
@@ -26,19 +27,27 @@ class PaletteDialogContentCategory extends React.Component {
 		};
 
 		this.categorySelected = this.categorySelected.bind(this);
+		this.onKeyDown = this.onKeyDown.bind(this);
 	}
 
+
+	// Selects the category when the user presses Enter or Space, which is the
+	// keyboard equivalent of clicking on it.
+	onKeyDown(evt) {
+		if (KeyboardUtils.openCategory(evt)) {
+			// Stop the Space key scrolling the category list.
+			evt.preventDefault();
+			this.categorySelected(evt);
+		}
+	}
 
 	categorySelected(catSelEvent) {
 		this.props.categorySelectedMethod(catSelEvent);
 	}
 
 	render() {
-		var style = "palette-dialog-category";
-
-		if (this.props.selectedCategory === this.props.category.label) {
-			style = "palette-dialog-category-selected";
-		}
+		const isSelected = this.props.selectedCategory === this.props.category.label;
+		const style = isSelected ? "palette-dialog-category-selected" : "palette-dialog-category";
 
 		const content = this.props.category.loading_text
 			? (
@@ -56,7 +65,13 @@ class PaletteDialogContentCategory extends React.Component {
 			: this.props.category.label;
 
 		return (
-			<div data-id={this.props.category.id} data-label={this.props.category.label} className={style} onClick={this.categorySelected}>
+			<div data-id={this.props.category.id} data-label={this.props.category.label} className={style}
+				role="button"
+				tabIndex={0}
+				aria-current={isSelected ? true : null}
+				onClick={this.categorySelected}
+				onKeyDown={this.onKeyDown}
+			>
 				{content}
 			</div>
 		);

--- a/canvas_modules/common-canvas/src/palette/palette-dialog-content-grid-node.jsx
+++ b/canvas_modules/common-canvas/src/palette/palette-dialog-content-grid-node.jsx
@@ -20,6 +20,7 @@ import { has } from "lodash";
 import SVG from "react-inlinesvg";
 // Carbon icons - direct imports for tree-shaking optimization
 import Warning from "@carbon/icons-react/lib/Warning";
+import KeyboardUtils from "../common-canvas/keyboard-utils.js";
 import { DND_DATA_TEXT, TIP_TYPE_PALETTE_ITEM,
 	USE_DEFAULT_ICON, USE_DEFAULT_EXT_ICON }
 	from "../common-canvas/constants/canvas-constants.js";
@@ -42,7 +43,9 @@ class PaletteDialogContentGridNode extends React.Component {
 		this.onDoubleClick = this.onDoubleClick.bind(this);
 		this.onMouseOver = this.onMouseOver.bind(this);
 		this.onMouseLeave = this.onMouseLeave.bind(this);
+		this.onFocus = this.onFocus.bind(this);
 		this.onMouseDown = this.onMouseDown.bind(this);
+		this.onKeyDown = this.onKeyDown.bind(this);
 	}
 
 	onMouseDown() {
@@ -84,24 +87,45 @@ class PaletteDialogContentGridNode extends React.Component {
 		this.createAutoNode();
 	}
 
+	// Adds the node when the user presses Enter or Space. Unlike onClick this is
+	// not guarded by allowClickToAdd because the keyboard has no equivalent of
+	// the double click that adds a node when that option is turned off.
+	onKeyDown(evt) {
+		if (KeyboardUtils.createAutoNode(evt) || KeyboardUtils.createAutoNodeNoLink(evt)) {
+			// Stop the Space key scrolling the palette contents.
+			evt.preventDefault();
+			this.createAutoNode();
+		}
+	}
+
 	onMouseOver(ev) {
 		if (ev.buttons === 0) {
-			const nodeTemplate = this.props.category.empty_text
-				? { app_data: { ui_data: { label: this.props.category.empty_text } } }
-				: this.props.nodeTemplate;
-
-			this.props.canvasController.openTip({
-				id: "paletteTip_" + this.props.nodeTemplate.op,
-				type: TIP_TYPE_PALETTE_ITEM,
-				targetObj: ev.currentTarget,
-				nodeTemplate: nodeTemplate,
-				category: this.props.category
-			});
+			this.displayTip(ev);
 		}
 	}
 
 	onMouseLeave() {
 		this.props.canvasController.closeTip();
+	}
+
+	// Displays the tip when the user moves focus to this node using the
+	// keyboard. This is the keyboard equivalent of onMouseOver.
+	onFocus(ev) {
+		this.displayTip(ev);
+	}
+
+	displayTip(ev) {
+		const nodeTemplate = this.props.category.empty_text
+			? { app_data: { ui_data: { label: this.props.category.empty_text } } }
+			: this.props.nodeTemplate;
+
+		this.props.canvasController.openTip({
+			id: "paletteTip_" + this.props.nodeTemplate.op,
+			type: TIP_TYPE_PALETTE_ITEM,
+			targetObj: ev.currentTarget,
+			nodeTemplate: nodeTemplate,
+			category: this.props.category
+		});
 	}
 
 	/** Returns true if this node should be treated as disabled (not draggable/clickable). */
@@ -167,9 +191,15 @@ class PaletteDialogContentGridNode extends React.Component {
 		return (
 			<div id={this.props.nodeTemplate.id}
 				data-id={this.props.nodeTemplate.op}
+				role="button"
+				tabIndex={itemDisabled ? -1 : 0}
+				aria-disabled={itemDisabled}
 				draggable={draggable}
 				onMouseOver={this.onMouseOver}
 				onMouseLeave={this.onMouseLeave}
+				onFocus={this.onFocus}
+				onBlur={this.onMouseLeave}
+				onKeyDown={itemDisabled ? null : this.onKeyDown}
 				onMouseDown={itemDisabled ? null : this.onMouseDown}
 				onDragStart={itemDisabled ? null : this.onDragStart}
 				onDragEnd={itemDisabled ? null : this.onDragEnd}

--- a/canvas_modules/common-canvas/src/palette/palette-dialog-topbar.jsx
+++ b/canvas_modules/common-canvas/src/palette/palette-dialog-topbar.jsx
@@ -76,6 +76,9 @@ class PaletteDialogTopbar extends React.Component {
 
 
 		return (
+			// The handlers on this div move and resize the floating palette window, pointer gestures
+			// with no keyboard equivalent rather than a control, so no role to give it.
+			// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 			<div
 				className="palette-dialog-topbar"
 				onMouseDown={this.mouseDown}

--- a/canvas_modules/common-canvas/src/palette/palette-dialog-under.jsx
+++ b/canvas_modules/common-canvas/src/palette/palette-dialog-under.jsx
@@ -535,6 +535,10 @@ class PaletteDialog extends React.Component {
 		);
 		return (
 			<div role="region" aria-label={label} >
+				{/* The handler on this div starts a resize when the pointer is in one of the sizing
+				    hover zones, a pointer gesture with no keyboard equivalent rather than a control,
+					no role to give it. */}
+				{/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
 				<div ref={this.dialogPaletteDivRef} className="palette-dialog-div"
 					onMouseDown={this.mouseDownOnPalette}
 				>

--- a/canvas_modules/common-canvas/src/palette/palette-flyout-content-category.jsx
+++ b/canvas_modules/common-canvas/src/palette/palette-flyout-content-category.jsx
@@ -153,6 +153,10 @@ class PaletteFlyoutContentCategory extends React.Component {
 				ref={this.catRef}
 				data-id={get(this.props.category, "id", "")}
 				value={this.props.category.label}
+				// This div cannot receive focus, no onFocus to pair with onMouseOver. The tip
+				// is displayed for keyboard users by the onFocus on the AccordionItem
+				// this div is passed to as its title
+				// eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
 				onMouseOver={this.onMouseOver}
 				onMouseLeave={this.onMouseLeave}
 			>

--- a/canvas_modules/common-canvas/src/palette/palette-flyout-content-filtered-list.jsx
+++ b/canvas_modules/common-canvas/src/palette/palette-flyout-content-filtered-list.jsx
@@ -32,7 +32,9 @@ class PaletteFlyoutContentFilteredList extends React.Component {
 	}
 
 	onKeyDownResults(evt) {
-		if (KeyboardUtils.tabFocusOutOfPalette(evt)) {
+		// tabOutOfOfPalette is an optional callback so check it is provided before
+		// calling it, in the same way as the tabOut callback in palette-content-list-item.
+		if (KeyboardUtils.tabFocusOutOfPalette(evt) && this.props.tabOutOfOfPalette) {
 			this.props.tabOutOfOfPalette(evt);
 		}
 	}
@@ -41,7 +43,11 @@ class PaletteFlyoutContentFilteredList extends React.Component {
 		const noResultsFound = this.props.intl.formatMessage({ id: "palette.flyout.search.noresults", defaultMessage: defaultMessages["palette.flyout.search.noresults"] });
 		const adjustSearch = this.props.intl.formatMessage({ id: "palette.flyout.search.adjustsearch", defaultMessage: defaultMessages["palette.flyout.search.adjustsearch"] });
 		return (
-			<div tabIndex={0} onKeyDown={this.onKeyDownResults}>
+			// role="status" announces the message when a search returns nothing. The message is
+			// also deliberately made focusable so that it, rather than nothing, receives the focus
+			// when the result list is empty.
+			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-noninteractive-tabindex
+			<div role="status" tabIndex={0} onKeyDown={this.onKeyDownResults}>
 				<div className="palette-no-results-title">{noResultsFound}</div>
 				<br />
 				<div className="palette-no-results-desc">{adjustSearch}</div>
@@ -82,7 +88,7 @@ class PaletteFlyoutContentFilteredList extends React.Component {
 					defaultMessage: defaultMessages["palette.flyout.search.resultsrestricted"]
 				});
 			contentItems.push(
-				<div key="restrict-item" className="palette-flyout-restrict-item" onKeyDown={this.onKeyDownResults}>
+				<div key="restrict-item" className="palette-flyout-restrict-item">
 					{resultsRestricted}
 				</div>
 			);

--- a/canvas_modules/common-canvas/src/palette/palette.scss
+++ b/canvas_modules/common-canvas/src/palette/palette.scss
@@ -110,6 +110,11 @@ $palette-dialog-list-item-height: 46px;
 		color: carbon.$link-primary;
 		cursor: pointer;
 		padding: 5px 0 0;
+		display: block;
+		background: none;
+		border: none;
+		font: inherit;
+		text-align: left;
 	}
 
 	.palette-list-item {


### PR DESCRIPTION
Fixes #3315 

- The "Show more"/"Show less" toggle under truncated descriptions in the
  flyout search results was a `<div>` and could not be reached by keyboard.
  It is now a `<button>`, with click and Enter/Space stopped from
  propagating to the parent palette item, which would otherwise have added a
  node to the canvas at the same time.
- `.palette-list-item-desc-button` gains the usual reset (`background`,
  `border`, `font`, `text-align`, `display`) so the new `<button>` still
  renders as the inline link it replaced.
- Categories and tiles now carry `role="button"`, a `tabIndex` and an
  `onKeyDown` for Enter/Space, with `aria-disabled` and `tabIndex={-1}`
  keeping disabled tiles out of the tab order. Categories also gain
  `aria-current`, since the selected one was previously indicated by font
  weight alone and so was invisible to a screen reader.
- Node tips now appear on focus as well as hover, in both the dialog grid and
  the flyout search results.
- The "No results found" message is now `role="status"`, so a screen reader
  announces an empty search immediately rather than the user having to
  navigate to the message to discover it.
- Tabbing out of an empty result list called `tabOutOfOfPalette` unguarded —
  an optional prop that common-canvas never supplies. Now guarded, matching
  `tabOut` in `palette-content-list-item`.
- The truncated-results message carried an `onKeyDown` it could never fire,
  having no `tabIndex` and only text children. Removed.

Warnings suppressed:

- The dialog title bar and window edges handle dragging, maximizing and
  resizing the floating window. Those are pointer gestures with no keyboard
  equivalent rather than controls — giving them `role="button"` would announce
  a button that does nothing and wrap the real toolbar buttons in a fake one.
- The flyout category title div is asked for an `onFocus` beside its
  `onMouseOver`, but it cannot receive focus. Focus is handled on the
  `AccordionItem` it is passed to as its title, which ESLint does not look at.
  Confirmed in the harness — tabbing to a category does show the tip.
- The `tabIndex` on the no-results message is deliberate and is required by
  the public `tabOutOfOfPalette` prop, so it stays.
  
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

