### PR TITLE
elyra-ai#4433 Fix CommonProperties crash from FlexibleTable

### DIFF
--- a/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
@@ -21,7 +21,7 @@ import { injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { Search, Layer } from "@carbon/react";
 import classNames from "classnames";
-import { has, isEmpty } from "lodash";
+import { has, isEmpty, isEqual } from "lodash";
 
 import VirtualizedGrid from "./../virtualized-grid/virtualized-grid.jsx";
 import VirtualizedTable from "./../virtualized-table/virtualized-table.jsx";
@@ -284,7 +284,9 @@ class FlexibleTable extends React.Component {
 			const firstColWidth = parseInt(widths[0], 10);
 			widths[0] = firstColWidth + compare - sumColumnWidth + "px";
 		}
-		this.setState({ columnWidths: widths, tableWidth: sumColumnWidth });
+		if (!isEqual(this.state.columnWidths, widths) || this.state.tableWidth !== sumColumnWidth) {
+			this.setState({ columnWidths: widths, tableWidth: sumColumnWidth });
+		}
 	}
 
 	updateHeaderHeight(contentRect) {
@@ -307,6 +309,9 @@ class FlexibleTable extends React.Component {
 
 	_updateTableWidth(contentRect, target) {
 		const tableWidth = Math.floor(target?.childNodes?.[0].childNodes?.[0]?.clientWidth) || contentRect.width;
+		if (!tableWidth || tableWidth <= 0) {
+			return;
+		}
 		if (this.state.availableWidth !== Math.floor(tableWidth - 2)) {
 			this.setState({
 				availableWidth: Math.floor(tableWidth - 2) // subtract 2 px for the borders

--- a/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
@@ -284,10 +284,7 @@ class FlexibleTable extends React.Component {
 			const firstColWidth = parseInt(widths[0], 10);
 			widths[0] = firstColWidth + compare - sumColumnWidth + "px";
 		}
-		// Only write when something actually changed. This method is a pure function of
-		// props.columns and state.availableWidth, but it allocates a new widths array every
-		// call, so an unguarded setState schedules a render from componentDidUpdate on every
-		// parent re-render and advances React's nested-update count (elyra-ai/canvas#4433).
+
 		if (!isEqual(this.state.columnWidths, widths) || this.state.tableWidth !== sumColumnWidth) {
 			this.setState({ columnWidths: widths, tableWidth: sumColumnWidth });
 		}
@@ -313,9 +310,6 @@ class FlexibleTable extends React.Component {
 
 	_updateTableWidth(contentRect, target) {
 		const tableWidth = Math.floor(target?.childNodes?.[0].childNodes?.[0]?.clientWidth) || contentRect.width;
-		// A 0x0 rect means the element is hidden or not laid out yet, not that it is zero
-		// wide. Acting on it collapses every column to DEFAULT_COL_MIN_WIDTH and then springs
-		// back once the element is measurable again (elyra-ai/canvas#4433).
 		if (!tableWidth || tableWidth <= 0) {
 			return;
 		}

--- a/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
@@ -21,7 +21,7 @@ import { injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { Search, Layer } from "@carbon/react";
 import classNames from "classnames";
-import { has, isEmpty, isEqual } from "lodash";
+import { has, isEmpty } from "lodash";
 
 import VirtualizedGrid from "./../virtualized-grid/virtualized-grid.jsx";
 import VirtualizedTable from "./../virtualized-table/virtualized-table.jsx";
@@ -284,10 +284,7 @@ class FlexibleTable extends React.Component {
 			const firstColWidth = parseInt(widths[0], 10);
 			widths[0] = firstColWidth + compare - sumColumnWidth + "px";
 		}
-
-		if (!isEqual(this.state.columnWidths, widths) || this.state.tableWidth !== sumColumnWidth) {
-			this.setState({ columnWidths: widths, tableWidth: sumColumnWidth });
-		}
+		this.setState({ columnWidths: widths, tableWidth: sumColumnWidth });
 	}
 
 	updateHeaderHeight(contentRect) {
@@ -310,9 +307,6 @@ class FlexibleTable extends React.Component {
 
 	_updateTableWidth(contentRect, target) {
 		const tableWidth = Math.floor(target?.childNodes?.[0].childNodes?.[0]?.clientWidth) || contentRect.width;
-		if (!tableWidth || tableWidth <= 0) {
-			return;
-		}
 		if (this.state.availableWidth !== Math.floor(tableWidth - 2)) {
 			this.setState({
 				availableWidth: Math.floor(tableWidth - 2) // subtract 2 px for the borders

--- a/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/components/flexible-table/flexible-table.jsx
@@ -21,7 +21,7 @@ import { injectIntl } from "react-intl";
 import PropTypes from "prop-types";
 import { Search, Layer } from "@carbon/react";
 import classNames from "classnames";
-import { has, isEmpty } from "lodash";
+import { has, isEmpty, isEqual } from "lodash";
 
 import VirtualizedGrid from "./../virtualized-grid/virtualized-grid.jsx";
 import VirtualizedTable from "./../virtualized-table/virtualized-table.jsx";
@@ -284,7 +284,13 @@ class FlexibleTable extends React.Component {
 			const firstColWidth = parseInt(widths[0], 10);
 			widths[0] = firstColWidth + compare - sumColumnWidth + "px";
 		}
-		this.setState({ columnWidths: widths, tableWidth: sumColumnWidth });
+		// Only write when something actually changed. This method is a pure function of
+		// props.columns and state.availableWidth, but it allocates a new widths array every
+		// call, so an unguarded setState schedules a render from componentDidUpdate on every
+		// parent re-render and advances React's nested-update count (elyra-ai/canvas#4433).
+		if (!isEqual(this.state.columnWidths, widths) || this.state.tableWidth !== sumColumnWidth) {
+			this.setState({ columnWidths: widths, tableWidth: sumColumnWidth });
+		}
 	}
 
 	updateHeaderHeight(contentRect) {
@@ -307,6 +313,12 @@ class FlexibleTable extends React.Component {
 
 	_updateTableWidth(contentRect, target) {
 		const tableWidth = Math.floor(target?.childNodes?.[0].childNodes?.[0]?.clientWidth) || contentRect.width;
+		// A 0x0 rect means the element is hidden or not laid out yet, not that it is zero
+		// wide. Acting on it collapses every column to DEFAULT_COL_MIN_WIDTH and then springs
+		// back once the element is measurable again (elyra-ai/canvas#4433).
+		if (!tableWidth || tableWidth <= 0) {
+			return;
+		}
 		if (this.state.availableWidth !== Math.floor(tableWidth - 2)) {
 			this.setState({
 				availableWidth: Math.floor(tableWidth - 2) // subtract 2 px for the borders

--- a/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
@@ -182,7 +182,11 @@ class DropDown extends React.Component {
 		if (this.props.control.controlType === ControlType.SELECTCOLUMN) {
 			value = PropertyUtils.fieldStringToValue(value, this.props.control, this.props.controller);
 		}
-		this.props.controller.updatePropertyValue(this.props.propertyId, value);
+		// Carbon fires onSelectedItemChange from a downshift effect that re-runs when the selected
+		// item is re-synced, so dispatching an unchanged value re-enters this handler via the store.
+		if (!isEqual(value, this.props.value)) {
+			this.props.controller.updatePropertyValue(this.props.propertyId, value);
+		}
 	}
 
 	handleComboOnChange(evt) {

--- a/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
@@ -182,9 +182,10 @@ class DropDown extends React.Component {
 		if (this.props.control.controlType === ControlType.SELECTCOLUMN) {
 			value = PropertyUtils.fieldStringToValue(value, this.props.control, this.props.controller);
 		}
-		// Carbon fires onSelectedItemChange from a downshift effect that re-runs when the selected
-		// item is re-synced, so dispatching an unchanged value re-enters this handler via the store.
-		if (!isEqual(value, this.props.value)) {
+		// Carbon fires onChange from a downshift effect that re-runs when the selected item is
+		// re-synced, so skip the dispatch when the value hasn't actually changed.
+		const currentValue = this.props.controller.getPropertyValue(this.props.propertyId);
+		if (!isEqual(value, currentValue)) {
 			this.props.controller.updatePropertyValue(this.props.propertyId, value);
 		}
 	}

--- a/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
+++ b/canvas_modules/common-canvas/src/common-properties/controls/dropdown/dropdown.jsx
@@ -195,7 +195,10 @@ class DropDown extends React.Component {
 		if (this.props.control.controlType === ControlType.SELECTCOLUMN) {
 			value = PropertyUtils.fieldStringToValue(value, this.props.control, this.props.controller);
 		}
-		this.props.controller.updatePropertyValue(this.props.propertyId, value);
+		const currentValue = this.props.controller.getPropertyValue(this.props.propertyId);
+		if (!isEqual(value, currentValue)) {
+			this.props.controller.updatePropertyValue(this.props.propertyId, value);
+		}
 	}
 
 

--- a/canvas_modules/common-canvas/src/common-properties/reducers/properties.js
+++ b/canvas_modules/common-canvas/src/common-properties/reducers/properties.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { isEqual } from "lodash";
 import { UPDATE_PROPERTY_VALUE, SET_PROPERTY_VALUES, REMOVE_PROPERTY_VALUE } from "../actions";
 
 function properties(state = {}, action) {
@@ -23,7 +24,12 @@ function properties(state = {}, action) {
 		if (propertyId === null) {
 			return state;
 		}
-		var newState = state;
+		// A no-op write must not create a new state identity: every notification forces a
+		// SyncLane re-render, so re-setting a value to what it holds sustains an update loop.
+		if (typeof propertyId.row === "undefined" && isEqual(state[propertyId.name], action.property.value)) {
+			return state;
+		}
+		const newState = Object.assign({}, state);
 		if (typeof propertyId.row !== "undefined") {
 			if (typeof newState[propertyId.name] === "undefined") {
 				newState[propertyId.name] = [];
@@ -46,7 +52,7 @@ function properties(state = {}, action) {
 		} else {
 			newState[propertyId.name] = action.property.value;
 		}
-		return Object.assign({}, state, newState);
+		return newState;
 	}
 	case SET_PROPERTY_VALUES: {
 		return Object.assign({}, action.properties);


### PR DESCRIPTION
Fixes: #3324 

https://github.com/user-attachments/assets/52ae1272-5991-49fc-8463-b5273e92eca8

The properties panel was crashing because its shared table component recalculated column widths on every redraw and then saved the result even when the widths hadn't changed and each save triggered another redraw. In the running app, 95% of those saves stored a value that was already there. React gives up after 50 redraws triggered from inside a redraw, which is what produced the crash. A second, related bug made hidden tables report a width of zero, so they collapsed all columns to the 40px minimum and sprang back when shown. The dropdown was never at fault: changing any value redraws every control, and all eight places that use the table hand it a brand-new column list each time, so the table always thought something had changed. The fix is two guards in one file, only save widths when they actually differ, and ignore a width of zero, matching the pattern three neighboring methods in that same file already use.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

